### PR TITLE
fixes #393 - Properly selects all of the text in the URLBar on focus

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -565,12 +565,16 @@ class URLBar: UIView {
 
 extension URLBar: AutocompleteTextFieldDelegate {
     func autocompleteTextFieldShouldBeginEditing(_ autocompleteTextField: AutocompleteTextField) -> Bool {
+
+        autocompleteTextField.highlightAll()
+        
         if !isEditing && inBrowsingMode {
             present()
             delegate?.urlBarDidActivate(self)
         } else {
             shouldPresent = true
         }
+
 
         return true
     }


### PR DESCRIPTION
#393 