### PR TITLE
Add Print and Save as PDF to Share Sheet

### DIFF
--- a/Blockzilla/Browser.swift
+++ b/Blockzilla/Browser.swift
@@ -270,6 +270,10 @@ extension Browser: UIWebViewDelegate {
             canGoForward = webView.canGoForward
         }
     }
+    
+    func getPrintFormatter() -> UIViewPrintFormatter? {
+        return self.webView?.viewPrintFormatter()
+    }
 }
 
 extension Browser: LocalContentBlockerDelegate {
@@ -298,3 +302,4 @@ extension Browser: UIScrollViewDelegate {
         return delegate?.browserShouldScrollToTop(self) ?? true
     }
 }
+

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -411,7 +411,7 @@ extension BrowserViewController: BrowserToolsetDelegate {
 
     func browserToolsetDidPressSend(_ browserToolset: BrowserToolset) {
         guard let url = browser.url else { return }
-        present(OpenUtils.buildShareViewController(url: url, anchor: browserToolset.sendButton), animated: true, completion: nil)
+        present(OpenUtils.buildShareViewController(url: url, browser: browser, anchor: browserToolset.sendButton), animated: true, completion: nil)
     }
 
     func browserToolsetDidPressSettings(_ browserToolbar: BrowserToolset) {

--- a/Blockzilla/OpenUtils.swift
+++ b/Blockzilla/OpenUtils.swift
@@ -56,8 +56,9 @@ class OpenUtils {
         app.openURL(url)
     }
 
-    static func buildShareViewController(url: URL, anchor: UIView) -> UIActivityViewController {
+    static func buildShareViewController(url: URL, browser: Browser, anchor: UIView) -> UIActivityViewController {
         var activities = [UIActivity]()
+        var activityItems: [Any] = [url]
 
         if canOpenInFirefox {
             activities.append(OpenInFirefoxActivity(url: url))
@@ -68,8 +69,19 @@ class OpenUtils {
         }
 
         activities.append(OpenInSafariActivity(url: url))
+        
+        if let printFormatter = browser.getPrintFormatter() {
+            let printInfo = UIPrintInfo(dictionary: nil)
+            printInfo.jobName = url.absoluteString
+            printInfo.outputType = .general
+            activityItems.append(printInfo)
+            
+            let renderer = UIPrintPageRenderer()
+            renderer.addPrintFormatter(printFormatter, startingAtPageAt: 0)
+            activityItems.append(renderer)
+        }
 
-        let shareController = UIActivityViewController(activityItems: [url], applicationActivities: activities)
+        let shareController = UIActivityViewController(activityItems: activityItems, applicationActivities: activities)
 
         shareController.popoverPresentationController?.sourceView = anchor
         shareController.popoverPresentationController?.sourceRect = anchor.bounds


### PR DESCRIPTION
This addresses issue #491. Note that it does not include the header & footer information: URL, page title, date, page number like the Firefox iOS app does. I am happy to add those but it would make the pull request a bit larger. Page title isn't available at the moment but should be after the move to WKWebView.

Screencast: http://recordit.co/yzdRENdssk