### PR TITLE
fixes #126 - Handles opening external app schemes

### DIFF
--- a/Blockzilla/RequestHandler.swift
+++ b/Blockzilla/RequestHandler.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Telemetry
 
 private let internalSchemes = ["http", "https", "ftp", "file", "about", "javascript", "data"]
 
@@ -33,7 +34,23 @@ class RequestHandler {
                 let alert = RequestHandler.makeAlert(title: title, action: UIConstants.strings.externalLinkEmail, forURL: url)
                 alertCallback(alert)
             default:
-                break
+                let openAction = UIAlertAction(title: UIConstants.strings.open, style: .default) { _ in
+                    Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.open, object: TelemetryEventObject.requestHandler, value: "external link")
+                    UIApplication.shared.openURL(url)
+                }
+
+                let cancelAction = UIAlertAction(title: UIConstants.strings.externalLinkCancel, style: .cancel) { _ in
+                    Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.cancel, object: TelemetryEventObject.requestHandler, value: "external link")
+                }
+
+                let alert = UIAlertController(title: String(format: UIConstants.strings.externalAppLink, AppInfo.productName),
+                                              message: nil,
+                                              preferredStyle: .alert)
+
+                alert.addAction(cancelAction)
+                alert.addAction(openAction)
+                alert.preferredAction = openAction
+                alertCallback(alert)
             }
 
             return false

--- a/Blockzilla/TelemetryIntegration.swift
+++ b/Blockzilla/TelemetryIntegration.swift
@@ -20,6 +20,7 @@ class TelemetryEventMethod {
     public static let click = "click"
     public static let change = "change"
     public static let open = "open"
+    public static let cancel = "cancel"
     public static let openAppStore = "open_app_store"
     public static let openedFromExtension = "opened_from_extension"
     public static let share = "share"
@@ -37,4 +38,5 @@ class TelemetryEventObject {
     public static let pasteAndGo = "paste_and_go"
     public static let copyImage = "copy_image_buuton"
     public static let saveImage = "save_image_button"
+    public static let requestHandler = "request_handler"
 }


### PR DESCRIPTION
So this ended up being a little more complicated than we initially though.

in iOS 9 Apple deprecated [`openURL(_:)`](https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl) for privacy reasons and hasn't provided a great alternative.

So we're left with showing our [dialog](https://user-images.githubusercontent.com/1250545/30175024-ee8e22b4-93b1-11e7-966c-141affd8ee94.png) on _every_ link whether or not the user has an application that can handle it.

Another change that happened is if you do have an application that can open the scheme iOS will prompt you with a dialog asking if you want to open the link in that application.

![img_2554](https://user-images.githubusercontent.com/1250545/30175064-1858932c-93b2-11e7-9bfd-9dc9da6ac824.PNG)

But it only prompts you _once_.