### PR TITLE
Fixes #1264: Invalid Char While Entering Text in AutocompleteTextField

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -747,7 +747,8 @@ extension URLBar: AutocompleteTextFieldDelegate {
     func autocompleteTextFieldShouldBeginEditing(_ autocompleteTextField: AutocompleteTextField) -> Bool {
 
         setTextToURL(displayFullUrl: true)
-        
+        autocompleteTextField.highlightAll()
+
         if !isEditing && inBrowsingMode {
             present()
             delegate?.urlBarDidActivate(self)
@@ -823,11 +824,6 @@ private class URLTextField: AutocompleteTextField {
 
     override fileprivate func rightViewRect(forBounds bounds: CGRect) -> CGRect {
         return super.rightViewRect(forBounds: bounds).offsetBy(dx: -UIConstants.layout.urlBarWidthInset, dy: 0)
-    }
-    
-    func textFieldDidBeginEditing(_ textField: UITextField) {
-        guard let autocompleteTextField = textField as? AutocompleteTextField else { return }
-        autocompleteTextField.highlightAll()
     }
 }
 


### PR DESCRIPTION
Revert back to how we were highlighting in 6.0. The implementation we had made for 7.0 resulted in undefined behavior with AutocompleteTextField.