### PR TITLE
Fixes #1006: Add passbook downloads

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		2696EB04211F540600F0C73F /* SearchHistoryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */; };
 		2825C3665AB14081B262F767 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D051AC1857A0EEEBB833D15 /* SystemConfiguration.framework */; };
 		2B36326E97D2E67E9C684B4B /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80D9AA926EFBD788739486EB /* CoreTelephony.framework */; };
+		2B8BF78C2166E3B3005CE7F4 /* OpenInHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8BF78B2166E3B3005CE7F4 /* OpenInHelper.swift */; };
+		2B8BF78E2166E4B4005CE7F4 /* DownloadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8BF78D2166E4B4005CE7F4 /* DownloadQueue.swift */; };
 		2F2F84BCF076B21DE42D1F29 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C652A61E213D254A86DF5736 /* CoreMedia.framework */; };
 		34056D10515852F370C83A01 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB8E622E994545108473554 /* QuartzCore.framework */; };
 		4285B8E0671F40DA543A2E58 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29B90C056305836CB297FF79 /* AssetsLibrary.framework */; };
@@ -370,6 +372,8 @@
 		1DE903CD20C751D7002E53ED /* FindInPageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindInPageTest.swift; sourceTree = "<group>"; };
 		2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryUtils.swift; sourceTree = "<group>"; };
 		29B90C056305836CB297FF79 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
+		2B8BF78B2166E3B3005CE7F4 /* OpenInHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenInHelper.swift; sourceTree = "<group>"; };
+		2B8BF78D2166E4B4005CE7F4 /* DownloadQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadQueue.swift; sourceTree = "<group>"; };
 		427B752EF11959F9C38B12D6 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		4F1284851FC5E242001A775B /* TPSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPSettingsTest.swift; sourceTree = "<group>"; };
 		4F582F7A1F44A10F006C744B /* OpenInFocusTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenInFocusTest.swift; sourceTree = "<group>"; };
@@ -1259,6 +1263,8 @@
 				B3AFC2B91F7C0B66001AEF38 /* Modules */,
 				B31DAAC71F7D87E800A11A74 /* Lib */,
 				D3E54FD41DEFB25B003E1AFF /* SearchPlugins */,
+				2B8BF78D2166E4B4005CE7F4 /* DownloadQueue.swift */,
+				2B8BF78B2166E3B3005CE7F4 /* OpenInHelper.swift */,
 				D30179C51BCD78E1009AD388 /* Blockzilla-Bridging-Header.h */,
 				D3DA778B1DC2C60E009C114E /* errorPage.html */,
 				E47F9AE91DB9329D00A93285 /* Adjust-Focus.plist */,
@@ -1868,6 +1874,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B8BF78C2166E3B3005CE7F4 /* OpenInHelper.swift in Sources */,
 				D0967A811EC50002009D937F /* TelemetryIntegration.swift in Sources */,
 				16837EA62135EFCC000424BB /* TipManager.swift in Sources */,
 				163BFFE62125EE260007CEBC /* SiriShortcuts.swift in Sources */,
@@ -1939,6 +1946,7 @@
 				D3E2C96B1DA3069000DEBE3D /* URIFixup.swift in Sources */,
 				D3DA77851DC2C307009C114E /* ErrorPage.swift in Sources */,
 				D3426AE91DB7F4060016DA5A /* KeyboardHelper.swift in Sources */,
+				2B8BF78E2166E4B4005CE7F4 /* DownloadQueue.swift in Sources */,
 				B3CD41CC1FD1CAF000AEBD58 /* PaddedSwitch.swift in Sources */,
 				D3E251EA1DAD714C005918DC /* InstructionsView.swift in Sources */,
 				D3561B2B1DB5925100A5EEAF /* GradientBackgroundView.swift in Sources */,

