### PR TITLE
Fixes #964: Safe area of iPhone x when using find in page not respected

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -388,9 +388,16 @@ class BrowserViewController: UIViewController {
             if let keyboardHeight = keyboardState?.intersectionHeightForView(view: self.view), keyboardHeight > 0 {
                 make.bottom.equalTo(self.view).offset(-keyboardHeight)
             } else if !browserToolbar.isHidden {
-                make.bottom.equalTo(self.browserToolbar.snp.top)
+                // is an iPhone
+                if scrollBarOffsetAlpha == 1 {
+                    // browserToolbar is collapsed
+                    make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+                } else {
+                    make.bottom.equalTo(self.browserToolbar.snp.top)
+                }
             } else {
-                make.bottom.equalTo(self.view.snp.bottom)
+                // is an iPad
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
             }
         }
     }


### PR DESCRIPTION
Find in page bar used to not respect the bottom safe area layout guide on iPhone X. Updated to have the following behavior:

![safe](https://user-images.githubusercontent.com/4400286/42188974-fc317e04-7e0a-11e8-9e35-3916453dd1ff.gif)
