### PR TITLE
Fixes #1307: Open URL being donated on every site load

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -576,7 +576,7 @@ class BrowserViewController: UIViewController {
 
         webViewController.load(URLRequest(url: url))
         guard #available(iOS 12.0, *), let savedUrl = UserDefaults.standard.value(forKey: "favoriteUrl") as? String else { return }
-        if url.baseURL == URL(string: savedUrl)?.baseURL {
+        if let currentDomain = url.baseDomain, let savedDomain = URL(string: savedUrl)?.baseDomain, currentDomain == savedDomain {
             userActivity = SiriShortcuts().getActivity(for: .openURL)
         }
         if urlBar.url == nil {


### PR DESCRIPTION
Before, baseURL was always returning nil, so it was being donated because both were equally nil. Now, it checks that both are not nil, and it checks for the baseDomain rather than baseURL, which actually does return the base.