### PR TITLE
Double paste when copying a URL from Focus and pasting into Slack #662

### DIFF
--- a/Blockzilla/OpenUtils.swift
+++ b/Blockzilla/OpenUtils.swift
@@ -84,8 +84,6 @@ class OpenUtils {
             activityItems.append(TitleActivityItemProvider(title: title))
         }
         
-        activityItems.append(url as AnyObject)
-
         let shareController = UIActivityViewController(activityItems: activityItems, applicationActivities: activities)
 
         shareController.popoverPresentationController?.sourceView = anchor


### PR DESCRIPTION
Line #61, we already have url in the array when it's created