### PR TITLE
Fixes #1139: Video is visible before biometric authentication

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -232,6 +232,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
 
     func applicationWillResignActive(_ application: UIApplication) {
         AppDelegate.splashView?.animateHidden(false, duration: 0)
+        browserViewController.exitFullScreenVideo()
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -308,6 +308,11 @@ class BrowserViewController: UIViewController {
             make.edges.equalTo(webViewContainer.snp.edges)
         }
     }
+    
+    public func exitFullScreenVideo() {
+        let js = "document.getElementsByTagName('video')[0].webkitExitFullScreen()"
+        webViewController.evaluate(js, completion: nil)
+    }
 
     private func containTrackingProtectionSummary() {
         addChild(trackingProtectionSummaryController)


### PR DESCRIPTION
Full screen videos are now minimized before the app is backgrounded to ensure they cannot be seen before re-authenticating. This is the best solution I can think of as the full screen video layer is presented above the "0th" layer that our splash view is on. Simply presenting the splash view on a negative index could lead to undefined behavior. 