### PR TITLE
Reverts HEAD request back to a GET

### DIFF
--- a/Blockzilla/AddSearchEngineViewController.swift
+++ b/Blockzilla/AddSearchEngineViewController.swift
@@ -189,8 +189,6 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
         }
 
         var request = URLRequest(url: url)
-        request.httpMethod = "HEAD"
-
         request.timeoutInterval = REQUEST_TIMEOUT
 
         dataTask = URLSession.shared.dataTask(with: request) { data, response, error in


### PR DESCRIPTION
Looks like MDN doesn't allow HEAD requests. So we're going to revert back to
GET to make sure we don't get any false negatives.