### PR TITLE
Fixes #1337: Add home screen tips toggle

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -696,6 +696,10 @@ class BrowserViewController: UIViewController {
             UIKeyCommand(input: "]", modifierFlags: .command, action: #selector(BrowserViewController.goForward), discoverabilityTitle: UIConstants.strings.browserForward),
         ]
     }
+    
+    func refreshTipsDisplay() {
+        createHomeView()
+    }
 
     func canShowTips() -> Bool {
         return NSLocale.current.identifier == "en_US" && !AppInfo.isKlar

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -385,7 +385,6 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             cell.detailTextLabel?.text = toggle.subtitle
             cell.detailTextLabel?.numberOfLines = 0
             cell.selectionStyle = .none
-            
             return cell
         }
         

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -657,6 +657,10 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             Telemetry.default.configuration.isUploadEnabled = sender.isOn
         } else if toggle.setting == .biometricLogin {
             UserDefaults.standard.set(false, forKey: TipManager.TipKey.biometricTip)
+        } else if toggle.setting == .showHomeScreenTips {
+            if let browserViewController = presentingViewController as? BrowserViewController {
+                browserViewController.refreshTipsDisplay()
+            }
         }
 
         switch toggle.setting {

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -100,7 +100,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             case .search: return 2
             case .siri: return 3
             case .integration: return 1
-            case .mozilla: return 2
+            case .mozilla: return 3
             }
         }
         
@@ -188,26 +188,34 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         let usageDataSubtitle = String(format: UIConstants.strings.detailTextSendUsageData, AppInfo.productName)
         let usageDataToggle = BlockerToggle(label: UIConstants.strings.labelSendAnonymousUsageData, setting: SettingsToggle.sendAnonymousUsageData, subtitle: usageDataSubtitle)
         let safariToggle = BlockerToggle(label: UIConstants.strings.toggleSafari, setting: SettingsToggle.safari)
+        let homeScreenTipsToggle = BlockerToggle(label: UIConstants.strings.toggleHomeScreenTips, setting: SettingsToggle.homeScreenTips)
+        
         var toggles = [Int : BlockerToggle]()
         if let biometricToggle = createBiometricLoginToggleIfAvailable() {
             toggles = [
                 1: blockFontsToggle,
                 2: biometricToggle,
                 3: usageDataToggle,
-                6: safariToggle
+                6: safariToggle,
+                7: homeScreenTipsToggle
             ]
-        }
-        else {
+        } else {
             toggles = [
                 1: blockFontsToggle,
                 2: usageDataToggle,
-                5: safariToggle
+                5: safariToggle,
+                6: homeScreenTipsToggle
             ]
         }
         if #available(iOS 12.0, *) {
             if let safariRow = toggles.first(where: { $1 == safariToggle })?.key {
                 toggles.removeValue(forKey: safariRow)
-                toggles[(safariRow +  Section.siri.numberOfRows)] = safariToggle
+                toggles[(safariRow + Section.siri.numberOfRows)] = safariToggle
+            }
+            
+            if let homeScreenTipsRow = toggles.first(where: { $1 == homeScreenTipsToggle })?.key {
+                toggles.removeValue(forKey: homeScreenTipsRow)
+                toggles[(homeScreenTipsRow + Section.siri.numberOfRows)] = homeScreenTipsToggle
             }
         }
         return toggles
@@ -398,6 +406,15 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             cell = siriCell
         case .mozilla:
             if indexPath.row == 0 {
+                cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "toggleCell")
+                let toggle = toggleForIndexPath(indexPath)
+                cell.textLabel?.text = toggle.label
+                cell.textLabel?.numberOfLines = 0
+                cell.accessoryView = PaddedSwitch(switchView: toggle.toggle)
+                cell.detailTextLabel?.text = toggle.subtitle
+                cell.detailTextLabel?.numberOfLines = 0
+                cell.selectionStyle = .none
+            } else if indexPath.row == 1 {
                 cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "aboutCell")
                 cell.textLabel?.text = String(format: UIConstants.strings.aboutTitle, AppInfo.productName)
                 cell.accessibilityIdentifier = "settingsViewController.about"
