### PR TITLE
Closes #978: failing screenshot tests

### DIFF
--- a/Blockzilla/IntroViewController.swift
+++ b/Blockzilla/IntroViewController.swift
@@ -166,7 +166,7 @@ class IntroViewController: UIViewController {
         skipButton.titleLabel?.font = UIConstants.fonts.aboutText
         skipButton.setTitleColor(.white, for: .normal)
         skipButton.sizeToFit()
-        skipButton.accessibilityIdentifier = "skipButton.button"
+        skipButton.accessibilityIdentifier = "IntroViewController.button"
         skipButton.addTarget(self, action: #selector(IntroViewController.didTapSkipButton), for: UIControlEvents.touchUpInside)
         
         skipButton.snp.makeConstraints { make in

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -16,7 +16,7 @@ class SnapshotTests: XCTestCase {
     func test01Screenshots() {
         let app = XCUIApplication()
         snapshot("00FirstRun")
-        app.buttons["FirstRunViewController.button"].tap()
+        app.buttons["IntroViewController.button"].tap()
 
         snapshot("01Home")
 
@@ -130,8 +130,6 @@ class SnapshotTests: XCTestCase {
     func test10CustomSearchEngines() {
         let app = XCUIApplication()
 
-        // Cancel URLBar
-        app.buttons["URLBar.cancelButton"].tap()
         app.buttons["HomeView.settingsButton"].tap()
         app.cells["SettingsViewController.searchCell"].tap()
         app.cells["addSearchEngine"].tap()
@@ -141,8 +139,6 @@ class SnapshotTests: XCTestCase {
     func test11AutocompleteURLs() {
         let app = XCUIApplication()
 
-        // Cancel URLBar
-        app.buttons["URLBar.cancelButton"].tap()
         app.buttons["HomeView.settingsButton"].tap()
         app.cells["SettingsViewController.autocompleteCell"].tap()
         snapshot("11AutocompleteURLs")


### PR DESCRIPTION
Updated accessibilityIdentifier to match the name change from FirstRunViewController to IntroViewController.
Removed cancelling the URLBar as the bar only needs to be cancelled once typing has begun. 