### PR TITLE
Fixes #1096: Keyboard shows over splash view

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -12,7 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     static var splashView: UIView?
     static let prefIntroDone = "IntroDone"
     static let prefIntroVersion = 2
-    private let browserViewController = BrowserViewController()
+    static private let browserViewController = BrowserViewController()
     private var queuedUrl: URL?
     private var queuedString: String?
     static let prefWhatsNewDone = "WhatsNewDone"
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        let rootViewController = UINavigationController(rootViewController: browserViewController)
+        let rootViewController = UINavigationController(rootViewController: AppDelegate.browserViewController)
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
 
@@ -125,7 +125,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if application.applicationState == .active {
                 // If we are active then we can ask the BVC to open the new tab right away.
                 // Otherwise, we remember the URL and we open it in applicationDidBecomeActive.
-                browserViewController.submit(url: url)
+                AppDelegate.browserViewController.submit(url: url)
             } else {
                 queuedUrl = url
             }
@@ -135,7 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if application.applicationState == .active {
                 // If we are active then we can ask the BVC to open the new tab right away.
                 // Otherwise, we remember the URL and we open it in applicationDidBecomeActive.
-                browserViewController.openOverylay(text: text)
+                AppDelegate.browserViewController.openOverylay(text: text)
             } else {
                 queuedString = text
             }
@@ -211,13 +211,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let url = queuedUrl {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.openedFromExtension, object: TelemetryEventObject.app)
 
-            browserViewController.ensureBrowsingMode()
-            browserViewController.submit(url: url)
+            AppDelegate.browserViewController.ensureBrowsingMode()
+            AppDelegate.browserViewController.submit(url: url)
             queuedUrl = nil
         } else if let text = queuedString {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.openedFromExtension, object: TelemetryEventObject.app)
 
-            browserViewController.openOverylay(text: text)
+            AppDelegate.browserViewController.openOverylay(text: text)
             queuedString = nil
         }
 
@@ -232,6 +232,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let orientation = UIDevice.current.orientation.isPortrait ? "Portrait" : "Landscape"
         Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.background, object:
             TelemetryEventObject.app, value: nil, extras: ["orientation": orientation])
+    }
+    
+    static func shouldHideSplashView(hide: Bool) {
+        print("Hiding: \(hide)")
+        AppDelegate.splashView?.animateHidden(hide, duration: 0.25)
+        if hide {
+            // Dismiss the keyboard
+        }
     }
 }
 
@@ -286,8 +294,8 @@ extension AppDelegate {
         Telemetry.default.beforeSerializePing(pingType: CorePingBuilder.PingType) { (inputDict) -> [String : Any?] in
             var outputDict = inputDict // make a mutable copy
 
-            if self.browserViewController.canShowTrackerStatsShareButton() { // Klar users are not included in this experiment
-                self.browserViewController.flipCoinForShowTrackerButton() // Force a coin flip if one has not been flipped yet
+            if AppDelegate.browserViewController.canShowTrackerStatsShareButton() { // Klar users are not included in this experiment
+                AppDelegate.browserViewController.flipCoinForShowTrackerButton() // Force a coin flip if one has not been flipped yet
                 outputDict["showTrackerStatsSharePhase2"] = UserDefaults.standard.bool(forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyNEW)
             }
             

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -202,7 +202,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        AppDelegate.splashView?.animateHidden(false, duration: 0)
+        AppDelegate.shouldHideSplashView(hide: false, duration: 0.25)
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
@@ -234,11 +234,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             TelemetryEventObject.app, value: nil, extras: ["orientation": orientation])
     }
     
-    static func shouldHideSplashView(hide: Bool) {
-        print("Hiding: \(hide)")
-        AppDelegate.splashView?.animateHidden(hide, duration: 0.25)
-        if hide {
-            // Dismiss the keyboard
+    static func shouldHideSplashView(hide: Bool, duration: TimeInterval = 0.25) {
+        AppDelegate.splashView?.animateHidden(hide, duration: duration)
+        if !hide {
+            AppDelegate.browserViewController.deactivateUrlBarOnHomeView()
+        } else {
+            AppDelegate.browserViewController.activateUrlBarOnHomeView()
         }
     }
 }

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -12,7 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     static var splashView: UIView?
     static let prefIntroDone = "IntroDone"
     static let prefIntroVersion = 2
-    static private let browserViewController = BrowserViewController()
+    private let browserViewController = BrowserViewController()
     private var queuedUrl: URL?
     private var queuedString: String?
     static let prefWhatsNewDone = "WhatsNewDone"
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        let rootViewController = UINavigationController(rootViewController: AppDelegate.browserViewController)
+        let rootViewController = UINavigationController(rootViewController: browserViewController)
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
 
@@ -125,7 +125,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if application.applicationState == .active {
                 // If we are active then we can ask the BVC to open the new tab right away.
                 // Otherwise, we remember the URL and we open it in applicationDidBecomeActive.
-                AppDelegate.browserViewController.submit(url: url)
+                browserViewController.submit(url: url)
             } else {
                 queuedUrl = url
             }
@@ -135,7 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if application.applicationState == .active {
                 // If we are active then we can ask the BVC to open the new tab right away.
                 // Otherwise, we remember the URL and we open it in applicationDidBecomeActive.
-                AppDelegate.browserViewController.openOverylay(text: text)
+                browserViewController.openOverylay(text: text)
             } else {
                 queuedString = text
             }
@@ -211,13 +211,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let url = queuedUrl {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.openedFromExtension, object: TelemetryEventObject.app)
 
-            AppDelegate.browserViewController.ensureBrowsingMode()
-            AppDelegate.browserViewController.submit(url: url)
+            browserViewController.ensureBrowsingMode()
+            browserViewController.submit(url: url)
             queuedUrl = nil
         } else if let text = queuedString {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.openedFromExtension, object: TelemetryEventObject.app)
 
-            AppDelegate.browserViewController.openOverylay(text: text)
+            browserViewController.openOverylay(text: text)
             queuedString = nil
         }
 
