### PR TITLE
Fixes #1338: Client Tests are Failing 

### DIFF
--- a/ClientTests/BrowserViewControllerTests.swift
+++ b/ClientTests/BrowserViewControllerTests.swift
@@ -60,7 +60,7 @@ class BrowserViewControllerTests: XCTestCase {
         mockUserDefaults.set(10, forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
         mockUserDefaults.set(true, forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyOLD)
         
-        let shouldShow = bvc.shouldShowTrackerStatsShareButton(percent: 100, userDefaults: mockUserDefaults)
+        let shouldShow = bvc.shouldShowTips(percent: 100, userDefaults: mockUserDefaults)
         XCTAssertTrue(shouldShow)
         
     }
@@ -71,17 +71,8 @@ class BrowserViewControllerTests: XCTestCase {
         mockUserDefaults.set(10, forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
         mockUserDefaults.set(false, forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyOLD)
         
-        let shouldShow = bvc.shouldShowTrackerStatsShareButton(percent: 100, userDefaults: mockUserDefaults)
+        let shouldShow = bvc.shouldShowTips(percent: 100, userDefaults: mockUserDefaults)
         XCTAssertTrue(shouldShow)
-    }
-    
-    func testShareButtonHasNotHitEnoughTrackers() {
-        let bvc = BrowserViewController(appSplashController: TestAppSplashController())
-        mockUserDefaults.clear()
-        mockUserDefaults.set(9, forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
-        
-        let shouldShow = bvc.shouldShowTrackerStatsShareButton(percent: 100, userDefaults: mockUserDefaults)
-        XCTAssertFalse(shouldShow)
     }
     
     func testShareButtonInGroup() {
@@ -90,7 +81,7 @@ class BrowserViewControllerTests: XCTestCase {
         mockUserDefaults.set(10, forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
         mockUserDefaults.set(true, forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyNEW)
         
-        let shouldShow = bvc.shouldShowTrackerStatsShareButton(percent: 100, userDefaults: mockUserDefaults)
+        let shouldShow = bvc.shouldShowTips(percent: 100, userDefaults: mockUserDefaults)
         XCTAssertTrue(shouldShow)
     }
     
@@ -100,7 +91,7 @@ class BrowserViewControllerTests: XCTestCase {
         mockUserDefaults.set(10, forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
         mockUserDefaults.set(false, forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyNEW)
         
-        let shouldShow = bvc.shouldShowTrackerStatsShareButton(percent: 100, userDefaults: mockUserDefaults)
+        let shouldShow = bvc.shouldShowTips(percent: 100, userDefaults: mockUserDefaults)
         XCTAssertFalse(shouldShow)
     }
 }

--- a/ClientTests/UserAgentTests.swift
+++ b/ClientTests/UserAgentTests.swift
@@ -22,7 +22,9 @@ class UserAgentTests: XCTestCase {
     }
 
     func testSetsCachedUserAgent() {
-        mockUserDefaults.set(UIDevice.current.systemVersion, forKey: "LastSeenSystemVersion")
+        mockUserDefaults.set(UIDevice.current.systemVersion, forKey: "LastDeviceSystemVersionNumber")
+        mockUserDefaults.set(AppInfo.shortVersion, forKey: "LastFocusVersionNumber")
+        mockUserDefaults.set(AppInfo.buildNumber, forKey: "LastFocusBuildNumber")
         mockUserDefaults.set(fakeUserAgent, forKey: "UserAgent")
 
         _ = UserAgent(userDefaults: mockUserDefaults)
@@ -32,13 +34,15 @@ class UserAgentTests: XCTestCase {
     }
 
     func testSetsGeneratedUserAgent() {
-        mockUserDefaults.removeObject(forKey: "LastSeenSystemVersion")
+        mockUserDefaults.removeObject(forKey: "LastDeviceSystemVersionNumber")
+        mockUserDefaults.removeObject(forKey: "LastFocusVersionNumber")
+        mockUserDefaults.removeObject(forKey: "LastFocusBuildNumber")
         mockUserDefaults.removeObject(forKey: "UserAgent")
 
         _ = UserAgent(userDefaults: mockUserDefaults)
         XCTAssertTrue(mockUserDefaults.synchronizeCalled)
         XCTAssertNotNil(mockUserDefaults.registerValue)
-        XCTAssertNotNil(mockUserDefaults.string(forKey: "LastSeenSystemVersion"))
+        XCTAssertNotNil(mockUserDefaults.string(forKey: "LastFocusVersionNumber"))
         XCTAssertTrue(((mockUserDefaults.registerValue!["UserAgent"] as? String)?.contains(AppInfo.config.productName))!)
     }
 
@@ -52,7 +56,9 @@ fileprivate class MockUserDefaults: UserDefaults {
     var registerValue: [String : Any]?
 
     func clear() {
-        removeObject(forKey: "LastSeenSystemVersion")
+        removeObject(forKey: "LastFocusVersionNumber")
+        removeObject(forKey: "LastFocusBuildNumber")
+        removeObject(forKey: "LastDeviceSystemVersionNumber")
         removeObject(forKey: "UserAgent")
         synchronizeCalled = false
         registerValue = nil


### PR DESCRIPTION
Updated to match new function name. Removed test to check for minimum trackers blocked as that is handled separately now.