### PR TITLE
Add Hacker News to the top domains.

### DIFF
--- a/Blockzilla/topdomains.txt
+++ b/Blockzilla/topdomains.txt
@@ -453,3 +453,4 @@ ksl.com
 tdbank.com
 sourceforge.net
 careerbuilder.com
+news.ycombinator.com


### PR DESCRIPTION
I use Firefox Focus a lot, and Hacker News is one of my favourite sites to read. So it seemed like a good idea to add it to the list of top domains.

I understand that adding arbitrary domains to the list might become a "slippery slope", but Hacker News seems useful given the target audience.