### PR TITLE
Fixes #1223: Jumpy url bar animation

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -328,7 +328,6 @@ class BrowserViewController: UIViewController {
         urlBar = URLBar()
         urlBar.delegate = self
         urlBar.toolsetDelegate = self
-        urlBar.shrinkFromView = urlBarContainer
         urlBar.showToolset = showsToolsetInURLBar
         mainContainerView.insertSubview(urlBar, aboveSubview: urlBarContainer)
 
@@ -922,7 +921,6 @@ extension BrowserViewController: URLBarDelegate {
     func urlBarDidDeactivate(_ urlBar: URLBar) {
         UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration) {
             self.urlBarContainer.alpha = 0
-            self.view.layoutIfNeeded()
         }
     }
 


### PR DESCRIPTION
URL bar animation is much improved when moving from static to editing!

Demo:
![demo](https://user-images.githubusercontent.com/4400286/44854347-4c1d4c00-ac36-11e8-9187-3bd1fe8cec87.gif)
