### PR TITLE
Fixes #988: SettingAppearanceTests updated

### DIFF
--- a/XCUITest/SettingAppearanceTest.swift
+++ b/XCUITest/SettingAppearanceTest.swift
@@ -17,36 +17,40 @@ class SettingAppearanceTest: BaseTestCase {
     
     // Check for the basic appearance of the Settings Menu
     func testCheckSetting() {
+        waitforHittable(element: app.buttons["Settings"])
         app.buttons["Settings"].tap()
         
         // Check About page
+        app.tables.firstMatch.swipeUp()
         let aboutCell = app.cells["settingsViewController.about"]
-        waitforExistence(element: aboutCell)
+        waitforHittable(element: aboutCell)
         aboutCell.tap()
         
         let tablesQuery = app.tables
         
         // Check Help page, wait until the webpage is shown
+        waitforHittable(element: tablesQuery.staticTexts["Help"])
         tablesQuery.staticTexts["Help"].tap()
         if app.label == "Firefox Focus" {
-            waitforExistence(element: app.staticTexts["What is Firefox Focus?"])
+            waitforHittable(element: app.staticTexts["What is Firefox Focus?"])
             app.navigationBars["Firefox_Focus.SettingsContentView"].buttons["About"].tap()
         } else {
-            waitforExistence(element: app.staticTexts["Firefox Klar"])
+            waitforHittable(element: app.staticTexts["Firefox Klar"])
             app.navigationBars["Firefox_Klar.SettingsContentView"].buttons["About"].tap()
         }
         
         // Check Your Rights page, until the text is displayed
         tablesQuery.staticTexts["Your Rights"].tap()
         if app.label == "Firefox Focus" {
-            waitforExistence(element: app.staticTexts["Your Rights"])
+            waitforHittable(element: app.staticTexts["Your Rights"])
             app.navigationBars["Firefox_Focus.SettingsContentView"].buttons["About"].tap()
         } else {
-            waitforExistence(element: app.staticTexts["Ihre Rechte"])
+            waitforHittable(element: app.staticTexts["Ihre Rechte"])
             app.navigationBars["Firefox_Klar.SettingsContentView"].buttons["About"].tap()
         }
         
         // Go to Settings
+        waitforHittable(element: app.navigationBars["About"].buttons["Settings"])
         app.navigationBars["About"].buttons["Settings"].tap()
         
         //Check the initial state of the switch values
@@ -110,36 +114,27 @@ class SettingAppearanceTest: BaseTestCase {
     
     func testOpenInSafari() {
         let safariapp = XCUIApplication(privateWithPath: nil, bundleID: "com.apple.mobilesafari")!
-        // Enter 'mozilla' on the search field
-        let searchOrEnterAddressTextField = app.textFields["Search or enter address"]
+        loadWebPage("https://www.google.com", waitForLoadToFinish: true)
         
-        let label = app.textFields["Search or enter address"]
-        searchOrEnterAddressTextField.typeText("https://www.google.com\n")
-        
-        // Check the correct site is reached
-        waitForWebPageLoad()
-        waitForValueContains(element: label, value: "https://www.google")
-        
+        waitforHittable(element: app.buttons["Share"])
         app.buttons["Share"].tap()
-        let button = app.buttons["Open in Safari"]
-        waitforExistence(element: button)
-
-        let appName = app.label
-        app.buttons["Open in Safari"].tap()
-
+        let requestDesktop = app.buttons["Request Desktop Site"]
+        waitforHittable(element: requestDesktop)
+        requestDesktop.swipeLeft()
+        
+        let safariButton = app.buttons["Open in Safari"]
+        waitforHittable(element: safariButton)
+        safariButton.tap()
+        
         // Now in Safari
         let safariLabel = safariapp.otherElements["Address"]
         waitForValueContains(element: safariLabel, value: "google")
-        if appName == "Firefox Focus" {
-            XCTAssertTrue(safariapp.buttons["Return to Firefox Focus"].exists)
-            safariapp.statusBars.buttons["Return to Firefox Focus"].tap()
-        } else {
-            XCTAssertTrue(safariapp.buttons["Return to Firefox Klar"].exists)
-            safariapp.statusBars.buttons["Return to Firefox Klar"].tap()
-        }
+        
+        // Go back to Focus
+        app.activate()
         
         // Now back to Focus
-        waitForValueContains(element: label, value: "https://www.google")
+        waitForValueContains(element: app.textFields["Search or enter address"], value: "https://www.google")
         waitForWebPageLoad()
         app.buttons["ERASE"].tap()
         waitforExistence(element: app.staticTexts["Your browsing history has been erased."])
@@ -147,16 +142,17 @@ class SettingAppearanceTest: BaseTestCase {
     
     func testDisableAutocomplete() {
         // Navigate to Settings
+        waitforHittable(element: app.buttons["Settings"])
         app.buttons["Settings"].tap()
         
         // Navigate to Autocomplete Settings
+        waitforHittable(element: app.tables.cells["SettingsViewController.autocompleteCell"])
         app.tables.cells["SettingsViewController.autocompleteCell"].tap()
         
         // Verify that autocomplete is enabled
         waitforExistence(element: app.tables.switches["toggleAutocompleteSwitch"])
         let toggle = app.tables.switches["toggleAutocompleteSwitch"]
         XCTAssertEqual(toggle.value as! String, "1")
-
         
         // Turn autocomplete off
         toggle.tap()
@@ -168,31 +164,40 @@ class SettingAppearanceTest: BaseTestCase {
     
     func testAddRemoveCustomDomain() {
         // Navigate to Settings
+        waitforHittable(element: app.buttons["Settings"])
         app.buttons["Settings"].tap()
         
         // Navigate to Autocomplete Settings
+        waitforHittable(element: app.tables.cells["SettingsViewController.autocompleteCell"])
         app.tables.cells["SettingsViewController.autocompleteCell"].tap()
         
         // Navigate to the customURL list
+        waitforHittable(element: app.tables.cells["customURLS"])
         app.tables.cells["customURLS"].tap()
 
         // Navigate to add domain screen
+        waitforHittable(element: app.tables.cells["addCustomDomainCell"])
         app.tables.cells["addCustomDomainCell"].tap()
         
         // Edit Text Field
         let urlInput = app.textFields["urlInput"]
         urlInput.typeText("mozilla.org")
+        waitforHittable(element: app.navigationBars.buttons["saveButton"])
         app.navigationBars.buttons["saveButton"].tap()
         
         // Validate that the new domain shows up in the Autocomplete Settings
-        XCTAssertTrue(app.tables.cells["mozilla.org"].exists)
+        waitforExistence(element: app.tables.cells["mozilla.org"])
         
         // Start Editing
+        waitforHittable(element: app.navigationBars.buttons["editButton"])
         app.navigationBars.buttons["editButton"].tap()
+        waitforHittable(element:  app.tables.cells["mozilla.org"].buttons["Delete mozilla.org"])
         app.tables.cells["mozilla.org"].buttons["Delete mozilla.org"].tap()
+        waitforHittable(element: app.tables.cells["mozilla.org"].buttons["Delete"])
         app.tables.cells["mozilla.org"].buttons["Delete"].tap()
         
         // Finish Editing
+        waitforHittable(element: app.navigationBars.buttons["editButton"])
         app.navigationBars.buttons["editButton"].tap()
         
         // Validate that the domain is gone


### PR DESCRIPTION
SettingsApperanceTests were improved with waitForHittables so they no longer fail when UI is still transitioning. Also modified the open in safari test to work on iPhone X.