### PR TITLE
Fix #847: long l10n strings are not font shrinking, and also breaking layouts

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		EB84F96D2093799900BA6739 /* TrackingProtectionPageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB84F96C2093799800BA6739 /* TrackingProtectionPageStats.swift */; };
 		EB84F96F209380CE00BA6739 /* URLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB84F96E209380CE00BA6739 /* URLExtensions.swift */; };
 		EB84F9712093815500BA6739 /* effective_tld_names.dat in Resources */ = {isa = PBXBuildFile; fileRef = EB84F9702093815500BA6739 /* effective_tld_names.dat */; };
+		EBE44F4E20ADDF6A005AFEA6 /* SmartLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE44F4D20ADDF6A005AFEA6 /* SmartLabel.swift */; };
 		F805722F1DBEE504004339C1 /* WebCacheUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F805722E1DBEE504004339C1 /* WebCacheUtils.swift */; };
 		F84AFE751DE77FE6005C4DD1 /* LaunchScreen.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE721DE77FE6005C4DD1 /* LaunchScreen.png */; };
 		F84AFE761DE77FE6005C4DD1 /* LaunchScreen@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE731DE77FE6005C4DD1 /* LaunchScreen@2x.png */; };
@@ -746,6 +747,7 @@
 		EB84F96C2093799800BA6739 /* TrackingProtectionPageStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TrackingProtectionPageStats.swift; path = Lib/TrackingProtection/TrackingProtectionPageStats.swift; sourceTree = "<group>"; };
 		EB84F96E209380CE00BA6739 /* URLExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLExtensions.swift; sourceTree = "<group>"; };
 		EB84F9702093815500BA6739 /* effective_tld_names.dat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = effective_tld_names.dat; sourceTree = "<group>"; };
+		EBE44F4D20ADDF6A005AFEA6 /* SmartLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SmartLabel.swift; sourceTree = "<group>"; };
 		F4C4943B406FCA9B74B4E186 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		F805722E1DBEE504004339C1 /* WebCacheUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebCacheUtils.swift; sourceTree = "<group>"; };
 		F84AFE721DE77FE6005C4DD1 /* LaunchScreen.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = LaunchScreen.png; sourceTree = "<group>"; };
@@ -1111,6 +1113,7 @@
 				D3E54FD01DEFB063003E1AFF /* SearchEngineManager.swift */,
 				D3E54FDF1DF0E221003E1AFF /* SearchSettingsViewController.swift */,
 				D33A1AB01BC48FAC0003D929 /* SettingsViewController.swift */,
+				EBE44F4D20ADDF6A005AFEA6 /* SmartLabel.swift */,
 				D34E70341DA874AA00BABDCC /* StringExtensions.swift */,
 				E40AFB131DC939FF00DA5651 /* SupportUtils.swift */,
 				D0967A801EC50002009D937F /* TelemetryIntegration.swift */,
@@ -1562,6 +1565,7 @@
 				B3CD41C91FD1027000AEBD58 /* InsetTextField.swift in Sources */,
 				D30179071BC6CB19009AD388 /* BlockerEnabledDetector.swift in Sources */,
 				B3481A551FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift in Sources */,
+				EBE44F4E20ADDF6A005AFEA6 /* SmartLabel.swift in Sources */,
 				D37DE55D1BCDBD6100906364 /* WaveView.swift in Sources */,
 				E4BF2DD71BACE8CA00DA9D68 /* AppDelegate.swift in Sources */,
 				746D78FB1F4E0095002EB522 /* ShareSheetActivities.swift in Sources */,

