### PR TITLE
Fixes #1306: Share trackers button does nothing on tap

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -308,15 +308,15 @@ class BrowserViewController: UIViewController {
         }
         self.homeView = homeView
         
-//        if canShowTrackerStatsShareButton() && shouldShowTrackerStatsShareButton() {
+        if canShowTrackerStatsShareButton() && shouldShowTrackerStatsShareButton() {
             let numberOfTrackersBlocked = getNumberOfLifetimeTrackersBlocked()
             
             // Since this is only English locale for now, don't worry about localizing for now
             let shareTrackerStatsLabel = "%@ trackers blocked so far"
             homeView.showTrackerStatsShareButton(text: String(format: shareTrackerStatsLabel, String(numberOfTrackersBlocked)))
-//        } else {
-//            homeView.hideTrackerStatsShareButton()
-//        }
+        } else {
+            homeView.hideTrackerStatsShareButton()
+        }
     }
 
     private func createURLBar() {

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -308,15 +308,15 @@ class BrowserViewController: UIViewController {
         }
         self.homeView = homeView
         
-        if canShowTrackerStatsShareButton() && shouldShowTrackerStatsShareButton() {
+//        if canShowTrackerStatsShareButton() && shouldShowTrackerStatsShareButton() {
             let numberOfTrackersBlocked = getNumberOfLifetimeTrackersBlocked()
             
             // Since this is only English locale for now, don't worry about localizing for now
             let shareTrackerStatsLabel = "%@ trackers blocked so far"
             homeView.showTrackerStatsShareButton(text: String(format: shareTrackerStatsLabel, String(numberOfTrackersBlocked)))
-        } else {
-            homeView.hideTrackerStatsShareButton()
-        }
+//        } else {
+//            homeView.hideTrackerStatsShareButton()
+//        }
     }
 
     private func createURLBar() {

--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -15,6 +15,7 @@ class HomeView: UIView {
     private let trackerStatsView = UIView()
     private let trackerStatsLabel = SmartLabel()
     let toolbar = HomeViewToolbar()
+    let trackerStatsShareButton = UIButton()
     
     init() {
         super.init(frame: CGRect.zero)
@@ -52,7 +53,6 @@ class HomeView: UIView {
         trackerStatsLabel.minimumScaleFactor = 0.65
         trackerStatsView.addSubview(trackerStatsLabel)
         
-        let trackerStatsShareButton = UIButton()
         trackerStatsShareButton.setTitleColor(UIConstants.colors.defaultFont, for: .normal)
         trackerStatsShareButton.titleLabel?.font = UIConstants.fonts.shareTrackerStatsLabel
         trackerStatsShareButton.titleLabel?.textAlignment = .center
@@ -80,8 +80,8 @@ class HomeView: UIView {
         }
         
         trackerStatsView.snp.makeConstraints { make in
-            make.bottom.equalTo(self).offset(-24)
-            make.height.equalTo(20)
+            make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.shareTrackersBottomOffset)
+            make.height.equalTo(UIConstants.layout.shareTrackersHeight)
             make.centerX.equalToSuperview()
             make.width.greaterThanOrEqualTo(280)
             make.width.lessThanOrEqualToSuperview().offset(-32)
@@ -93,11 +93,11 @@ class HomeView: UIView {
         }
         
         trackerStatsShareButton.snp.makeConstraints { make in
-            make.bottom.equalTo(toolbar.snp.top).offset(-20)
+            make.bottom.equalToSuperview()
             make.right.equalToSuperview()
             make.width.equalTo(80).priority(500)
             make.width.greaterThanOrEqualTo(50)
-            make.height.equalTo(36)
+            make.height.equalToSuperview()
         }
         
         trackerStatsLabel.snp.makeConstraints { make in

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -209,6 +209,8 @@ struct UIConstants {
         static let siriUrlSectionPadding: CGFloat = 40
         static let settingsSectionHeight: CGFloat = 44
         static let separatorHeight: CGFloat = 0.5
+        static let shareTrackersBottomOffset: CGFloat = -20
+        static let shareTrackersHeight: CGFloat = 36
     }
 
     struct strings {


### PR DESCRIPTION
This was happening because the button subview was actually placed outside the superview. Moving the superview to the correct size and location and basing the subviews off it fixed the issue.