@@ -549,9 +566,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
                 navigationController?.pushViewController(siriFavoriteVC, animated: true)
             }
         case .mozilla:
-            if indexPath.row == 0 {
+            if indexPath.row == 1 {
                 aboutClicked()
-            } else if indexPath.row == 1 {
+            } else if indexPath.row == 2 {
                 let appId = AppInfo.config.appId
                 if let reviewURL = URL(string: "https://itunes.apple.com/app/id\(appId)?action=write-review"), UIApplication.shared.canOpenURL(reviewURL) {
                     UIApplication.shared.open(reviewURL, options: [:], completionHandler: nil)

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -201,10 +201,6 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
                 6: safariToggle,
                 7: homeScreenTipsToggle
             ]
-            
-            if !UserDefaults.standard.bool(forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyNEW) {
-                toggles[7] = nil
-            }
         } else {
             toggles = [
                 1: blockFontsToggle,
@@ -212,17 +208,19 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
                 5: safariToggle,
                 6: homeScreenTipsToggle
             ]
-            
-            if !UserDefaults.standard.bool(forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyNEW) {
-                toggles[6] = nil
-            }
         }
-        if #available(iOS 12.0, *) {
-            if let safariRow = toggles.first(where: { $1 == safariToggle })?.key {
+        
+        if let safariRow = toggles.first(where: { $1 == safariToggle })?.key {
+            if !UserDefaults.standard.bool(forKey: BrowserViewController.userDefaultsShareTrackerStatsKeyNEW) {
+                toggles.removeValue(forKey: safariRow + 1)
+            }
+            
+            if #available(iOS 12.0, *) {
                 toggles.removeValue(forKey: safariRow)
                 toggles[(safariRow + Section.siri.numberOfRows)] = safariToggle
             }
-            
+        }
+        if #available(iOS 12.0, *) {
             if let homeScreenTipsRow = toggles.first(where: { $1 == homeScreenTipsToggle })?.key {
                 toggles.removeValue(forKey: homeScreenTipsRow)
                 toggles[(homeScreenTipsRow + Section.siri.numberOfRows)] = homeScreenTipsToggle

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -188,7 +188,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         let usageDataSubtitle = String(format: UIConstants.strings.detailTextSendUsageData, AppInfo.productName)
         let usageDataToggle = BlockerToggle(label: UIConstants.strings.labelSendAnonymousUsageData, setting: SettingsToggle.sendAnonymousUsageData, subtitle: usageDataSubtitle)
         let safariToggle = BlockerToggle(label: UIConstants.strings.toggleSafari, setting: SettingsToggle.safari)
-        let homeScreenTipsToggle = BlockerToggle(label: UIConstants.strings.toggleHomeScreenTips, setting: SettingsToggle.homeScreenTips)
+        let homeScreenTipsToggle = BlockerToggle(label: UIConstants.strings.toggleHomeScreenTips, setting: SettingsToggle.showHomeScreenTips)
         
         var toggles = [Int : BlockerToggle]()
         if let biometricToggle = createBiometricLoginToggleIfAvailable() {

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -654,10 +654,6 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             Telemetry.default.configuration.isUploadEnabled = sender.isOn
         } else if toggle.setting == .biometricLogin {
             UserDefaults.standard.set(false, forKey: TipManager.TipKey.biometricTip)
-        } else if toggle.setting == .showHomeScreenTips {
-            if let browserViewController = presentingViewController as? BrowserViewController {
-                browserViewController.refreshTipsDisplay()
-            }
         }
 
         switch toggle.setting {
@@ -667,6 +663,13 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             updateSetting()
         default:
             updateSetting()
+        }
+        
+        // This update must occur after the setting has been updated to properly take effect.
+        if toggle.setting == .showHomeScreenTips {
+            if let browserViewController = presentingViewController as? BrowserViewController {
+                browserViewController.refreshTipsDisplay()
+            }
         }
     }
 }

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -77,7 +77,7 @@ class TipManager {
     
     lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, identifier: TipKey.shareTrackersTip)
     
