### PR TITLE
Fixes #1106 - Import locale updates as part of CI Builds

### DIFF
--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -2,3 +2,10 @@
 
 ./build-disconnect.py
 
+# Update existing locales. This will only update locales that are already
+# imported to the application. It will not include new locales, that
+# remains a manual action.
+
+git clone --depth 1 https://github.com/mozilla-l10n/focusios-l10n.git \
+    && ./import-locales -allowIncomplete ../focusios-l10n/{??,???,??-??}/focus-ios.xliff
+

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -7,5 +7,5 @@
 # remains a manual action.
 
 git clone --depth 1 https://github.com/mozilla-l10n/focusios-l10n.git \
-    && ./import-locales -allowIncomplete ../focusios-l10n/{??,???,??-??}/focus-ios.xliff
+    && ./import-locales -allowIncomplete focusios-l10n/{??,???,??-??}/focus-ios.xliff
 


### PR DESCRIPTION
This patch imports locales as part of a BuddyBuild build. It does this for all builds currently. If this takes a unreasonable amount of time, it can also be done for just specific branches or schemes.