### PR TITLE
Improve de locales for tracking protection toggle

### DIFF
--- a/Blockzilla/de.lproj/Localizable.strings
+++ b/Blockzilla/de.lproj/Localizable.strings
@@ -374,7 +374,7 @@
 "trackingProtection.contentTrackerLabel" = "Inhalts-Tracker";
 
 /* text showing the tracking protection is disabled. */
-"trackingProtection.disabledLabel" = "Schutz vor Aktivitätenverfolgung aus";
+"trackingProtection.disabledLabel" = "Tracking-Schutz aus";
 
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "Weitere Informationen";
@@ -386,7 +386,7 @@
 "trackingProtection.toggleDescription1" = "Deaktivieren, bis Sie %@ schließen oder auf ENTFERNEN tippen.";
 
 /* Text for the toggle that temporarily disables tracking protection. */
-"trackingProtection.toggleLabel" = "Schutz vor Aktivitätenverfolgung";
+"trackingProtection.toggleLabel" = "Tracking-Schutz";
 
 /* General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar */
 "trackingProtection.trackerDescriptionLabel" = "Auswählen, ob %@ Werbe-, Analyse-, soziale und andere Verfolger blockiert.";


### PR DESCRIPTION
Use a shorter label to prevent the toggle from disappearing from the tracking protection sidebar.

This should solve #847. (I can not test this.)

_From a pure language point of view, the current version is of course a better translation; but "Tracking" (instead of "Aktivitätenverfolgung") should be understandable enough, especially since "Werbe-Tracker" etc. is used for labels in the same sidebar; furthermore, "Tracking-Schutz" is a not uncommon term._