### PR TITLE
Fix #894 - limit TP toggle info label to 2 lines max.

### DIFF
--- a/Blockzilla/Lib/TrackingProtection/TrackingProtectionSummaryViewController.swift
+++ b/Blockzilla/Lib/TrackingProtection/TrackingProtectionSummaryViewController.swift
@@ -327,7 +327,7 @@ class TrackingProtectionToggleView: UIView {
         descriptionLabel.text = String(format: UIConstants.strings.trackingProtectionToggleDescription, AppInfo.productName)
         descriptionLabel.font = UIFont.systemFont(ofSize: 14)
         descriptionLabel.textColor = UIConstants.colors.trackingProtectionSecondary
-        descriptionLabel.numberOfLines = 0
+        descriptionLabel.numberOfLines = 2
         addSubview(descriptionLabel)
         setupConstraints()
     }


### PR DESCRIPTION
For translations that would require 3 lines, the label will shrink to fit the text.