--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -163,7 +163,7 @@ private class AboutHeaderView: UIView {
 
 
 
-        let aboutParagraph = UILabel()
+        let aboutParagraph = SmartLabel()
         aboutParagraph.attributedText = attributed
         aboutParagraph.textColor = UIConstants.colors.defaultFont
         aboutParagraph.font = UIConstants.fonts.aboutText
@@ -172,7 +172,7 @@ private class AboutHeaderView: UIView {
     }()
 
     private lazy var versionNumber: UILabel = {
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         label.font = UIConstants.fonts.aboutText
         label.textColor = UIConstants.colors.defaultFont.withAlphaComponent(0.5)

--- a/Blockzilla/AddCustomDomainViewController.swift
+++ b/Blockzilla/AddCustomDomainViewController.swift
@@ -12,9 +12,9 @@ protocol AddCustomDomainViewControllerDelegate: class {
 
 class AddCustomDomainViewController: UIViewController, UITextFieldDelegate {
     private let autocompleteSource: CustomAutocompleteSource
-    private let inputLabel = UILabel()
+    private let inputLabel = SmartLabel()
     private let textInput: UITextField = InsetTextField(insetBy: 10)
-    private let inputDescription = UILabel()
+    private let inputDescription = SmartLabel()
     weak var delegate: AddCustomDomainViewControllerDelegate?
     
     init(autocompleteSource: CustomAutocompleteSource) {

--- a/Blockzilla/AddSearchEngineViewController.swift
+++ b/Blockzilla/AddSearchEngineViewController.swift
@@ -21,7 +21,7 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
     
     private var nameInput = UITextField()
     private var templateInput = UITextView()
-    private var templatePlaceholderLabel = UILabel()
+    private var templatePlaceholderLabel = SmartLabel()
     
     init(delegate: AddSearchEngineDelegate, searchEngineManager: SearchEngineManager) {
         self.delegate = delegate
@@ -49,7 +49,7 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
         let container = UIView()
         view.addSubview(container)
         
-        let nameLabel = UILabel()
+        let nameLabel = SmartLabel()
         nameLabel.text = UIConstants.strings.NameToDisplay
         nameLabel.textColor = UIConstants.colors.settingsTextLabel
         container.addSubview(nameLabel)
@@ -75,7 +75,7 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
         templatePlaceholderLabel.numberOfLines = 0
         templateContainer.addSubview(templatePlaceholderLabel)
         
-        let templateLabel = UILabel()
+        let templateLabel = SmartLabel()
         templateLabel.text = UIConstants.strings.AddSearchEngineTemplate
         templateLabel.textColor = UIConstants.colors.settingsTextLabel
         container.addSubview(templateLabel)
@@ -90,7 +90,7 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
         templateInput.autocorrectionType = .no
         templateContainer.addSubview(templateInput)
 
-        let exampleLabel = UILabel()
+        let exampleLabel = SmartLabel()
         let learnMore = NSAttributedString(string: UIConstants.strings.learnMore, attributes: [NSAttributedStringKey.foregroundColor : UIConstants.colors.toggleOn])
         let subtitle = NSMutableAttributedString(string: UIConstants.strings.AddSearchEngineTemplateExample, attributes: [NSAttributedStringKey.foregroundColor : UIConstants.colors.settingsDetailLabel])
         let space = NSAttributedString(string: " ", attributes: [NSAttributedStringKey.foregroundColor : UIConstants.colors.toggleOn])

--- a/Blockzilla/AutocompleteCustomUrlViewController.swift
+++ b/Blockzilla/AutocompleteCustomUrlViewController.swift
@@ -23,7 +23,7 @@ class AutocompleteCustomUrlViewController: UIViewController {
 
         view.addSubview(tableView)
 
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = UIConstants.strings.autocompleteEmptyState
         label.font = UIConstants.fonts.settingsDescriptionText
         label.textColor = UIConstants.colors.settingsTextLabel

--- a/Blockzilla/AutocompleteSettingViewController.swift
+++ b/Blockzilla/AutocompleteSettingViewController.swift
@@ -56,7 +56,7 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
         cell.textLabel?.text = " "
         cell.backgroundColor = UIConstants.colors.background
 
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = labelText
         label.textColor = UIConstants.colors.tableSectionHeader
         label.font = UIConstants.fonts.tableSectionHeader

--- a/Blockzilla/FirstRunViewController.swift
+++ b/Blockzilla/FirstRunViewController.swift
@@ -19,14 +19,14 @@ class FirstRunViewController: UIViewController {
         let wave = WaveView()
         view.addSubview(wave)
 
-        let title = UILabel()
+        let title = SmartLabel()
         title.font = UIConstants.fonts.firstRunTitle
         title.numberOfLines = 0
         title.textColor = .white
         title.attributedText = NSAttributedString(string: UIConstants.strings.firstRunTitle, attributes: attributes)
         view.addSubview(title)
 
-        let message = UILabel()
+        let message = SmartLabel()
         message.font = UIConstants.fonts.firstRunMessage
         message.numberOfLines = 0
         message.textColor = .white

--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -12,10 +12,10 @@ protocol HomeViewDelegate: class {
 class HomeView: UIView {
     weak var delegate: HomeViewDelegate?
     private(set) var settingsButton: UIButton! = nil
-    private let description1 = UILabel()
-    private let description2 = UILabel()
+    private let description1 = SmartLabel()
+    private let description2 = SmartLabel()
     private let trackerStatsView = UIView()
-    private let trackerStatsLabel = UILabel()
+    private let trackerStatsLabel = SmartLabel()
     
     init() {
         super.init(frame: CGRect.zero)

--- a/Blockzilla/InstructionsView.swift
+++ b/Blockzilla/InstructionsView.swift
@@ -46,7 +46,7 @@ private class InstructionView: UIView {
         imageView.image = image
         addSubview(imageView)
 
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = text
         label.textColor = UIConstants.colors.defaultFont
         label.numberOfLines = 0

--- a/Blockzilla/Lib/TrackingProtection/TrackingProtectionSummaryViewController.swift
+++ b/Blockzilla/Lib/TrackingProtection/TrackingProtectionSummaryViewController.swift
@@ -126,8 +126,8 @@ class TrackingProtectionBreakdownVisualizer: UIView {
 
 class TrackingProtectionBreakdownItem: UIView {
     private let indicatorView = UIView()
-    private let titleLabel = UILabel()
-    private let counterLabel = UILabel()
+    private let titleLabel = SmartLabel()
+    private let counterLabel = SmartLabel()
 
     override var intrinsicContentSize: CGSize { return CGSize(width: 0, height: 56) }
 
@@ -154,9 +154,13 @@ class TrackingProtectionBreakdownItem: UIView {
             make.width.equalTo(8)
         }
 
+        let counterWidth = NSString(string: "1000").size(withAttributes: [NSAttributedStringKey.font: counterLabel.font]).width
+
         titleLabel.snp.makeConstraints { make in
             make.centerY.equalTo(indicatorView.snp.centerY)
             make.leading.equalTo(indicatorView.snp.trailing).offset(12)
+            // Leave space on the right for the label to grow
+            make.trailing.equalToSuperview().inset(counterWidth)
         }
 
         counterLabel.snp.makeConstraints { make in
@@ -177,8 +181,8 @@ class TrackingProtectionBreakdownItem: UIView {
 }
 
 class TrackingProtectionBreakdownView: UIView {
-    private let titleLabel = UILabel()
-    private let counterLabel = UILabel()
+    private let titleLabel = SmartLabel()
+    private let counterLabel = SmartLabel()
     private let breakdown = TrackingProtectionBreakdownVisualizer()
     private let adItem = TrackingProtectionBreakdownItem(text: UIConstants.strings.adTrackerLabel, color: BlocklistName.advertising.color)
     private let analyticItem = TrackingProtectionBreakdownItem(text: UIConstants.strings.analyticTrackerLabel, color: BlocklistName.analytics.color)
@@ -288,11 +292,10 @@ class TrackingProtectionBreakdownView: UIView {
 
 class TrackingProtectionToggleView: UIView {
     private let icon = UIImageView(image: #imageLiteral(resourceName: "tracking_protection").imageFlippedForRightToLeftLayoutDirection())
-    private let label = UILabel(frame: .zero)
+    private let label = SmartLabel(frame: .zero)
     let toggle = UISwitch()
     private let borderView = UIView()
-    private let descriptionLabel = UILabel()
-
+    private let descriptionLabel = SmartLabel()
 
     var trackingProtectionStatus = TrackingProtectionStatus.off {
         didSet {
@@ -337,8 +340,7 @@ class TrackingProtectionToggleView: UIView {
         }
 
         label.snp.makeConstraints {make in
-            make.leading.equalTo(icon.snp.trailing).offset(08)
-            make.height.equalToSuperview()
+            make.leading.equalTo(icon.snp.trailing).offset(8)
             make.centerY.equalToSuperview()
             make.trailing.equalTo(toggle.snp.leading).offset(-8)
         }
@@ -347,6 +349,8 @@ class TrackingProtectionToggleView: UIView {
             make.centerY.equalToSuperview()
             make.trailing.equalTo(safeAreaLayoutGuide).offset(-16)
         }
+
+        toggle.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         borderView.snp.makeConstraints { make in
             make.top.equalTo(toggle.snp.bottom).offset(8)

--- a/Blockzilla/SafariInstructionsViewController.swift
+++ b/Blockzilla/SafariInstructionsViewController.swift
@@ -33,7 +33,7 @@ private class DisabledStateView: UIView {
     init() {
         super.init(frame: CGRect.zero)
 
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = UIConstants.strings.safariInstructionsNotEnabled
         label.textColor = UIConstants.colors.focusRed
         label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: UILayoutConstraintAxis.vertical)

--- a/Blockzilla/SearchEngine.swift
+++ b/Blockzilla/SearchEngine.swift
@@ -66,7 +66,7 @@ class SearchEngine: NSObject, NSCoding {
         
         var faviconImage = UIImage()
 
-        let faviconLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
+        let faviconLabel = SmartLabel(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
         faviconLabel.backgroundColor = UIColor(rgb: 0xededf0)
         faviconLabel.text = String(faviconLetter)
         faviconLabel.textAlignment = .center

--- a/Blockzilla/SearchSettingsViewController.swift
+++ b/Blockzilla/SearchSettingsViewController.swift
@@ -41,7 +41,7 @@ class SearchSettingsViewController: UITableViewController {
         cell.textLabel?.text = " "
         cell.backgroundColor = UIConstants.colors.background
         
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = UIConstants.strings.InstalledSearchEngines
         label.textColor = UIConstants.colors.tableSectionHeader
         label.font = UIConstants.fonts.tableSectionHeader
@@ -76,7 +76,7 @@ class SearchSettingsViewController: UITableViewController {
             return cell
         } else if indexPath.item > engines.count {
             let cell = UITableViewCell(style: .default, reuseIdentifier: "restoreDefaultEngines")
-            let label = UILabel()
+            let label = SmartLabel()
             label.text = UIConstants.strings.RestoreSearchEnginesLabel
             label.font = UIFont.systemFont(ofSize: 17)
             label.textColor = UIConstants.colors.settingsTextLabel

--- a/Blockzilla/SettingsContentViewController.swift
+++ b/Blockzilla/SettingsContentViewController.swift
@@ -141,7 +141,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
         let spinner = UIActivityIndicatorView(activityIndicatorStyle: UIActivityIndicatorViewStyle.whiteLarge)
         view.addSubview(spinner)
         
-        let error = UILabel()
+        let error = SmartLabel()
 //        error.text = TODOPageLoadErrorString
 //        error.textColor = UIColor.red
 //        error.textAlignment = NSTextAlignment.center

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -8,8 +8,8 @@ import UIKit
 import Telemetry
 
 class SettingsTableViewSearchCell: UITableViewCell {
-    private let newLabel = UILabel()
-    private let accessoryLabel = UILabel()
+    private let newLabel = SmartLabel()
+    private let accessoryLabel = SmartLabel()
     private let spacerView = UIView()
 
     var accessoryLabelText: String? {
@@ -284,6 +284,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         cell.layoutMargins = UIEdgeInsets.zero
         cell.detailTextLabel?.textColor = UIConstants.colors.settingsDetailLabel
 
+        cell.textLabel?.setupShrinkage()
+        cell.detailTextLabel?.setupShrinkage()
+
         return cell
     }
 
@@ -356,7 +359,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         cell.textLabel?.text = " "
         cell.backgroundColor = UIConstants.colors.background
 
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = labelText
         label.textColor = UIConstants.colors.tableSectionHeader
         label.font = UIConstants.fonts.tableSectionHeader

--- a/Blockzilla/SmartLabel.swift
+++ b/Blockzilla/SmartLabel.swift
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+class SmartLabel: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder:aDecoder)
+        setupShrinkage()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame:frame)
+        setupShrinkage()
+    }
+}
+
+extension UILabel {
+    func setupShrinkage() {
+        adjustsFontSizeToFitWidth = true
+        minimumScaleFactor = 0.6 // Arbitrarily set to 60%
+    }
+}

--- a/Blockzilla/Toast.swift
+++ b/Blockzilla/Toast.swift
@@ -22,7 +22,7 @@ class Toast {
         toast.layer.cornerRadius = 18
         window.addSubview(toast)
 
-        let label = UILabel()
+        let label = SmartLabel()
         label.text = text
         label.textColor = UIConstants.colors.toastText
         label.font = UIConstants.fonts.toast

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -733,7 +733,7 @@ private class URLTextField: AutocompleteTextField {
 }
 
 class TrackingProtectionBadge: UIView {
-    let counterLabel = UILabel()
+    let counterLabel = SmartLabel()
     let trackingProtectionOff = UIImageView(image: #imageLiteral(resourceName: "tracking_protection_off").imageFlippedForRightToLeftLayoutDirection())
     let trackingProtectionCounter = UIImageView(image: #imageLiteral(resourceName: "tracking_protection_counter").imageFlippedForRightToLeftLayoutDirection())
     let counterLabelWrapper = UIView()


### PR DESCRIPTION
The layout breakage is that on the TP stats view, the title strings can grow too long and push elements off the view.