--- a/Blockzilla/DownloadQueue.swift
+++ b/Blockzilla/DownloadQueue.swift
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+private let downloadOperationQueue = OperationQueue()
+
+protocol DownloadDelegate {
+    func download(_ download: Download, didCompleteWithError error: Error?)
+    func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64)
+    func download(_ download: Download, didFinishDownloadingTo location: URL)
+}
+
+class Download: NSObject {
+    let preflightResponse: URLResponse
+    let request: URLRequest
+
+    let mimeType: String
+    let filename: String
+
+    var delegate: DownloadDelegate?
+
+    var state: URLSessionTask.State {
+        return task?.state ?? .suspended
+    }
+
+    private(set) var totalBytesExpected: Int64?
+    private(set) var bytesDownloaded: Int64
+
+    private(set) var session: URLSession?
+    private(set) var task: URLSessionDownloadTask?
+
+    private(set) var isComplete = false
+
+    init(preflightResponse: URLResponse, request: URLRequest) {
+        self.preflightResponse = preflightResponse
+        self.request = request
+
+        self.mimeType = preflightResponse.mimeType ?? "application/octet-stream"
+        self.filename = preflightResponse.suggestedFilename ?? "unknown"
+
+        self.totalBytesExpected = preflightResponse.expectedContentLength > 0 ? preflightResponse.expectedContentLength : nil
+        self.bytesDownloaded = 0
+
+        super.init()
+
+        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: downloadOperationQueue)
+        self.task = session?.downloadTask(with: request)
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+
+    func resume() {
+        task?.resume()
+    }
+}
+
+extension Download: URLSessionTaskDelegate, URLSessionDownloadDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        delegate?.download(self, didCompleteWithError: error)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        bytesDownloaded = totalBytesWritten
+        totalBytesExpected = totalBytesExpectedToWrite
+
+        delegate?.download(self, didDownloadBytes: bytesWritten)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        do {
+            let destination = try uniqueDownloadPathForFilename(filename)
+            try FileManager.default.moveItem(at: location, to: destination)
+            isComplete = true
+            delegate?.download(self, didFinishDownloadingTo: destination)
+        } catch let error {
+            delegate?.download(self, didCompleteWithError: error)
+        }
+    }
+
+    private func uniqueDownloadPathForFilename(_ filename: String) throws -> URL {
+        let downloadsPath = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false).appendingPathComponent("Downloads")
+
+        let basePath = downloadsPath.appendingPathComponent(filename)
+        let fileExtension = basePath.pathExtension
+        let filenameWithoutExtension = fileExtension.count > 0 ? String(filename.dropLast(fileExtension.count + 1)) : filename
+
+        var proposedPath = basePath
+        var count = 0
+
+        while FileManager.default.fileExists(atPath: proposedPath.path) {
+            count += 1
+
+            let proposedFilenameWithoutExtension = "\(filenameWithoutExtension) (\(count))"
+            proposedPath = downloadsPath.appendingPathComponent(proposedFilenameWithoutExtension).appendingPathExtension(fileExtension)
+        }
+
+        return proposedPath
+    }
+}
+
+protocol DownloadQueueDelegate {
+    func downloadQueue(_ downloadQueue: DownloadQueue, didStartDownload download: Download)
+    func downloadQueue(_ downloadQueue: DownloadQueue, didDownloadCombinedBytes combinedBytesDownloaded: Int64, combinedTotalBytesExpected: Int64?)
+    func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL)
+    func downloadQueue(_ downloadQueue: DownloadQueue, didCompleteWithError error: Error?)
+}
+
+class DownloadQueue {
+    var downloads: [Download]
+
+    var delegate: DownloadQueueDelegate?
+
+    var isEmpty: Bool {
+        return downloads.isEmpty
+    }
+
+    fileprivate var combinedBytesDownloaded: Int64 = 0
+    fileprivate var combinedTotalBytesExpected: Int64?
+    fileprivate var lastDownloadError: Error?
+
+    init() {
+        self.downloads = []
+    }
+
+    func enqueueDownload(_ download: Download) {
+        // Clear the download stats if the queue was empty at the start.
+        if downloads.isEmpty {
+            combinedBytesDownloaded = 0
+            combinedTotalBytesExpected = 0
+            lastDownloadError = nil
+        }
+
+        downloads.append(download)
+        download.delegate = self
+
+        if let totalBytesExpected = download.totalBytesExpected, combinedTotalBytesExpected != nil {
+            combinedTotalBytesExpected! += totalBytesExpected
+        } else {
+            combinedTotalBytesExpected = nil
+        }
+
+        download.resume()
+        delegate?.downloadQueue(self, didStartDownload: download)
+    }
+
+    func cancelAllDownloads() {
+        for download in downloads where !download.isComplete {
+            download.cancel()
+        }
+    }
+}
+
+extension DownloadQueue: DownloadDelegate {
+    func download(_ download: Download, didCompleteWithError error: Error?) {
+        guard let error = error, let index = downloads.index(of: download) else {
+            return
+        }
+
+        lastDownloadError = error
+        downloads.remove(at: index)
+
+        if downloads.isEmpty {
+            delegate?.downloadQueue(self, didCompleteWithError: lastDownloadError)
+        }
+    }
+
+    func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64) {
+        combinedBytesDownloaded += bytesDownloaded
+        delegate?.downloadQueue(self, didDownloadCombinedBytes: combinedBytesDownloaded, combinedTotalBytesExpected: combinedTotalBytesExpected)
+    }
+
+    func download(_ download: Download, didFinishDownloadingTo location: URL) {
+        guard let index = downloads.index(of: download) else {
+            return
+        }
+
+        downloads.remove(at: index)
+        delegate?.downloadQueue(self, download: download, didFinishDownloadingTo: location)
+
+        if downloads.isEmpty {
+            delegate?.downloadQueue(self, didCompleteWithError: lastDownloadError)
+        }
+    }
+}

