### PR TITLE
Fixes #537 - Adding a verification to see if already has a prefix with 'http'

### DIFF
--- a/Blockzilla/URIFixup.swift
+++ b/Blockzilla/URIFixup.swift
@@ -10,7 +10,7 @@ class URIFixup {
         guard let escaped = trimmed.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlAllowed) else {
             return nil
         }
-        
+
         // Check if the URL includes a scheme. This will handle
         // all valid requests starting with "http://", "about:", etc.
         // Also check with a regular expression if there is a port in the url

--- a/Blockzilla/URIFixup.swift
+++ b/Blockzilla/URIFixup.swift
@@ -10,10 +10,12 @@ class URIFixup {
         guard let escaped = trimmed.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlAllowed) else {
             return nil
         }
-
+        
         // Check if the URL includes a scheme. This will handle
         // all valid requests starting with "http://", "about:", etc.
-        if let url = URL(string: entry), url.scheme != nil {
+        // Also check with a regular expression if there is a port in the url
+        // this will be handle later in this function adding http prefix
+        if let url = URL(string: entry), url.scheme != nil, trimmed.range(of: ":") == nil, trimmed.range(of:"\\b:[0-9]{1,5}", options: .regularExpression) == nil {
             return url
         }
 

--- a/Blockzilla/URIFixup.swift
+++ b/Blockzilla/URIFixup.swift
@@ -28,10 +28,13 @@ class URIFixup {
         if trimmed.range(of: " ") != nil {
             return nil
         }
+        
+        // If the input url has a prefix http or https, don't append again
+        let finalurl = escaped.hasPrefix("http://") || escaped.hasPrefix("https://") ? escaped : "http://\(escaped)"
 
         // If there is a ".", prepend "http://" and try again. Since this
         // is strictly an "http://" URL, we also require a host.
-        if let url = URL(string: "http://\(escaped)"), url.host != nil {
+        if let url = URL(string: finalurl), url.host != nil {
             return url
         }
 


### PR DESCRIPTION
This commit fix the problem that, if the user already has input the url with 'http' or 'https', don't make this prepend again.