### PR TITLE
Re-enable 3rd party VKBs

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -236,12 +236,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Telemetry.default.scheduleUpload(pingType: CorePingBuilder.PingType)
         Telemetry.default.scheduleUpload(pingType: FocusEventPingBuilder.PingType)
     }
-
-    func application(_ application: UIApplication, shouldAllowExtensionPointIdentifier extensionPointIdentifier: UIApplicationExtensionPointIdentifier) -> Bool {
-        // We don't currently support third-party keyboards due to incompatibilities with our
-        // autocomplete text field (e.g., bug 1317104).
-        return extensionPointIdentifier != UIApplicationExtensionPointIdentifier.keyboard
-    }
 }
 
 extension UINavigationController {


### PR DESCRIPTION
    func application(_ application: UIApplication, shouldAllowExtensionPointIdentifier extensionPointIdentifier: UIApplicationExtensionPointIdentifier) -> Bool {
        // We don't currently support third-party keyboards due to incompatibilities with our
        // autocomplete text field (e.g., bug 1317104).
        return extensionPointIdentifier != UIApplicationExtensionPointIdentifier.keyboard
    }

Turns out https://bugzilla.mozilla.org/show_bug.cgi?id=1317104 is fixed for a while now. See https://github.com/mozilla-mobile/focus-ios/issues/270, we should re-enable 3rd Party VKB's and see if there's any problems with modern Focus.