--- a/Blockzilla/OpenInHelper.swift
+++ b/Blockzilla/OpenInHelper.swift
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import MobileCoreServices
+import PassKit
+import WebKit
+
+struct MIMEType {
+    static let Bitmap = "image/bmp"
+    static let CSS = "text/css"
+    static let GIF = "image/gif"
+    static let JavaScript = "text/javascript"
+    static let JPEG = "image/jpeg"
+    static let HTML = "text/html"
+    static let OctetStream = "application/octet-stream"
+    static let Passbook = "application/vnd.apple.pkpass"
+    static let PDF = "application/pdf"
+    static let PlainText = "text/plain"
+    static let PNG = "image/png"
+    static let WebP = "image/webp"
+    static let Calendar = "text/calendar"
+
+    private static let webViewViewableTypes: [String] = [MIMEType.Bitmap, MIMEType.GIF, MIMEType.JPEG, MIMEType.HTML, MIMEType.PDF, MIMEType.PlainText, MIMEType.PNG, MIMEType.WebP]
+
+    static func canShowInWebView(_ mimeType: String) -> Bool {
+        return webViewViewableTypes.contains(mimeType.lowercased())
+    }
+
+    static func mimeTypeFromFileExtension(_ fileExtension: String) -> String {
+        if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension as CFString, nil)?.takeRetainedValue(), let mimeType = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?.takeRetainedValue() {
+            return mimeType as String
+        }
+
+        return MIMEType.OctetStream
+    }
+}
+
+protocol OpenInHelper {
+    init?(request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: WebViewController)
+    func open()
+}
+
+class OpenPassBookHelper: NSObject, OpenInHelper {
+    fileprivate var url: URL
+
+    fileprivate let browserViewController: WebViewController
+
+    required init?(request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: WebViewController) {
+        guard let mimeType = response.mimeType, mimeType == MIMEType.Passbook, PKAddPassesViewController.canAddPasses(),
+            let responseURL = response.url, !forceDownload else { return nil }
+        self.url = responseURL
+        self.browserViewController = browserViewController
+        super.init()
+    }
+
+    func open() {
+        guard let passData = try? Data(contentsOf: url) else { return }
+
+        do {
+            let pass = try PKPass(data: passData)
+            let passLibrary = PKPassLibrary()
+            if passLibrary.containsPass(pass) {
+                UIApplication.shared.open(pass.passURL!, options: [:])
+            } else {
+                let addController = PKAddPassesViewController(pass: pass)
+                browserViewController.present(addController!, animated: true, completion: nil)
+            }
+        } catch {
+            // display an error
+            let alertController = UIAlertController(
+                title: Strings.UnableToAddPassErrorTitle,
+                message: Strings.UnableToAddPassErrorMessage,
+                preferredStyle: .alert)
+            alertController.addAction(
+                UIAlertAction(title: Strings.UnableToAddPassErrorDismiss, style: .cancel) { (action) in
+                    // Do nothing.
+            })
+            browserViewController.present(alertController, animated: true, completion: nil)
+            return
+        }
+    }
+}
+
+class Strings { }
+
+// errors
+extension Strings {
+    public static let UnableToAddPassErrorTitle = NSLocalizedString("AddPass.Error.Title", value: "Failed to Add Pass", comment: "Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet.")
+    public static let UnableToAddPassErrorMessage = NSLocalizedString("AddPass.Error.Message", value: "An error occured while adding the pass to Wallet. Please try again later.", comment: "Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.")
+    public static let UnableToAddPassErrorDismiss = NSLocalizedString("AddPass.Error.Dismiss", value: "OK", comment: "Button to dismiss the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.")
+}

