### PR TITLE
#287 - switches to share extension

### DIFF
--- a/OpenInFocus/Info.plist
+++ b/OpenInFocus/Info.plist
@@ -22,20 +22,20 @@
 	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
-		<key>NSExtensionPrincipalClass</key>
-		<string>OpenInFocus.ActionViewController</string>
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
 				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.ui-services</string>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>OpenInFocus.ActionViewController</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This changes the OpenInFocus extension from an action extension to a share extension.

## Old
![img_bdf5658cc531-1](https://user-images.githubusercontent.com/1250545/29295184-e9182f6c-8107-11e7-95e8-6beddc3e2c16.jpeg)

This worked well on the iPhone. But there is a certain behavior on the iPad that causes a weird modal and alert dialog during the app switch.

## New
![img_f6e4d4d6cc0e-1](https://user-images.githubusercontent.com/1250545/29295209-0d40dee8-8108-11e7-8486-8cabe1d45eb1.jpeg)

