### PR TITLE
Capture iframes and stylesheets in preload.js

### DIFF
--- a/Blockzilla/Lib/TrackingProtection/Assets/preload.js
+++ b/Blockzilla/Lib/TrackingProtection/Assets/preload.js
@@ -44,7 +44,7 @@
   var observer = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {
       mutation.addedNodes.forEach(function(node) {
-        if (node.tagName === 'SCRIPT') {
+        if (node.tagName === 'SCRIPT' || node.tagName === 'IFRAME' || node.tagName === 'LINK') {
           messageHandler.postMessage({ url: node.src })
         }
       });


### PR DESCRIPTION
An iframe can track users, so I am wondering why you don't count the iframes that are blocked. Aren't iframes blocked? (Same for stylesheets)