### PR TITLE
Add validation to custom search engine

### DIFF
--- a/Blockzilla/AddSearchEngineViewController.swift
+++ b/Blockzilla/AddSearchEngineViewController.swift
@@ -10,6 +10,7 @@ protocol AddSearchEngineDelegate {
 
 class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
     private var delegate: AddSearchEngineDelegate
+    private var searchEngineManager: SearchEngineManager
     
     private let leftMargin = 10
     private let rowHeight = 44
@@ -18,8 +19,9 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
     private var templateInput = UITextView()
     private var templatePlaceholderLabel = UILabel()
     
-    init(delegate: AddSearchEngineDelegate) {
+    init(delegate: AddSearchEngineDelegate, searchEngineManager: SearchEngineManager) {
         self.delegate = delegate
+        self.searchEngineManager = searchEngineManager
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -142,25 +144,39 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
         guard let name = nameInput.text else { return }
         guard let template = templateInput.text else { return }
         
+        if !AddSearchEngineViewController.isValidTemplate(template) || !searchEngineManager.isValidSearchEngineName(name) {
+            Toast(text: UIConstants.strings.errorTryAgain).show()
+            return
+        }
+        
         delegate.addSearchEngineViewController(self, name: name, searchTemplate: template)
         Toast(text: UIConstants.strings.NewSearchEngineAdded).show()
         self.navigationController?.popViewController(animated: true)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-        templatePlaceholderLabel.isHidden = !isNullOrEmpty(text: textView.text)
+        templatePlaceholderLabel.isHidden = !AddSearchEngineViewController.isNullOrEmpty(text: textView.text)
     }
     
     func textViewDidChange(_ textView: UITextView) {
-        templatePlaceholderLabel.isHidden = !isNullOrEmpty(text: textView.text)
+        templatePlaceholderLabel.isHidden = !AddSearchEngineViewController.isNullOrEmpty(text: textView.text)
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        templatePlaceholderLabel.isHidden = !isNullOrEmpty(text: textView.text)
+        templatePlaceholderLabel.isHidden = !AddSearchEngineViewController.isNullOrEmpty(text: textView.text)
     }
     
-    private func isNullOrEmpty(text:String?) -> Bool{
+    private static func isNullOrEmpty(text:String?) -> Bool {
         guard let text = text else { return true }
         return text.isEmpty
+    }
+    
+    static func isValidTemplate(_ template:String) -> Bool {
+        if isNullOrEmpty(text: template) {
+            return false
+        }
+        
+        guard let url = URL(string: template.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed)!) else { return false }
+        return url.isWebPage()
     }
 }

--- a/Blockzilla/AddSearchEngineViewController.swift
+++ b/Blockzilla/AddSearchEngineViewController.swift
@@ -155,24 +155,19 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-        templatePlaceholderLabel.isHidden = !AddSearchEngineViewController.isNullOrEmpty(text: textView.text)
+        templatePlaceholderLabel.isHidden = !textView.text.isEmpty
     }
     
     func textViewDidChange(_ textView: UITextView) {
-        templatePlaceholderLabel.isHidden = !AddSearchEngineViewController.isNullOrEmpty(text: textView.text)
+        templatePlaceholderLabel.isHidden = !textView.text.isEmpty
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        templatePlaceholderLabel.isHidden = !AddSearchEngineViewController.isNullOrEmpty(text: textView.text)
-    }
-    
-    private static func isNullOrEmpty(text:String?) -> Bool {
-        guard let text = text else { return true }
-        return text.isEmpty
+        templatePlaceholderLabel.isHidden = !textView.text.isEmpty
     }
     
     static func isValidTemplate(_ template:String) -> Bool {
-        if isNullOrEmpty(text: template) {
+        if template.isEmpty {
             return false
         }
         

--- a/Blockzilla/AddSearchEngineViewController.swift
+++ b/Blockzilla/AddSearchEngineViewController.swift
@@ -171,6 +171,10 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
             return false
         }
         
+        if !template.contains("%s") {
+            return false
+        }
+        
         guard let url = URL(string: template.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed)!) else { return false }
         return url.isWebPage()
     }

--- a/Blockzilla/SearchEngineManager.swift
+++ b/Blockzilla/SearchEngineManager.swift
@@ -81,6 +81,22 @@ class SearchEngineManager {
         loadEngines()
     }
     
+    func isValidSearchEngineName(_ name: String) -> Bool {
+        if name.isEmpty {
+            return false
+        }
+        
+        var names = engines.map { (engine) -> String in
+            return engine.name
+        }
+        
+        names = names + getDisabledDefaultEngineNames()
+        
+        return !names.contains(where: { (n) -> Bool in
+            return n == name
+        })
+    }
+    
     private func loadEngines() {
         
         // Get the directories to look for engines, from most to least specific.

--- a/Blockzilla/SearchSettingsViewController.swift
+++ b/Blockzilla/SearchSettingsViewController.swift
@@ -143,7 +143,7 @@ class SearchSettingsViewController: UITableViewController {
         
         if indexPath.item == engines.count {
             // Add search engine tapped
-            let vc = AddSearchEngineViewController(delegate: self)
+            let vc = AddSearchEngineViewController(delegate: self, searchEngineManager: searchEngineManager)
             navigationController?.pushViewController(vc, animated: true)
         } else if indexPath.item > engines.count {
             // Restore default engines tapped

--- a/ClientTests/SearchEngineManagerTests.swift
+++ b/ClientTests/SearchEngineManagerTests.swift
@@ -80,6 +80,26 @@ class SearchEngineManagerTests: XCTestCase {
         XCTAssertEqual(manager.activeEngine.name, activeEngine.name)
         XCTAssertEqual(mockUserDefaults.setCalls, 0)
     }
+    
+    func testEmptyIsNotValidSearchEngineName() {
+        let manager = SearchEngineManager(prefs: mockUserDefaults)
+        XCTAssertFalse(manager.isValidSearchEngineName(""))
+    }
+    
+    func testCustomEngineIsNotValidSearchEngineName() {
+        let manager = SearchEngineManager(prefs: mockUserDefaults)
+        XCTAssertTrue(manager.isValidSearchEngineName(CUSTOM_ENGINE_NAME))
+        _ = manager.addEngine(name: CUSTOM_ENGINE_NAME, template: CUSTOM_ENGINE_TEMPLATE)
+        XCTAssertFalse(manager.isValidSearchEngineName(CUSTOM_ENGINE_NAME))
+    }
+    
+    func testDisabledEngineIsNotValidSearchEngineName() {
+        let manager = SearchEngineManager(prefs: mockUserDefaults)
+        let engineToRemove = manager.engines[1]
+        XCTAssertFalse(manager.isValidSearchEngineName(engineToRemove.name))
+        manager.removeEngine(engine: engineToRemove)
+        XCTAssertFalse(manager.isValidSearchEngineName(engineToRemove.name))
+    }
 }
 
 class MockUserDefaults: UserDefaults {


### PR DESCRIPTION
For issue #759. 

Validate that:
 - name is not null, empty, or already being used
 - template is not null, empty, or an invalid url