### PR TITLE
Fixes #1064: Large gap between copied link and search prompt

### DIFF
--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -194,6 +194,12 @@ class OverlayView: UIView {
                     make.top.leading.trailing.equalTo(safeAreaLayoutGuide)
                     make.height.equalTo(56)
                 }
+            } else if findInPageButton.isHidden {
+                copyButton.snp.remakeConstraints { make in
+                    make.leading.trailing.equalTo(safeAreaLayoutGuide)
+                    make.top.equalTo(searchBorder)
+                    make.height.equalTo(56)
+                }
             } else {
                 copyButton.snp.remakeConstraints { make in
                     make.leading.trailing.equalTo(safeAreaLayoutGuide)


### PR DESCRIPTION
Updated overlay view to have proper behavior on the home screen (when find in page button doesn't exist but a link is copied to the clipboard). Fix shown below.

<img width="545" alt="screen shot 2018-07-05 at 10 30 22 am" src="https://user-images.githubusercontent.com/4400286/42338417-a22154c6-803e-11e8-8e15-09911c059fce.png">
