### PR TITLE
#290 - Fixes the URL Bar Disappearing when opened from share menu

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -209,6 +209,7 @@ class BrowserViewController: UIViewController {
     func ensureBrowsingMode() {
         guard !urlBar.inBrowsingMode else { return }
 
+        urlBarContainer.alpha = 1
         urlBar.ensureBrowsingMode()
 
         topURLBarConstraints.forEach { $0.activate() }


### PR DESCRIPTION
This fixes the case where the URL bar would be missing when opened from the share menu.

