### PR TITLE
Fixes #547 - Open in Focus not showing on News app

### DIFF
--- a/OpenInFocus/Info.plist
+++ b/OpenInFocus/Info.plist
@@ -26,6 +26,12 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
 				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>


### PR DESCRIPTION
Sending a correct pull request for #547 as request by @boek.

This changes fix the problem of not show firefox focus on News share extension.

<img width="231" alt="screen shot 2017-10-12 at 22 51 47" src="https://user-images.githubusercontent.com/648079/31568955-c1456246-b04d-11e7-9cec-838f3e52ea3e.png">
<img width="287" alt="screen shot 2017-10-12 at 22 51 37" src="https://user-images.githubusercontent.com/648079/31568958-c173e74c-b04d-11e7-8369-3b7f0aa3869e.png">

