### PR TITLE
Fixes #1101: Handle infoplist.strings in incomplete locales

### DIFF
--- a/Blockzilla/af.lproj/InfoPlist.strings
+++ b/Blockzilla/af.lproj/InfoPlist.strings
@@ -2,10 +2,16 @@
 "NSCameraUsageDescription" = "Hierdie laat mens foto’s neem en oplaai.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Webwerwe wat u besoek kan dalk u ligging vra.";
 
 /* (No Comment) */
 "NSMicrophoneUsageDescription" = "Hierdie laat mens video’s neem en oplaai.";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
 
 /* (No Comment) */
 "NSPhotoLibraryUsageDescription" = "Hierdie laat mens foto’s stoor en oplaai.";

--- a/Blockzilla/an.lproj/InfoPlist.strings
+++ b/Blockzilla/an.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Esto te permite de fer y cargar fotos.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Los puestos web que vesites pueden demandar la tuya ubicación.";
 
 /* (No Comment) */

--- a/Blockzilla/ast.lproj/InfoPlist.strings
+++ b/Blockzilla/ast.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Esto déxate facer y xubir semeyes.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Los sitios que visites podríen solicitar el to allugamientu.";
 
 /* (No Comment) */

--- a/Blockzilla/bn.lproj/InfoPlist.strings
+++ b/Blockzilla/bn.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "এটা আপনাকে ছবি তোলা এবং আপলোড করার সুযোগ দেবে।";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "যেসকল ওয়েবসাইটগুলি আপনি দেখছেন, সেগুলো আপনার অবস্থান জানতে চাইতে পারে।";
 
 /* (No Comment) */

--- a/Blockzilla/cs.lproj/InfoPlist.strings
+++ b/Blockzilla/cs.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Toto vám dovolí pořizovat a nahrávat fotografie.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Servery, které navštěvujete, mohou chtít znát vaše umístění.";
 
 /* (No Comment) */

--- a/Blockzilla/da.lproj/InfoPlist.strings
+++ b/Blockzilla/da.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Dette lader dig tage og uploade fotografier.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Websteder kan anmode om din position, når du besøger dem.";
 
 /* (No Comment) */

--- a/Blockzilla/el.lproj/InfoPlist.strings
+++ b/Blockzilla/el.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Αυτό σάς επιτρέπει να τραβάτε και να μεταφορτώνετε φωτογραφίες.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Οι ιστοσελίδες που επισκέπτεστε ενδέχεται να ζητήσουν την τοποθεσία σας.";
 
 /* (No Comment) */

--- a/Blockzilla/eo.lproj/InfoPlist.strings
+++ b/Blockzilla/eo.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Tio ĉi permesas al vi preni fotojn.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Vizititaj retejoj povas peti vian pozicion.";
 
 /* (No Comment) */

--- a/Blockzilla/es-ES.lproj/InfoPlist.strings
+++ b/Blockzilla/es-ES.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Esto te permite hacer y subir fotos.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Los sitios web que visitas pueden pedir tu ubicación.";
 
 /* (No Comment) */

--- a/Blockzilla/es-MX.lproj/InfoPlist.strings
+++ b/Blockzilla/es-MX.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Esto te permite tomar y subir fotos.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Los sitios web que visitas pueden pedir tu ubicación.";
 
 /* (No Comment) */

--- a/Blockzilla/fi.lproj/InfoPlist.strings
+++ b/Blockzilla/fi.lproj/InfoPlist.strings
@@ -1,0 +1,18 @@
+/* (No Comment) */
+"NSCameraUsageDescription" = "This lets you take and upload photos.";
+
+/* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
+"NSLocationWhenInUseUsageDescription" = "Websites you visit may request your location.";
+
+/* (No Comment) */
+"NSMicrophoneUsageDescription" = "This lets you take and upload videos.";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
+
+/* (No Comment) */
+"NSPhotoLibraryUsageDescription" = "This lets you save and upload photos.";
+

--- a/Blockzilla/fil.lproj/InfoPlist.strings
+++ b/Blockzilla/fil.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Maaari kang kumuha at mag-upload ng mga larawan dito.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Maaaring hingin ng mga website na binibisita mo ang iyon lokasyon.";
 
 /* (No Comment) */

--- a/Blockzilla/ga.lproj/InfoPlist.strings
+++ b/Blockzilla/ga.lproj/InfoPlist.strings
@@ -2,10 +2,16 @@
 "NSCameraUsageDescription" = "Ligeann seo duit pictiúir a thógáil agus a uaslódáil.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "D'fhéadfadh suíomhanna a dtugann tú cuairt orthu do láthair a iarraidh.";
 
 /* (No Comment) */
 "NSMicrophoneUsageDescription" = "Ligeann seo duit físeáin a thógáil agus a uaslódáil.";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
 
 /* (No Comment) */
 "NSPhotoLibraryUsageDescription" = "Ligeann seo duit pictiúir a shábháil agus a uaslódáil.";

