### PR TITLE
[1382] - Fix Broken character encoding on button

### DIFF
--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -239,7 +239,7 @@ extension WebViewController: WKNavigationDelegate {
         let error = error as NSError
         guard error.code != Int(CFNetworkErrors.cfurlErrorCancelled.rawValue), let errorUrl = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL else { return }
         let errorPageData = ErrorPage(error: error).data
-        webView.load(errorPageData, mimeType: "", characterEncodingName: "", baseURL: errorUrl)
+        webView.load(errorPageData, mimeType: "", characterEncodingName: UIConstants.strings.encodingNameUTF8, baseURL: errorUrl)
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -429,5 +429,6 @@ struct UIConstants {
         static let siriEraseTipTitle = String(format: "Ask Siri to erase %@ history:", AppInfo.productName)
         static let siriEraseTipDescription = "Add Siri shortcut"
         static let shareTrackersTipTitle = "%@ trackers blocked so far"
+        static let encodingNameUTF8 = "utf-8"
     }
 }


### PR DESCRIPTION
Issue: https://github.com/mozilla-mobile/focus-ios/issues/1382

WKWebView load was not being able to convert utf-8 strings without specifically letting it know what encode to use.

Docs: https://developer.apple.com/documentation/webkit/wkwebview/1415011-load