### PR TITLE
Fixes #1271: Trying to fix duplicated tracking protection icon

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -531,7 +531,7 @@ class URLBar: UIView {
         let duration = UIConstants.layout.urlBarTransitionAnimationDuration / 2
 
         pageActionsButton.animateHidden(!visible, duration: duration)
-        shieldIcon.animateHidden(!visible, duration: duration)
+        
         self.layoutIfNeeded()
 
         UIView.animate(withDuration: duration) {
@@ -556,6 +556,7 @@ class URLBar: UIView {
         shouldPresent = false
         updateLockIcon()
         updateUrlIcons()
+        shieldIcon.animateHidden(true, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
         toolset.settingsButton.isEnabled = true
         delegate?.urlBarDidFocus(self)
 
@@ -600,6 +601,7 @@ class URLBar: UIView {
         hideCancelConstraints.forEach { $0.activate() }
 
         if inBrowsingMode {
+            shieldIcon.animateHidden(false, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
             deleteButton.animateHidden(false, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
         } else {
             deactivate()

--- a/Blockzilla/URLBarContainer.swift
+++ b/Blockzilla/URLBarContainer.swift
@@ -44,9 +44,9 @@ class URLBarContainer: UIView {
     
     var color: barState = .editing {
         didSet {
-            backgroundDark.animateHidden(color != .dark, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
-            backgroundBright.animateHidden(color != .bright, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
-            backgroundEditing.animateHidden(color != .editing, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
+            backgroundDark.animateHidden(color != .dark, duration: 0)
+            backgroundBright.animateHidden(color != .bright, duration: 0)
+            backgroundEditing.animateHidden(color != .editing, duration: 0)
         }
     }
 

--- a/Blockzilla/URLBarContainer.swift
+++ b/Blockzilla/URLBarContainer.swift
@@ -44,9 +44,9 @@ class URLBarContainer: UIView {
     
     var color: barState = .editing {
         didSet {
-            backgroundDark.animateHidden(color != .dark, duration: 0)
-            backgroundBright.animateHidden(color != .bright, duration: 0)
-            backgroundEditing.animateHidden(color != .editing, duration: 0)
+            backgroundDark.animateHidden(color != .dark, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
+            backgroundBright.animateHidden(color != .bright, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
+            backgroundEditing.animateHidden(color != .editing, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
         }
     }
 


### PR DESCRIPTION
Here I am trying to mimic "delete button"'s animation logic since it works well after loading.

I think one possible reason why original code doesn't work well is that pageActionsButton is a sub-child of many other components (the top parent is urlBarBorderView), which has correct alpha value.
<img width="551" alt="screen shot 2018-09-22 at 1 30 25 pm" src="https://user-images.githubusercontent.com/25020683/45921243-ee200500-be7f-11e8-8d45-08aa819a9155.png">


Sorry, this PR is duplicate with #1366, I occasionally merged that PR but reverted it already.