--- a/Search/SearchPlugins/DownloadQueue.swift
+++ b/Search/SearchPlugins/DownloadQueue.swift
@@ -1,0 +1,190 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+private let downloadOperationQueue = OperationQueue()
+
+protocol DownloadDelegate {
+    func download(_ download: Download, didCompleteWithError error: Error?)
+    func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64)
+    func download(_ download: Download, didFinishDownloadingTo location: URL)
+}
+
+class Download: NSObject {
+    let preflightResponse: URLResponse
+    let request: URLRequest
+
+    let mimeType: String
+    let filename: String
+
+    var delegate: DownloadDelegate?
+
+    var state: URLSessionTask.State {
+        return task?.state ?? .suspended
+    }
+
+    private(set) var totalBytesExpected: Int64?
+    private(set) var bytesDownloaded: Int64
+
+    private(set) var session: URLSession?
+    private(set) var task: URLSessionDownloadTask?
+
+    private(set) var isComplete = false
+
+    init(preflightResponse: URLResponse, request: URLRequest) {
+        self.preflightResponse = preflightResponse
+        self.request = request
+
+        self.mimeType = preflightResponse.mimeType ?? "application/octet-stream"
+        self.filename = preflightResponse.suggestedFilename ?? "unknown"
+
+        self.totalBytesExpected = preflightResponse.expectedContentLength > 0 ? preflightResponse.expectedContentLength : nil
+        self.bytesDownloaded = 0
+
+        super.init()
+
+        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: downloadOperationQueue)
+        self.task = session?.downloadTask(with: request)
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+
+    func resume() {
+        task?.resume()
+    }
+}
+
+extension Download: URLSessionTaskDelegate, URLSessionDownloadDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        delegate?.download(self, didCompleteWithError: error)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        bytesDownloaded = totalBytesWritten
+        totalBytesExpected = totalBytesExpectedToWrite
+
+        delegate?.download(self, didDownloadBytes: bytesWritten)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        do {
+            let destination = try uniqueDownloadPathForFilename(filename)
+            try FileManager.default.moveItem(at: location, to: destination)
+            isComplete = true
+            delegate?.download(self, didFinishDownloadingTo: destination)
+        } catch let error {
+            delegate?.download(self, didCompleteWithError: error)
+        }
+    }
+
+    private func uniqueDownloadPathForFilename(_ filename: String) throws -> URL {
+        let downloadsPath = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false).appendingPathComponent("Downloads")
+
+        let basePath = downloadsPath.appendingPathComponent(filename)
+        let fileExtension = basePath.pathExtension
+        let filenameWithoutExtension = fileExtension.count > 0 ? String(filename.dropLast(fileExtension.count + 1)) : filename
+
+        var proposedPath = basePath
+        var count = 0
+
+        while FileManager.default.fileExists(atPath: proposedPath.path) {
+            count += 1
+
+            let proposedFilenameWithoutExtension = "\(filenameWithoutExtension) (\(count))"
+            proposedPath = downloadsPath.appendingPathComponent(proposedFilenameWithoutExtension).appendingPathExtension(fileExtension)
+        }
+
+        return proposedPath
+    }
+}
+
+protocol DownloadQueueDelegate {
+    func downloadQueue(_ downloadQueue: DownloadQueue, didStartDownload download: Download)
+    func downloadQueue(_ downloadQueue: DownloadQueue, didDownloadCombinedBytes combinedBytesDownloaded: Int64, combinedTotalBytesExpected: Int64?)
+    func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL)
+    func downloadQueue(_ downloadQueue: DownloadQueue, didCompleteWithError error: Error?)
+}
+
+class DownloadQueue {
+    var downloads: [Download]
+
+    var delegate: DownloadQueueDelegate?
+
+    var isEmpty: Bool {
+        return downloads.isEmpty
+    }
+
+    fileprivate var combinedBytesDownloaded: Int64 = 0
+    fileprivate var combinedTotalBytesExpected: Int64?
+    fileprivate var lastDownloadError: Error?
+
+    init() {
+        self.downloads = []
+    }
+
+    func enqueueDownload(_ download: Download) {
+        // Clear the download stats if the queue was empty at the start.
+        if downloads.isEmpty {
+            combinedBytesDownloaded = 0
+            combinedTotalBytesExpected = 0
+            lastDownloadError = nil
+        }
+
+        downloads.append(download)
+        download.delegate = self
+
+        if let totalBytesExpected = download.totalBytesExpected, combinedTotalBytesExpected != nil {
+            combinedTotalBytesExpected! += totalBytesExpected
+        } else {
+            combinedTotalBytesExpected = nil
+        }
+
+        download.resume()
+        delegate?.downloadQueue(self, didStartDownload: download)
+    }
+
+    func cancelAllDownloads() {
+        for download in downloads where !download.isComplete {
+            download.cancel()
+        }
+    }
+}
+
+extension DownloadQueue: DownloadDelegate {
+    func download(_ download: Download, didCompleteWithError error: Error?) {
+        guard let error = error, let index = downloads.index(of: download) else {
+            return
+        }
+
+        lastDownloadError = error
+        downloads.remove(at: index)
+
+        if downloads.isEmpty {
+            delegate?.downloadQueue(self, didCompleteWithError: lastDownloadError)
+        }
+    }
+
+    func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64) {
+        combinedBytesDownloaded += bytesDownloaded
+        delegate?.downloadQueue(self, didDownloadCombinedBytes: combinedBytesDownloaded, combinedTotalBytesExpected: combinedTotalBytesExpected)
+    }
+
+    func download(_ download: Download, didFinishDownloadingTo location: URL) {
+        guard let index = downloads.index(of: download) else {
+            return
+        }
+
+        downloads.remove(at: index)
+        delegate?.downloadQueue(self, download: download, didFinishDownloadingTo: location)
+
+        NotificationCenter.default.post(name: .FileDidDownload, object: location)
+
+        if downloads.isEmpty {
+            delegate?.downloadQueue(self, didCompleteWithError: lastDownloadError)
+        }
+    }
+}


### PR DESCRIPTION
Added and edited the OpenInHelper.swift and DownloadQueue.swift files from the Firefox-iOS project to allow for passes to be downloaded in Focus.

![focuspass](https://user-images.githubusercontent.com/9863339/46510983-4cef6200-c822-11e8-84ec-79110249848f.gif)




