### PR TITLE
Add telemetry to browser gestures

### DIFF
--- a/Blockzilla/Browser.swift
+++ b/Blockzilla/Browser.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Telemetry
 
 protocol BrowserDelegate: class {
     func browserDidStartNavigation(_ browser: Browser)
@@ -51,9 +52,9 @@ class Browser: NSObject {
         webView.scrollView.layer.masksToBounds = false
         webView.scrollView.delegate = self
         webView.delegate = self
-        let swipeLeftRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(goForward))
+        let swipeLeftRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(goForwardByGesture))
         swipeLeftRecognizer.direction = .left
-        let swipeRightRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(goBack))
+        let swipeRightRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(goBackByGesture))
         swipeRightRecognizer.direction = .right
         webView.addGestureRecognizer(swipeLeftRecognizer)
         webView.addGestureRecognizer(swipeRightRecognizer)
@@ -83,6 +84,16 @@ class Browser: NSObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.createWebView()
         }
+    }
+
+    func goBackByGesture() {
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.navigateBack, object: TelemetryEventObject.app)
+        goBack()
+    }
+
+    func goForwardByGesture() {
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.navigateForward, object: TelemetryEventObject.app)
+        goForward()
     }
 
     func goBack() {

--- a/Blockzilla/Browser.swift
+++ b/Blockzilla/Browser.swift
@@ -87,12 +87,12 @@ class Browser: NSObject {
     }
 
     func goBackByGesture() {
-        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.navigateBack, object: TelemetryEventObject.app)
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.swipeToNavigateBack, object: TelemetryEventObject.app)
         goBack()
     }
 
     func goForwardByGesture() {
-        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.navigateForward, object: TelemetryEventObject.app)
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.swipeToNavigateForward, object: TelemetryEventObject.app)
         goForward()
     }
 

--- a/Blockzilla/TelemetryIntegration.swift
+++ b/Blockzilla/TelemetryIntegration.swift
@@ -22,8 +22,8 @@ class TelemetryEventMethod {
     public static let open = "open"
     public static let openAppStore = "open_app_store"
     public static let share = "share"
-    public static let navigateBack = "navigate_back"
-    public static let navigateForward = "navigate_forward"
+    public static let navigateBack = "swipe_to_navigate_back"
+    public static let navigateForward = "swipe_to_navigate_forward"
 }
 
 class TelemetryEventObject {

--- a/Blockzilla/TelemetryIntegration.swift
+++ b/Blockzilla/TelemetryIntegration.swift
@@ -22,6 +22,8 @@ class TelemetryEventMethod {
     public static let open = "open"
     public static let openAppStore = "open_app_store"
     public static let share = "share"
+    public static let navigateBack = "navigate_back"
+    public static let navigateForward = "navigate_forward"
 }
 
 class TelemetryEventObject {

--- a/Blockzilla/TelemetryIntegration.swift
+++ b/Blockzilla/TelemetryIntegration.swift
@@ -22,8 +22,8 @@ class TelemetryEventMethod {
     public static let open = "open"
     public static let openAppStore = "open_app_store"
     public static let share = "share"
-    public static let navigateBack = "swipe_to_navigate_back"
-    public static let navigateForward = "swipe_to_navigate_forward"
+    public static let swipeToNavigateBack = "swipe_to_navigate_back"
+    public static let swipeToNavigateForward = "swipe_to_navigate_forward"
 }
 
 class TelemetryEventObject {


### PR DESCRIPTION
Add telemetry to back and forward gestures recognizers.

Telemetry Events Method:
`navigate_back`
`navigate_forward`

@bbinto @justindarc 