### PR TITLE
Fixes #1249 - Removing Clear Button Animation

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -890,12 +890,17 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidActivate(_ urlBar: URLBar) {
-        UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration) {
+        urlBar.showOrHideClearButton(show: false)
+        UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration, animations: {() -> Void in
             self.topURLBarConstraints.forEach { $0.activate() }
             self.urlBarContainer.alpha = 1
             self.updateFindInPageVisibility(visible: false)
             self.view.layoutIfNeeded()
-        }
+        }, completion: { finished in
+            if finished {
+                urlBar.showOrHideClearButton(show: true)
+            }
+        })
     }
 
     func urlBarDidDeactivate(_ urlBar: URLBar) {

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -419,6 +419,10 @@ class URLBar: UIView {
         Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.pasteAndGo)
     }
 
+    public func showOrHideClearButton(show: Bool) {
+        urlText.rightView?.alpha = show ? 1.0 : 0.0
+    }
+
     //Adds Menu Item
     func addCustomMenu() {
         if UIPasteboard.general.string != nil && urlText.isFirstResponder {


### PR DESCRIPTION
I've made a solution to hide the clear icon while animating and only show it after it finish.