@@ -236,10 +236,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     static func shouldHideSplashView(hide: Bool, duration: TimeInterval = 0.25) {
         AppDelegate.splashView?.animateHidden(hide, duration: duration)
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         if !hide {
-            AppDelegate.browserViewController.deactivateUrlBarOnHomeView()
+            appDelegate.browserViewController.deactivateUrlBarOnHomeView()
         } else {
-            AppDelegate.browserViewController.activateUrlBarOnHomeView()
+            appDelegate.browserViewController.activateUrlBarOnHomeView()
         }
     }
 }
@@ -295,8 +296,8 @@ extension AppDelegate {
         Telemetry.default.beforeSerializePing(pingType: CorePingBuilder.PingType) { (inputDict) -> [String : Any?] in
             var outputDict = inputDict // make a mutable copy
 
-            if AppDelegate.browserViewController.canShowTrackerStatsShareButton() { // Klar users are not included in this experiment
-                AppDelegate.browserViewController.flipCoinForShowTrackerButton() // Force a coin flip if one has not been flipped yet
+            if self.browserViewController.canShowTrackerStatsShareButton() { // Klar users are not included in this experiment
+                self.browserViewController.flipCoinForShowTrackerButton() // Force a coin flip if one has not been flipped yet
                 outputDict["showTrackerStatsSharePhase2"] = UserDefaults.standard.bool(forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyNEW)
             }
             

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -281,6 +281,17 @@ class BrowserViewController: UIViewController {
             }
         }
     }
+    
+    // These functions are used to handle displaying and hiding the keyboard after the splash view is animated
+    public func activateUrlBarOnHomeView() {
+        // If the home view is not displayed, do not activate the text field:
+        guard homeView != nil else { return }
+        urlBar.activateTextField()
+    }
+    
+    public func deactivateUrlBarOnHomeView() {
+        urlBar.dismissTextField()
+    }
 
     private func containWebView() {
         addChildViewController(webViewController)

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -593,35 +593,6 @@ class BrowserViewController: UIViewController {
         urlBar.fillUrlBar(text: text)
     }
 
-    private func hideSplashScreen() {
-        splashScreen?.removeFromSuperview()
-    }
-
-    private func displaySplashScreen() {
-        guard splashScreen == nil else { return }
-        
-        let splashView = UIView()
-        splashView.backgroundColor = UIConstants.colors.background
-        mainContainerView.addSubview(splashView)
-
-        let logoImage = UIImageView(image: AppInfo.config.wordmark)
-        splashView.addSubview(logoImage)
-
-        splashView.snp.makeConstraints { make in
-            make.edges.equalTo(mainContainerView)
-        }
-
-        logoImage.snp.makeConstraints { make in
-            make.center.equalTo(splashView)
-        }
-
-        view.layoutIfNeeded()
-        splashView.layoutIfNeeded()
-
-        splashScreen = splashView
-        hideToolbars()
-    }
-
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -14,7 +14,6 @@ class BrowserViewController: UIViewController {
         override var intrinsicContentSize: CGSize { return CGSize(width: 320, height: 0) }
     }
 
-    private var splashScreen: UIView?
     private var context = LAContext()
     private let mainContainerView = UIView(frame: .zero)
     private let drawerContainerView = DrawerView(frame: .zero)

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -13,6 +13,8 @@ class BrowserViewController: UIViewController {
     private class DrawerView: UIView {
         override var intrinsicContentSize: CGSize { return CGSize(width: 320, height: 0) }
     }
+    
+    let appSplashController: AppSplashController
 
     private var context = LAContext()
     private let mainContainerView = UIView(frame: .zero)
@@ -80,10 +82,16 @@ class BrowserViewController: UIViewController {
     static let userDefaultsShareTrackerStatsKeyOLD = "shareTrackerStats"
     static let userDefaultsShareTrackerStatsKeyNEW = "shareTrackerStatsNew"
 
-    convenience init() {
-        self.init(nibName: nil, bundle: nil)
+    init(appSplashController: AppSplashController) {
+        self.appSplashController = appSplashController
+        
+        super.init(nibName: nil, bundle: nil)
         drawerContainerView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         KeyboardHelper.defaultHelper.addDelegate(delegate: self)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("BrowserViewController hasn't implemented init?(coder:)")
     }
     
     override func viewDidLoad() {
@@ -251,7 +259,7 @@ class BrowserViewController: UIViewController {
 
             // Check if user is already in a cleared session, or doesn't have biometrics enabled in settings
             if  !Settings.getToggle(SettingsToggle.biometricLogin) || !AppDelegate.needsAuthenticated || self.webViewContainer.isHidden {
-                AppDelegate.shouldHideSplashView(hide: true)
+                self.appSplashController.toggleSplashView(hide: true)
                 return
             }
             AppDelegate.needsAuthenticated = false
@@ -266,10 +274,11 @@ class BrowserViewController: UIViewController {
                     DispatchQueue.main.async {
                         if success {
                             self.showToolbars()
-                            AppDelegate.shouldHideSplashView(hide: true)
+                            self.appSplashController.toggleSplashView(hide: true)
                         } else {
                             // Clear the browser session, as the user failed to authenticate
                             self.resetBrowser(hidePreviousSession: true)
+                            self.appSplashController.toggleSplashView(hide: true)
                         }
                     }
                 }
@@ -277,7 +286,7 @@ class BrowserViewController: UIViewController {
                 // Ran into an error with biometrics, so disable them and clear the browser:
                 Settings.set(false, forToggle: SettingsToggle.biometricLogin)
                 self.resetBrowser()
-                AppDelegate.shouldHideSplashView(hide: true)
+                self.appSplashController.toggleSplashView(hide: true)
             }
         }
     }

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -252,7 +252,7 @@ class BrowserViewController: UIViewController {
 
             // Check if user is already in a cleared session, or doesn't have biometrics enabled in settings
             if  !Settings.getToggle(SettingsToggle.biometricLogin) || !AppDelegate.needsAuthenticated || self.webViewContainer.isHidden {
-                AppDelegate.splashView?.animateHidden(true, duration: 0.25)
+                AppDelegate.shouldHideSplashView(hide: true)
                 return
             }
             AppDelegate.needsAuthenticated = false
@@ -267,7 +267,7 @@ class BrowserViewController: UIViewController {
                     DispatchQueue.main.async {
                         if success {
                             self.showToolbars()
-                            AppDelegate.splashView?.animateHidden(true, duration: 0.25)
+                            AppDelegate.shouldHideSplashView(hide: true)
                         } else {
                             // Clear the browser session, as the user failed to authenticate
                             self.resetBrowser(hidePreviousSession: true)
@@ -278,7 +278,7 @@ class BrowserViewController: UIViewController {
                 // Ran into an error with biometrics, so disable them and clear the browser:
                 Settings.set(false, forToggle: SettingsToggle.biometricLogin)
                 self.resetBrowser()
-                AppDelegate.splashView?.animateHidden(true, duration: 0.25)
+                AppDelegate.shouldHideSplashView(hide: true)
             }
         }
     }

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -360,6 +360,11 @@ class URLBar: UIView {
         urlText.becomeFirstResponder()
     }
     
+    public func dismissTextField() {
+        urlText.isUserInteractionEnabled = false
+        urlText.endEditing(true)
+    }
+    
     @objc private func displayURLContextMenu(sender: UILongPressGestureRecognizer) {
         if sender.state == .began {
             self.becomeFirstResponder()


### PR DESCRIPTION
Keyboard previously was not dismissed when the splash view was displayed. The new functionality is shown below

![dismiss keyboard](https://user-images.githubusercontent.com/4400286/42595052-dab42c8e-8505-11e8-8397-f8ca0cc88599.gif)