--- a/Blockzilla/gd.lproj/InfoPlist.strings
+++ b/Blockzilla/gd.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Bheir seo comas dhut dealbhan a thogail is a luchdadh suas.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Dh’fhaoidte gun iarr làraichean-lìn air an tadhal thu d’ ionad.";
 
 /* (No Comment) */

--- a/Blockzilla/hi-IN.lproj/InfoPlist.strings
+++ b/Blockzilla/hi-IN.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "यह आपको तस्वीरें लेने और अपलोड करने देता है.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "आपके द्वारा देखे गये वेबसाइट आपके पते के लिए अनुरोध कर सकते हैं.";
 
 /* (No Comment) */

--- a/Blockzilla/hy-AM.lproj/InfoPlist.strings
+++ b/Blockzilla/hy-AM.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Սա հնարավորություն է տալիս ստանալ և վերբեռնել լուսանկարներ:";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Ձեր այցելած կայքերը կարող են հարցնել ձեր տեղադրությունը:";
 
 /* (No Comment) */

--- a/Blockzilla/is.lproj/InfoPlist.strings
+++ b/Blockzilla/is.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Hér getur þú tekið og hlaðið upp myndum.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Vefsvæði sem þú skoðar gætu beðið um staðsetninguna þína.";
 
 /* (No Comment) */

--- a/Blockzilla/kk.lproj/InfoPlist.strings
+++ b/Blockzilla/kk.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Бұл арқылы фотоларды түсіріп, жүктеуге болады.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Сіз ашатын веб-сайттар сізден орналасуыңызды сұрауы мүмкін.";
 
 /* (No Comment) */

--- a/Blockzilla/kn.lproj/InfoPlist.strings
+++ b/Blockzilla/kn.lproj/InfoPlist.strings
@@ -2,10 +2,16 @@
 "NSCameraUsageDescription" = "ಇದು ನಿಮ್ಮನ್ನು ಫೋಟೊ ತೆಗೆಯಲು ಮತ್ತು ಅಪ್ಲೋಡ್ ಮಾಡಲು ಬಿಡುತ್ತದೆ.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "‍ನೀವು ಭೇಟಿ ನೀಡುವ ಜಾಲತಾಣಗಳು ನಿಮ್ಮ ಸ್ಥಳ ಮಾಹಿತಿಯನ್ನು ಕೇಳಬಹುದು.";
 
 /* (No Comment) */
 "NSMicrophoneUsageDescription" = "ಇದು ನಿಮ್ಮನ್ನು ಫೋಟೊ ತೆಗೆಯಲು ಮತ್ತು ಅಪ್ಲೋಡ್ ಮಾಡಲು ಬಿಡುತ್ತದೆ.‍";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
 
 /* (No Comment) */
 "NSPhotoLibraryUsageDescription" = "ಇದು ನಿಮ್ಮನ್ನು ಫೋಟೊ‌ಗಳನ್ನು ಉಳಿಸಲು ಮತ್ತು ಅಪ್ಲೋಡ್ ಮಾಡಲು ಬಿಡುತ್ತದೆ.‍";

--- a/Blockzilla/ko.lproj/InfoPlist.strings
+++ b/Blockzilla/ko.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "사진을 촬영하여 업로드 할 수 있습니다.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "현재 웹 사이트가 여러분의 위치 정보를 요구하고 있습니다.";
 
 /* (No Comment) */

--- a/Blockzilla/lo.lproj/InfoPlist.strings
+++ b/Blockzilla/lo.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "ສິ່ງນີ້ຈະເຮັດໃຫ້ທ່ານສາມາດຖ່າຍ ແລະ ອັບໂຫລດຮູບພາບໄດ້.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "ເວັບໄຊທ໌ທີ່ທ່ານເຂົ້າໄປອາດຈະຕ້ອງການຕຳແຫນ່ງທີຢູ່ຂອງທ່ານ.";
 
 /* (No Comment) */

--- a/Blockzilla/nb.lproj/InfoPlist.strings
+++ b/Blockzilla/nb.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Dette gjør det mulig å ta og laste opp bilder.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Nettsider du besøker kan be om din plassering.";
 
 /* (No Comment) */

