### PR TITLE
Fixes #1280: RequestDesktopSite Test Fails on 7.0

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -418,11 +418,20 @@ class URLBar: UIView {
             
         Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.pasteAndGo)
     }
+    
+    @objc func pasteAndGoFromContextMenu() {
+        guard let clipboardString = UIPasteboard.general.string else { return }
+        present()
+        delegate?.urlBarDidActivate(self)
+        delegate?.urlBar(self, didSubmitText: clipboardString)
+        
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.pasteAndGo)
+    }
 
     //Adds Menu Item
     func addCustomMenu() {
         if UIPasteboard.general.string != nil && urlText.isFirstResponder {
-            let lookupMenu = UIMenuItem(title: UIConstants.strings.urlPasteAndGo, action: #selector(pasteAndGo))
+            let lookupMenu = UIMenuItem(title: UIConstants.strings.urlPasteAndGo, action: #selector(pasteAndGoFromContextMenu))
             UIMenuController.shared.menuItems = [lookupMenu]
         }
     }

--- a/XCUITest/RequestDesktopTest.swift
+++ b/XCUITest/RequestDesktopTest.swift
@@ -44,11 +44,11 @@ class RequestDesktopTest: BaseTestCase {
         // Wait for existence rather than hittable because the textfield is technically disabled
         loadWebPage("facebook.com")
         
-        waitforExistence(element:  app.buttons["BrowserToolset.sendButton"])
-        app.buttons["BrowserToolset.sendButton"].tap()
+        waitforExistence(element:  app.buttons["URLBar.pageActionsButton"])
+        app.buttons["URLBar.pageActionsButton"].tap()
         
-        waitforHittable(element: app.buttons["Request Desktop Site"])
-        app.buttons["Request Desktop Site"].tap()
+        waitforHittable(element: app.cells["Request Desktop Site"])
+        app.cells["Request Desktop Site"].tap()
         
         waitForWebPageLoad()
         


### PR DESCRIPTION
This test still does not pass, but it now fails for the correct reasons. 