### PR TITLE
Fixes #1087: find in page showing inflated results

### DIFF
--- a/Blockzilla/FindInPage.js
+++ b/Blockzilla/FindInPage.js
@@ -217,7 +217,7 @@ function getMatchingNodeReplacements(regExp, callback) {
   let highlights = [];
   let isMaximumHighlightCount = false;
   let operation = asyncTextNodeWalker(function(originalNode) {
-    if (!isTextNodeVisible(originalNode)) {
+    if (!isTextNodeVisible(originalNode) || originalNode.parentElement.nodeName === "IFRAME") {
       return;
     }
 
@@ -335,6 +335,9 @@ function scrollToElement(element, duration) {
 
 function isTextNodeVisible(textNode) {
   let element = textNode.parentElement;
+  if (!element) {
+    return false;
+  }
   return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
 }
 


### PR DESCRIPTION
Based off of Firefox iOS's solution: https://github.com/mozilla-mobile/firefox-ios/pull/4043/files Working as expected in testing.