-    func fetchTip() -> Tip? {       
+    func fetchTip() -> Tip? {
         guard Settings.getToggle(.showHomeScreenTips) else { return shareTrackersTip }
         guard let tip = possibleTips.randomElement(), let indexToRemove = possibleTips.index(of: tip) else { return nil }
         if tip.identifier != TipKey.shareTrackersTip {

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -78,7 +78,7 @@ class TipManager {
     lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, identifier: TipKey.shareTrackersTip)
     
     func fetchTip() -> Tip? {
-        guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: SettingsToggle.showHomeScreenTips.rawValue) == true else { return shareTrackersTip }
+        guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: SettingsToggle.showHomeScreenTips.rawValue) == false else { return shareTrackersTip }
         guard let tip = possibleTips.randomElement(), let indexToRemove = possibleTips.index(of: tip) else { return nil }
         if tip.identifier != TipKey.shareTrackersTip {
             possibleTips.remove(at: indexToRemove)

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -78,7 +78,7 @@ class TipManager {
     lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, identifier: TipKey.shareTrackersTip)
     
     func fetchTip() -> Tip? {
-        guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: SettingsToggle.showHomeScreenTips.rawValue) == false else { return shareTrackersTip }
+        guard !Settings.getToggle(.showHomeScreenTips) else { return shareTrackersTip }
         guard let tip = possibleTips.randomElement(), let indexToRemove = possibleTips.index(of: tip) else { return nil }
         if tip.identifier != TipKey.shareTrackersTip {
             possibleTips.remove(at: indexToRemove)

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -77,8 +77,8 @@ class TipManager {
     
     lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, identifier: TipKey.shareTrackersTip)
     
-    func fetchTip() -> Tip? {
-        guard !Settings.getToggle(.showHomeScreenTips) else { return shareTrackersTip }
+    func fetchTip() -> Tip? {       
+        guard Settings.getToggle(.showHomeScreenTips) else { return shareTrackersTip }
         guard let tip = possibleTips.randomElement(), let indexToRemove = possibleTips.index(of: tip) else { return nil }
         if tip.identifier != TipKey.shareTrackersTip {
             possibleTips.remove(at: indexToRemove)

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -78,7 +78,7 @@ class TipManager {
     lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, identifier: TipKey.shareTrackersTip)
     
     func fetchTip() -> Tip? {
-        guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: SettingsToggle.homeScreenTips.rawValue) == true else { return shareTrackersTip }
+        guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: SettingsToggle.showHomeScreenTips.rawValue) == true else { return shareTrackersTip }
         guard let tip = possibleTips.randomElement(), let indexToRemove = possibleTips.index(of: tip) else { return nil }
         if tip.identifier != TipKey.shareTrackersTip {
             possibleTips.remove(at: indexToRemove)

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -78,6 +78,7 @@ class TipManager {
     lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, identifier: TipKey.shareTrackersTip)
     
     func fetchTip() -> Tip? {
+        guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: SettingsToggle.homeScreenTips.rawValue) == true else { return shareTrackersTip }
         guard let tip = possibleTips.randomElement(), let indexToRemove = possibleTips.index(of: tip) else { return nil }
         if tip.identifier != TipKey.shareTrackersTip {
             possibleTips.remove(at: indexToRemove)

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -298,6 +298,7 @@ struct UIConstants {
         static let settingsTitle = NSLocalizedString("Settings.screenTitle", value: "Settings", comment: "Title for settings screen")
         static let settingsToggleOtherSubtitle = NSLocalizedString("Settings.toggleOtherSubtitle", value: "May break some videos and Web pages", comment: "Label subtitle for toggle on main screen")
         static let learnMore = NSLocalizedString("Settings.learnMore", value: "Learn more.", comment: "Subtitle for Send Anonymous Usage Data toggle on main screen")
+        static let toggleHomeScreenTips = NSLocalizedString("Settings.toggleHomeScreenTips", value: "Show home screen tips", comment: "Show home screen tips toggle label on settings screen")
         static let toggleSectionIntegration = NSLocalizedString("Settings.sectionIntegration", value: "INTEGRATION", comment: "Label for Safari integration section") // deprecated
         static let toggleSectionSafari = NSLocalizedString("Settings.safariTitle", value: "SAFARI INTEGRATION", comment: "Label for Safari integration section")
         static let toggleSectionMozilla = NSLocalizedString("Settings.sectionMozilla", value: "MOZILLA", comment: "Section label for Mozilla toggles")

--- a/Blockzilla/en.lproj/Localizable.strings
+++ b/Blockzilla/en.lproj/Localizable.strings
@@ -343,9 +343,6 @@
 /* %@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu. */
 "Settings.toggleFaceIDDescription" = "Face ID can unlock %@ if a URL is already open in the app";
 
-/* Show home screen tips toggle label on settings screen */
-"Settings.toggleHomeScreenTips" = "Show home screen tips";
-
 /* Label subtitle for toggle on main screen */
 "Settings.toggleOtherSubtitle" = "May break some videos and Web pages";
 

--- a/Blockzilla/en.lproj/Localizable.strings
+++ b/Blockzilla/en.lproj/Localizable.strings
@@ -343,6 +343,9 @@
 /* %@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu. */
 "Settings.toggleFaceIDDescription" = "Face ID can unlock %@ if a URL is already open in the app";
 
+/* Show home screen tips toggle label on settings screen */
+"Settings.toggleHomeScreenTips" = "Show home screen tips";
+
 /* Label subtitle for toggle on main screen */
 "Settings.toggleOtherSubtitle" = "May break some videos and Web pages";
 

--- a/Shared/Settings.swift
+++ b/Shared/Settings.swift
@@ -11,6 +11,7 @@ enum SettingsToggle: String {
     case blockSocial = "BlockSocial"
     case blockOther = "BlockOther"
     case blockFonts = "BlockFonts"
+    case homeScreenTips = "HomeScreenTips"
     case safari = "Safari"
     case sendAnonymousUsageData = "SendAnonymousUsageData"
     case enableDomainAutocomplete = "enableDomainAutocomplete"
@@ -31,6 +32,7 @@ struct Settings {
         case .blockSocial: return true
         case .blockOther: return false
         case .blockFonts: return false
+        case .homeScreenTips: return true
         case .safari: return true
         case .sendAnonymousUsageData: return AppInfo.isKlar ? false : true
         case .enableDomainAutocomplete: return true

--- a/Shared/Settings.swift
+++ b/Shared/Settings.swift
@@ -11,7 +11,7 @@ enum SettingsToggle: String {
     case blockSocial = "BlockSocial"
     case blockOther = "BlockOther"
     case blockFonts = "BlockFonts"
-    case homeScreenTips = "HomeScreenTips"
+    case showHomeScreenTips = "HomeScreenTips"
     case safari = "Safari"
     case sendAnonymousUsageData = "SendAnonymousUsageData"
     case enableDomainAutocomplete = "enableDomainAutocomplete"
@@ -32,7 +32,7 @@ struct Settings {
         case .blockSocial: return true
         case .blockOther: return false
         case .blockFonts: return false
-        case .homeScreenTips: return true
+        case .showHomeScreenTips: return true
         case .safari: return true
         case .sendAnonymousUsageData: return AppInfo.isKlar ? false : true
         case .enableDomainAutocomplete: return true


### PR DESCRIPTION
These changes add a toggle to Settings to allow the user to decide whether or not to display the tips on the Home Screen, seen here (in the Mozilla section):

![simulator screen shot - iphone xs - 2018-09-29 at 13 43 30](https://user-images.githubusercontent.com/13912591/46248891-d3a0db00-c3ed-11e8-894b-c750bc0e6e74.png)

Currently, the tips remain after turning the switch off and returning to the browser, until a website is visited and then erased. It would be better for the tips to immediately disappear if when the user turns the switch off. I'm willing to hear suggestions on the best way to implement this if we decide it's necessary.

Some options are:
* Send a notification from the Settings view controller to the Browser view controller telling it to update the Home view.
* Link the Browser to the Settings view via a delegate or closure callback indicating that the setting has changed.