### PR TITLE
Example Text Resizable according To Screen Size

### DIFF
--- a/Blockzilla/AddSearchEngineViewController.swift
+++ b/Blockzilla/AddSearchEngineViewController.swift
@@ -97,9 +97,11 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
         subtitle.append(space)
         subtitle.append(learnMore)
 
-        exampleLabel.numberOfLines = 0
+        exampleLabel.numberOfLines = 1
         exampleLabel.attributedText = subtitle
         exampleLabel.font = UIFont.systemFont(ofSize: 12)
+        exampleLabel.adjustsFontSizeToFitWidth = true
+        exampleLabel.minimumScaleFactor = 0.5
         exampleLabel.isUserInteractionEnabled = true
 
 


### PR DESCRIPTION
Fixes #824 Example Text made Resizable in size to fit to iphone 5s screen.
![image](https://user-images.githubusercontent.com/21240014/43851620-ca34398a-9b58-11e8-9337-97a982bbf98d.png)

