### PR TITLE
Fixes #1017: Find in page displays on home screen

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -829,7 +829,9 @@ extension BrowserViewController: URLBarDelegate {
     }
     
     func urlBar(_ urlBar: URLBar, didEnterText text: String) {
-        overlayView.setSearchQuery(query: text, animated: true)
+        // Hide find in page if the home view is displayed
+        let isOnHomeView = homeView != nil
+        overlayView.setSearchQuery(query: text, animated: true, hideFindInPage: isOnHomeView)
     }
 
     func urlBarDidPressScrollTop(_: URLBar, tap: UITapGestureRecognizer) {

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -157,7 +157,7 @@ class OverlayView: UIView {
         button.setAttributedTitle(attributedString, for: .normal)
     }
     
-    func setSearchQuery(query: String, animated: Bool) {
+    func setSearchQuery(query: String, animated: Bool, hideFindInPage: Bool) {
         searchQuery = query
         let query = query.trimmingCharacters(in: .whitespaces)
 
@@ -175,8 +175,8 @@ class OverlayView: UIView {
                     let duration = animated ? UIConstants.layout.searchButtonAnimationDuration : 0
                     self.searchButton.animateHidden(query.isEmpty, duration: duration)
                     self.searchBorder.animateHidden(query.isEmpty, duration: duration)
-                    self.findInPageButton.animateHidden(query.isEmpty, duration: duration)
-                    self.findInPageBorder.animateHidden(query.isEmpty, duration: duration)
+                    self.findInPageButton.animateHidden((query.isEmpty || hideFindInPage), duration: duration)
+                    self.findInPageBorder.animateHidden((query.isEmpty || hideFindInPage), duration: duration)
                 }
                 self.setAttributedButtonTitle(phrase: query, button: self.searchButton, localizedStringFormat: UIConstants.strings.searchButton)
                 self.setAttributedButtonTitle(phrase: query, button: self.findInPageButton, localizedStringFormat: UIConstants.strings.findInPageButton)
@@ -226,7 +226,7 @@ class OverlayView: UIView {
     }
 
     func dismiss() {
-        setSearchQuery(query: "", animated: false)
+        setSearchQuery(query: "", animated: false, hideFindInPage: true)
         self.isUserInteractionEnabled = false
         copyButton.isHidden = true
         copyBorder.isHidden = true
@@ -236,7 +236,7 @@ class OverlayView: UIView {
     }
 
     func present() {
-        setSearchQuery(query: "", animated: false)
+        setSearchQuery(query: "", animated: false, hideFindInPage: true)
         self.isUserInteractionEnabled = false
         copyButton.isHidden = false
         copyBorder.isHidden = false


### PR DESCRIPTION
The find in page button will no longer appear in the overlay view when the user is on the home screen.

Example of updated behavior:
![find in page visibility](https://user-images.githubusercontent.com/4400286/42175685-27a8adc6-7ddb-11e8-8161-163197d1cd30.gif)
