### PR TITLE
Fixes #1272: Trying to fix urlbar transparent issue

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -531,7 +531,7 @@ class URLBar: UIView {
         let duration = UIConstants.layout.urlBarTransitionAnimationDuration / 2
 
         pageActionsButton.animateHidden(!visible, duration: duration)
-        shieldIcon.animateHidden(!visible, duration: duration)
+        
         self.layoutIfNeeded()
 
         UIView.animate(withDuration: duration) {
@@ -556,6 +556,7 @@ class URLBar: UIView {
         shouldPresent = false
         updateLockIcon()
         updateUrlIcons()
+        shieldIcon.animateHidden(true, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
         toolset.settingsButton.isEnabled = true
         delegate?.urlBarDidFocus(self)
 
@@ -600,6 +601,7 @@ class URLBar: UIView {
         hideCancelConstraints.forEach { $0.activate() }
 
         if inBrowsingMode {
+            shieldIcon.animateHidden(false, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
             deleteButton.animateHidden(false, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
         } else {
             deactivate()


### PR DESCRIPTION
In URLBarContainer.swift, I notice that animateHidden is trying to transit alpha from 0 to 1 in UIConstants.layout.urlBarTransitionAnimationDuration, which causes URL bar flashes transparent for a split second.
<img width="538" alt="screen shot 2018-09-22 at 10 56 54 am" src="https://user-images.githubusercontent.com/25020683/45918530-404c3080-be56-11e8-8a8d-eba728b4767c.png">
<img width="759" alt="screen shot 2018-09-22 at 10 54 20 am" src="https://user-images.githubusercontent.com/25020683/45918501-f2cfc380-be55-11e8-9caf-2b9074f54e8c.png">
Thus, I change the duration to 0 and it seems working well.
