### PR TITLE
Fixes #443 - sharpens icons on 2x devices

### DIFF
--- a/Blockzilla/OpenSearchParser.swift
+++ b/Blockzilla/OpenSearchParser.swift
@@ -121,7 +121,7 @@ class OpenSearchParser {
            let imageData = try? Data(contentsOf: imageURL),
            let uiImage = UIImage(data: imageData)
         {
-            image = uiImage.createScaled(size: CGSize(width: 32, height: 32))
+            image = uiImage
         } else {
             print("Warning: Invalid search image data")
             image = nil

--- a/Blockzilla/SearchSettingsViewController.swift
+++ b/Blockzilla/SearchSettingsViewController.swift
@@ -41,7 +41,7 @@ class SearchSettingsViewController: UITableViewController {
         let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
         cell.textLabel?.text = engine.name
         cell.textLabel?.textColor = UIConstants.colors.settingsTextLabel
-        cell.imageView?.image = engine.image
+        cell.imageView?.image = engine.image?.createScaled(size: CGSize(width: 32, height: 32))
         cell.backgroundColor = UIConstants.colors.background
 
         if engine === searchEngineManager.activeEngine {


### PR DESCRIPTION
![img_8462 png](https://user-images.githubusercontent.com/1250545/30717453-c4bfbf8a-9ed1-11e7-8a73-53758d16454a.png)

Changed where the image gets scaled to match Fennec. No idea how this makes a difference, but it fixes it.