### PR TITLE
Fixes #993: Update Mozilla section to include rate focus

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -87,7 +87,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             case .privacy: return 4
             case .security: return 1
             case .performance: return 1
-            case .mozilla: return 2
+            case .mozilla: return 3
             }
         }
         
@@ -379,7 +379,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
                 cell = UITableViewCell(style: .subtitle, reuseIdentifier: "aboutCell")
                 cell.textLabel?.text = UIConstants.strings.aboutTitle
                 cell.accessibilityIdentifier = "settingsViewController.about"
-            } else if indexPath.section == 4 && indexPath.row == 2 {
+            } else if sections[indexPath.section] == .mozilla && indexPath.row == 2 {
                 cell = UITableViewCell(style: .subtitle, reuseIdentifier: "ratingCell")
                 cell.textLabel?.text = UIConstants.strings.ratingSetting
                 cell.accessibilityIdentifier = "settingsViewController.rateFocus"
@@ -505,6 +505,10 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             case .mozilla:
                 if indexPath.row == 1 {
                     aboutClicked()
+                } else if indexPath.row == 2 {
+                    if let reviewURL = URL(string: "https://itunes.apple.com/us/app/firefox-focus-privacy-browser/id1055677337?mt=8"), UIApplication.shared.canOpenURL(reviewURL) {
+                            UIApplication.shared.open(reviewURL, options: [:], completionHandler: nil)
+                    }
                 }
             default: break
         }


### PR DESCRIPTION
Fixes a bug where the Mozilla section of settings did not include "Rate Focus"