### PR TITLE
Fixes #490: Include subject in mail title

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -937,13 +937,18 @@ extension BrowserViewController: URLBarDelegate {
         let items = PageActionSheetItems(url: url)
         let sharePageItem = PhotonActionSheetItem(title: UIConstants.strings.sharePage, iconString: "icon_openwith_active") { action in
             let shareVC = utils.buildShareViewController(url: url)
+            self.webViewController.evaluate("document.title") { title, error in
+                if let title = title as? String {
+                    shareVC.setValue(title, forKey: "Subject")
+                }
             
-            // Exact frame dimensions taken from presentPhotonActionSheet
-            shareVC.popoverPresentationController?.sourceView = urlBar.pageActionsButton
-            shareVC.popoverPresentationController?.sourceRect = CGRect(x: urlBar.pageActionsButton.frame.width/2, y: urlBar.pageActionsButton.frame.size.height * 0.75, width: 1, height: 1)
-            
-            shareVC.becomeFirstResponder()
-            self.present(shareVC, animated: true, completion: nil)
+                // Exact frame dimensions taken from presentPhotonActionSheet
+                shareVC.popoverPresentationController?.sourceView = urlBar.pageActionsButton
+                shareVC.popoverPresentationController?.sourceRect = CGRect(x: urlBar.pageActionsButton.frame.width/2, y: urlBar.pageActionsButton.frame.size.height * 0.75, width: 1, height: 1)
+                
+                shareVC.becomeFirstResponder()
+                self.present(shareVC, animated: true, completion: nil)
+            }
         }
         var shareItems = [sharePageItem]
         if items.canOpenInFirefox {


### PR DESCRIPTION
These changes make it so that when the user chooses to share a page, the uiactivityviewcontroller's subject is set as the page's title. The default mail extension automatically chooses this as the e-mail title. This doesn't work properly with gmail, but I believe that is a known bug in the gmail share extension.

Default mail:
<img src="https://user-images.githubusercontent.com/9863339/46484800-dbd38e80-c7d0-11e8-8833-7d9b318cefc1.PNG" width="400">

Gmail:
<img src="https://user-images.githubusercontent.com/9863339/46484804-dd9d5200-c7d0-11e8-9e84-c69b785db0f8.jpg" width="400">