### PR TITLE
 Historical backward page cache retained after erase #548

### DIFF
--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -59,6 +59,7 @@ class WebViewController: UIViewController, WebController {
     func reset() {
         browserView.load(URLRequest(url: URL(string: "about:blank")!))
         browserView.navigationDelegate = nil
+        browserView = WKWebView()
         setupWebview()
         self.view = browserView
     }


### PR DESCRIPTION
This also fixes https://github.com/mozilla-mobile/focus-ios/issues/549