### PR TITLE
Fixes #547 - Open in Focus not showing on News app

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -543,7 +543,7 @@ class URLBar: UIView {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
             components?.user = nil
             components?.password = nil
-            displayURL = components?.url?.absoluteString
+            displayURL = urlText.text
             truncatedURL = components?.host
         }
         urlText.text = displayURL

--- a/OpenInFocus/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/OpenInFocus/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -124,6 +124,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-iPadPro@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/OpenInFocus/Info.plist
+++ b/OpenInFocus/Info.plist
@@ -26,6 +26,12 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
 				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>


### PR DESCRIPTION
This fixes the #547 issue, where I need to add more 3 parameters on info.plist of Action Extension.

Now it works!

I'm only confused how can I handle a pull request when I have other pending approve, because my changes on URLBar.swift come with this one (I have created another branch to work on this problem, maybe I should have created one for the first pull request) 

<img width="231" alt="screen shot 2017-10-12 at 22 51 47" src="https://user-images.githubusercontent.com/648079/31527113-9d15af86-afa1-11e7-8c3c-e300acccc358.png">
<img width="287" alt="screen shot 2017-10-12 at 22 51 37" src="https://user-images.githubusercontent.com/648079/31527114-9d54aace-afa1-11e7-9752-20ec0d699dae.png">
<img width="547" alt="screen shot 2017-10-12 at 22 50 46" src="https://user-images.githubusercontent.com/648079/31527116-9d83ab76-afa1-11e7-9f72-ea2a61509c24.png">
