### PR TITLE
Add tracking protection title

### DIFF
--- a/Blockzilla/TrackingProtectionViewController.swift
+++ b/Blockzilla/TrackingProtectionViewController.swift
@@ -20,6 +20,8 @@ class TrackingProtectionViewController: UIViewController, UITableViewDataSource,
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIConstants.colors.background
+
+        title = UIConstants.strings.trackingProtectionLabel
         
         tableView.delegate = self
         tableView.dataSource = self


### PR DESCRIPTION
@oliviabrown9 I noticed that the title was missing on the new tracking protection settings screen so I added that.

![simulator screen shot - iphone 8 plus - 2018-08-20 at 15 22 39](https://user-images.githubusercontent.com/490833/44369921-eccc7880-a48c-11e8-9fc7-5f3c4722a6d8.png)
