### PR TITLE
Add XCUITest for TP Settings

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2F2F84BCF076B21DE42D1F29 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C652A61E213D254A86DF5736 /* CoreMedia.framework */; };
 		34056D10515852F370C83A01 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB8E622E994545108473554 /* QuartzCore.framework */; };
 		4285B8E0671F40DA543A2E58 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29B90C056305836CB297FF79 /* AssetsLibrary.framework */; };
+		4F1284861FC5E242001A775B /* TPSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1284851FC5E242001A775B /* TPSettingsTest.swift */; };
 		4F582F7B1F44A10F006C744B /* OpenInFocusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F582F7A1F44A10F006C744B /* OpenInFocusTest.swift */; };
 		4FE4E6F61FBB5E2C001BB779 /* TPSidebarBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE4E6F51FBB5E2C001BB779 /* TPSidebarBadge.swift */; };
 		58BD00527359D003DADE601E /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC16C41C8D4A74C79A493D42 /* CoreVideo.framework */; };
@@ -201,6 +202,7 @@
 		1D051AC1857A0EEEBB833D15 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		29B90C056305836CB297FF79 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		427B752EF11959F9C38B12D6 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		4F1284851FC5E242001A775B /* TPSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPSettingsTest.swift; sourceTree = "<group>"; };
 		4F582F7A1F44A10F006C744B /* OpenInFocusTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenInFocusTest.swift; sourceTree = "<group>"; };
 		4FE4E6F51FBB5E2C001BB779 /* TPSidebarBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPSidebarBadge.swift; sourceTree = "<group>"; };
 		6616A36E1BD17EFA00C7E493 /* style.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = style.css; sourceTree = "<group>"; };
@@ -708,6 +710,7 @@
 				0BA7B7BF1E9D6C1B0058EA5B /* XCUITests-Bridging-Header.h */,
 				4F582F7A1F44A10F006C744B /* OpenInFocusTest.swift */,
 				4FE4E6F51FBB5E2C001BB779 /* TPSidebarBadge.swift */,
+				4F1284851FC5E242001A775B /* TPSettingsTest.swift */,
 			);
 			path = XCUITest;
 			sourceTree = "<group>";
@@ -1299,6 +1302,7 @@
 				0B70C1631DE6128900CEF7E0 /* WebsiteMemoryTest.swift in Sources */,
 				4F582F7B1F44A10F006C744B /* OpenInFocusTest.swift in Sources */,
 				0BC928CE1E366A6E004AC581 /* AsianLocaleTest.swift in Sources */,
+				4F1284861FC5E242001A775B /* TPSettingsTest.swift in Sources */,
 				4FE4E6F61FBB5E2C001BB779 /* TPSidebarBadge.swift in Sources */,
 				0BA39A861DD2B8E4005F970A /* WebsiteAccessTest.swift in Sources */,
 				0B0D6BC41F3CDDBB00497D08 /* CollapsedURLTest.swift in Sources */,

--- a/XCUITest/TPSettingsTest.swift
+++ b/XCUITest/TPSettingsTest.swift
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class TrackingProtectionSettings: BaseTestCase {
+
+    override func setUp() {
+        super.setUp()
+        dismissFirstRunUI()
+    }
+
+    override func tearDown() {
+        app.terminate()
+        super.tearDown()
+    }
+
+    func testInactiveSettings() {
+
+        // Go to in-app settings
+        app.buttons["Settings"].tap()
+        waitforExistence(element: app.tables.switches["BlockerToggle.BlockAnalytics"])
+
+        // Disable 'block analytic trackers'
+        app.tables.switches["BlockerToggle.BlockAnalytics"].tap()
+        XCTAssertEqual(app.tables.switches["BlockerToggle.BlockAnalytics"].value as! String, "0")
+
+        // Exit in-app settings
+        app.navigationBars["Settings"].children(matching: .button).matching(identifier: "Back").element(boundBy: 0).tap()
+
+        // Visit https://www.mozilla.org
+        loadWebPage("mozilla")
+
+        // Check the correct site is reached
+        waitForWebPageLoad()
+
+        // Check for the presence of the shield
+        // Currently, Mozilla has one (1) analytical tracker that is un-blocked
+        XCTAssertEqual(app.staticTexts["TrackingProtectionBadge.counterLabel"].label, "0")
+
+        // Open the tracking protection sidebar
+        app.otherElements["URLBar.trackingProtectionIcon"].tap()
+
+        // Wait for the sidebar to open
+        waitforExistence(element: app.staticTexts["Tracking Protection"])
+
+        // Check for the existence of one (1) analytical tracker on Mozilla
+        let counters = app.staticTexts.matching(identifier: "TrackingProtectionBreakdownItem.counterLabel")
+
+        XCTAssertEqual(counters.element(boundBy: 0).label, "0") // Ad Trackers
+        XCTAssertEqual(counters.element(boundBy: 1).label, "0") // Analytical trackers
+        XCTAssertEqual(counters.element(boundBy: 2).label, "0") // Social trackers
+        XCTAssertEqual(counters.element(boundBy: 3).label, "0") // Content trackers
+
+        // Close the sidebar
+        app.buttons["TrackingProtectionView.closeButton"].tap()
+
+        // Erase the history
+        app.buttons["ERASE"].tap()
+        waitforExistence(element: app.staticTexts["Your browsing history has been erased."])
+
+        // Reset in-app settings (work-around until issue: #731)
+        app.buttons["Settings"].tap()
+        waitforExistence(element: app.tables.switches["BlockerToggle.BlockAnalytics"])
+
+        // Re-enable 'block analytic trackers'
+        app.tables.switches["BlockerToggle.BlockAnalytics"].tap()
+        XCTAssertEqual(app.tables.switches["BlockerToggle.BlockAnalytics"].value as! String, "1")
+    }
+
+}

--- a/XCUITest/TPSettingsTest.swift
+++ b/XCUITest/TPSettingsTest.swift
@@ -58,7 +58,6 @@ class TrackingProtectionSettings: BaseTestCase {
 
         // Erase the history
         app.buttons["ERASE"].tap()
-        waitforExistence(element: app.staticTexts["Your browsing history has been erased."])
 
         // Reset in-app settings (work-around until issue: #731)
         app.buttons["Settings"].tap()


### PR DESCRIPTION
Initial testing of in-app settings for tracking protection. This test can be expanded in the future for testing all settings against a self hosted site with many trackers but for now check against mozilla.org –  also reset settings manually until we have issue #731 resolved