--- a/Blockzilla/ne-NP.lproj/InfoPlist.strings
+++ b/Blockzilla/ne-NP.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "यसले तपाईँलाई तस्विर लिन र अपलोड गर्न दिन्छ।";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "तपाईँले भ्रमण गर्ने वेबसाइटले तपाईँको स्थान अनुरोध गर्न सक्छ।";
 
 /* (No Comment) */

--- a/Blockzilla/nn.lproj/InfoPlist.strings
+++ b/Blockzilla/nn.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Dette gjer det mogleg å ta og lasta opp bilde.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Nettsider du vitjar kan be om plasseringa di.";
 
 /* (No Comment) */

--- a/Blockzilla/ro.lproj/InfoPlist.strings
+++ b/Blockzilla/ro.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Acest lucru îți permite să realizezi și să încarci fotografii.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Site-urile web pe care le vizitezi îți pot solicita locația.";
 
 /* (No Comment) */

--- a/Blockzilla/ru.lproj/InfoPlist.strings
+++ b/Blockzilla/ru.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Это позволит вам снимать и загружать фотографии.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Посещаемые вам веб-сайты могут запрашивать ваше местоположение.";
 
 /* (No Comment) */

--- a/Blockzilla/ses.lproj/InfoPlist.strings
+++ b/Blockzilla/ses.lproj/InfoPlist.strings
@@ -2,10 +2,16 @@
 "NSCameraUsageDescription" = "Woo ga naŋ war ma biyey zaa k'i zijandi.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Interneti nungey kaŋ war g'i naaru ga hin ka war gorodogoo hãa.";
 
 /* (No Comment) */
 "NSMicrophoneUsageDescription" = "Woo nda war ga widewo zaa k'a zijandi.";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
 
 /* (No Comment) */
 "NSPhotoLibraryUsageDescription" = "Woo nda war ga biyey gaabu nd'i zijandi.";

--- a/Blockzilla/sq.lproj/InfoPlist.strings
+++ b/Blockzilla/sq.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Kjo ju lejon të bëni dhe ngarkoni foto.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Sajtet që vizitoni mund të kërkojmë të dinë vendndodhjen tuaj.";
 
 /* (No Comment) */

--- a/Blockzilla/sv.lproj/InfoPlist.strings
+++ b/Blockzilla/sv.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Detta gör det möjligt att ta och ladda upp bilder.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Webbsidor du besöker kan be om din plats.";
 
 /* (No Comment) */

--- a/Blockzilla/ta.lproj/InfoPlist.strings
+++ b/Blockzilla/ta.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "இது படங்களை எடுத்து பதிவேற்றச் செய்கிறது.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "வலைதள பக்கங்கள் உங்கள் இடத்தை அறிய விரும்பலாம்.";
 
 /* (No Comment) */

--- a/Blockzilla/te.lproj/InfoPlist.strings
+++ b/Blockzilla/te.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "ఇది మీకు ఫోటోలను తీసుకొని అప్లోడ్ చేయడానికి అనుమతిస్తుంది.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "మీరు సందర్శించే వెబ్ సైట్లు మీ స్థానాన్ని అభ్యర్థించవచ్చు.";
 
 /* (No Comment) */

--- a/Blockzilla/uk.lproj/InfoPlist.strings
+++ b/Blockzilla/uk.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Це дозволяє вам знімати й вивантажувати фото.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Відвідувані вами веб-сайти можуть запитувати ваше розташування.";
 
 /* (No Comment) */

--- a/Blockzilla/uz.lproj/InfoPlist.strings
+++ b/Blockzilla/uz.lproj/InfoPlist.strings
@@ -2,10 +2,16 @@
 "NSCameraUsageDescription" = "U rasmga tushirish va internetga yuklashda yordam beradi.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Sahifalarda joylashuvingiz so‘ralishi mumkin.";
 
 /* (No Comment) */
 "NSMicrophoneUsageDescription" = "U videoga olish va internetga yuklash imkonini beradi.";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
 
 /* (No Comment) */
 "NSPhotoLibraryUsageDescription" = "U rasmni saqlash va internetga yuklash imkonini beradi.";

--- a/Blockzilla/vi.lproj/InfoPlist.strings
+++ b/Blockzilla/vi.lproj/InfoPlist.strings
@@ -2,6 +2,9 @@
 "NSCameraUsageDescription" = "Điều này cho phép bạn chụp và tải hình ảnh lên.";
 
 /* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Trang web bạn truy cập có thể yêu cầu vị trí của bạn.";
 
 /* (No Comment) */


### PR DESCRIPTION
Added English strings to any incomplete InfoPlist.strings files to combat crashes for missing strings.