### PR TITLE
Swaps UIKeyboardAppearance to Dark (Issue #737)

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -47,6 +47,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         displaySplashAnimation()
         KeyboardHelper.defaultHelper.startObserving()
 
+        // Override default keyboard appearance
+        UITextField.appearance().keyboardAppearance = .dark
+
         let prefIntroDone = UserDefaults.standard.integer(forKey: AppDelegate.prefIntroDone)
 
         let needToShowFirstRunExperience = prefIntroDone < AppDelegate.prefIntroVersion

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -136,7 +136,7 @@ class URLBar: UIView {
         urlText.textColor = UIConstants.colors.urlTextFont
         urlText.highlightColor = UIConstants.colors.urlTextHighlight
         urlText.keyboardType = .webSearch
-        urlText.keyboardAppearance = UIKeyboardAppearance.dark;
+        urlText.keyboardAppearance = UIKeyboardAppearance.dark
         urlText.autocapitalizationType = .none
         urlText.autocorrectionType = .no
         urlText.rightView = clearButton

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -136,6 +136,7 @@ class URLBar: UIView {
         urlText.textColor = UIConstants.colors.urlTextFont
         urlText.highlightColor = UIConstants.colors.urlTextHighlight
         urlText.keyboardType = .webSearch
+        urlText.keyboardAppearance = UIKeyboardAppearance.dark;
         urlText.autocapitalizationType = .none
         urlText.autocorrectionType = .no
         urlText.rightView = clearButton

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -136,7 +136,6 @@ class URLBar: UIView {
         urlText.textColor = UIConstants.colors.urlTextFont
         urlText.highlightColor = UIConstants.colors.urlTextHighlight
         urlText.keyboardType = .webSearch
-        urlText.keyboardAppearance = UIKeyboardAppearance.dark
         urlText.autocapitalizationType = .none
         urlText.autocorrectionType = .no
         urlText.rightView = clearButton


### PR DESCRIPTION
Sets urlText.keyboardAppearance to UIKeyboardAppearance.Dark

A good idea from https://github.com/mozilla-mobile/focus-ios/issues/737