### PR TITLE
Revert "fix testSearchProvider UI Test - amazon text field id has changed"

### DIFF
--- a/XCUITest/SearchProviderTest.swift
+++ b/XCUITest/SearchProviderTest.swift
@@ -71,9 +71,7 @@ class SearchProviderTest: BaseTestCase {
 				waitForValueContains(element: urlbarUrltextTextField, value: "https://en.m.wikipedia.org/wiki/Mozilla")
             case "Amazon.com":
 				waitForValueContains(element: urlbarUrltextTextField, value: "https://www.amazon")
-                waitForValueContains(element: app.webViews.textFields["Type search keywords"],
-                    value: searchWord)
-            
+				waitForValueContains(element: app.textFields["Search"], value: searchWord)
 			default:
 				XCTFail("Invalid Search Provider")
 		}


### PR DESCRIPTION
Reverts mozilla-mobile/focus-ios#369

(didn't squash commits)