### PR TITLE
Enable allowsLinkPreview for 3D Touch on links

### DIFF
--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -81,7 +81,7 @@ class WebViewController: UIViewController, WebController {
 
     private func setupWebview() {
         browserView.allowsBackForwardNavigationGestures = true
-        browserView.allowsLinkPreview = false
+        browserView.allowsLinkPreview = true
         browserView.scrollView.clipsToBounds = false
         browserView.scrollView.delegate = self
         browserView.navigationDelegate = self


### PR DESCRIPTION
Re: mozilla-mobile#298

https://developer.apple.com/documentation/webkit/wkwebview/1415000-allowslinkpreview