### PR TITLE
Fixes #1344: Find in page bar jumps unnecessarily 

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -394,36 +394,34 @@ class BrowserViewController: UIViewController {
             if findInPageBar == nil {
                 Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.open, object: TelemetryEventObject.findInPageBar)
                 
-                urlBar.dismiss()
-                let findInPageBar = FindInPageBar()
-                self.findInPageBar = findInPageBar
-                let fillerView = UIView()
-                self.fillerView = fillerView
-                fillerView.backgroundColor = UIConstants.Photon.Grey70
-                findInPageBar.text = text
-                findInPageBar.delegate = self
-                
-                alertStackView.addArrangedSubview(findInPageBar)
-                mainContainerView.insertSubview(fillerView, belowSubview: browserToolbar)
-
-                updateViewConstraints()
-                
-                UIView.animate(withDuration: 2.0, animations: {
-                    findInPageBar.snp.makeConstraints { make in
+                urlBar.dismiss {
+                    // Start our animation after urlBar dismisses
+                    let findInPageBar = FindInPageBar()
+                    self.findInPageBar = findInPageBar
+                    let fillerView = UIView()
+                    self.fillerView = fillerView
+                    fillerView.backgroundColor = UIConstants.Photon.Grey70
+                    findInPageBar.text = text
+                    findInPageBar.delegate = self
+                    
+                    self.alertStackView.addArrangedSubview(findInPageBar)
+                    self.mainContainerView.insertSubview(fillerView, belowSubview: self.browserToolbar)
+                    
+                    findInPageBar.snp.makeConstraints{ make in
                         make.height.equalTo(UIConstants.ToolbarHeight)
                         make.leading.trailing.equalTo(self.alertStackView)
                         make.bottom.equalTo(self.alertStackView.snp.bottom)
                     }
-                }) { (_) in
                     fillerView.snp.makeConstraints { make in
                         make.top.equalTo(self.alertStackView.snp.bottom)
                         make.bottom.equalTo(self.view)
                         make.leading.trailing.equalTo(self.alertStackView)
                     }
+
+                    self.view.layoutIfNeeded()
+                    self.findInPageBar?.becomeFirstResponder()
                 }
             }
-            
-            self.findInPageBar?.becomeFirstResponder()
         } else if let findInPageBar = self.findInPageBar {
             findInPageBar.endEditing(true)
             webViewController.evaluate("__firefox__.findDone()", completion: nil)

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -586,8 +586,11 @@ class URLBar: UIView {
         }
     }
 
-    @objc func dismiss() {
-        guard isEditing else { return }
+    @objc func dismiss(completion: (() -> ())? = nil) {
+        guard isEditing else {
+            completion?()
+            return
+        }
 
         isEditing = false
         updateLockIcon()
@@ -606,8 +609,8 @@ class URLBar: UIView {
         }
 
         self.layoutIfNeeded()
-        UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration) {
 
+        UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration, animations: {
             if self.inBrowsingMode {
                 self.isEditingConstraints.forEach { $0.deactivate() }
                 // Reveal the URL bar buttons on iPad/landscape.
@@ -622,6 +625,8 @@ class URLBar: UIView {
             }
 
             self.layoutIfNeeded()
+        }) { ( _ ) in
+            completion?()
         }
     }
 


### PR DESCRIPTION
Updated behavior: 

![find in page bar](https://user-images.githubusercontent.com/4400286/46022435-92888e00-c0b0-11e8-9216-6e64fca7669a.gif)

