### PR TITLE
Fixes #1148: Overlay on home view keeps find in page spacing until 2+ letters typed

### DIFF
--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -175,12 +175,16 @@ class OverlayView: UIView {
                     let duration = animated ? UIConstants.layout.searchButtonAnimationDuration : 0
                     self.searchButton.animateHidden(query.isEmpty, duration: duration)
                     self.searchBorder.animateHidden(query.isEmpty, duration: duration)
-                    self.findInPageButton.animateHidden((query.isEmpty || hideFindInPage), duration: duration)
+                    self.findInPageButton.animateHidden(query.isEmpty || hideFindInPage, duration: duration, completion: {
+                        self.updateCopyConstraint(showCopyButton: showCopyButton)
+                    })
                     self.findInPageBorder.animateHidden((query.isEmpty || hideFindInPage), duration: duration)
+                } else {
+                    self.updateCopyConstraint(showCopyButton: showCopyButton)
                 }
+
                 self.setAttributedButtonTitle(phrase: query, button: self.searchButton, localizedStringFormat: UIConstants.strings.searchButton)
                 self.setAttributedButtonTitle(phrase: query, button: self.findInPageButton, localizedStringFormat: UIConstants.strings.findInPageButton)
-                self.updateCopyConstraint(showCopyButton: showCopyButton)
             }
         }
     }


### PR DESCRIPTION
Fix addressing [#1148](https://github.com/mozilla-mobile/focus-ios/issues/1148).

Updated the OverlayView to properly update its constraints on the home screen when a link is copied to the clipboard and any search query is typed. Screenshots are provided below.

![simulator screen shot - iphone x - 2018-08-01 at 15 20 11](https://user-images.githubusercontent.com/29597695/43552329-f3586ad0-959e-11e8-87bc-900954c23ee0.png)

![simulator screen shot - iphone x - 2018-08-01 at 15 20 15](https://user-images.githubusercontent.com/29597695/43552332-f5df89be-959e-11e8-81f6-fa233dd78919.png)