### PR TITLE
Fixes Issue #1393: Fix URL Bar Long Press and Drag

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -332,9 +332,6 @@ class BrowserViewController: UIViewController {
         urlBar.showToolset = showsToolsetInURLBar
         mainContainerView.insertSubview(urlBar, aboveSubview: urlBarContainer)
 
-        let dragInteraction = UIDragInteraction(delegate: self)
-        urlBar.addInteraction(dragInteraction)
-        
         urlBar.snp.makeConstraints { make in
             urlBarTopConstraint = make.top.equalTo(mainContainerView.safeAreaLayoutGuide.snp.top).constraint
             topURLBarConstraints = [
@@ -749,31 +746,7 @@ class BrowserViewController: UIViewController {
     }
 }
 
-extension BrowserViewController: UIDragInteractionDelegate, UIDropInteractionDelegate {
-    func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
-        guard let url = urlBar.url, let itemProvider = NSItemProvider(contentsOf: url) else { return [] }
-        let dragItem = UIDragItem(itemProvider: itemProvider)
-        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.drag, object: TelemetryEventObject.searchBar)
-        return [dragItem]
-    }
-
-    func dragInteraction(_ interaction: UIDragInteraction, previewForLifting item: UIDragItem, session: UIDragSession) -> UITargetedDragPreview? {
-        let params = UIDragPreviewParameters()
-        params.backgroundColor = UIColor.clear
-        return UITargetedDragPreview(view: urlBar.draggableUrlTextView, parameters: params)
-    }
- 
-    func dragInteraction(_ interaction: UIDragInteraction, sessionDidMove session: UIDragSession) {
-        for item in session.items {
-            item.previewProvider = {
-                guard let url = self.urlBar.url else {
-                    return UIDragPreview(view: UIView())
-                }
-                return UIDragPreview(for: url)
-            }
-        }
-    }
-    
+extension BrowserViewController: UIDropInteractionDelegate {
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
         return session.canLoadObjects(ofClass: URL.self)
     }

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -72,7 +72,7 @@ class URLBar: UIView {
         addGestureRecognizer(singleTap)
 
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(urlBarDidLongPress))
-        self.addGestureRecognizer(longPress)
+        textAndLockContainer.addGestureRecognizer(longPress)
         
         addSubview(toolset.backButton)
         addSubview(toolset.forwardButton)

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -73,6 +73,9 @@ class URLBar: UIView {
 
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(urlBarDidLongPress))
         textAndLockContainer.addGestureRecognizer(longPress)
+
+        let dragInteraction = UIDragInteraction(delegate: self)
+        textAndLockContainer.addInteraction(dragInteraction)
         
         addSubview(toolset.backButton)
         addSubview(toolset.forwardButton)
@@ -794,6 +797,33 @@ extension URLBar: AutocompleteTextFieldDelegate {
 
         delegate?.urlBar(self, didEnterText: text)
     }
+}
+
+extension URLBar: UIDragInteractionDelegate {
+    func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+        guard let url = url, let itemProvider = NSItemProvider(contentsOf: url) else { return [] }
+        let dragItem = UIDragItem(itemProvider: itemProvider)
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.drag, object: TelemetryEventObject.searchBar)
+        return [dragItem]
+    }
+    
+    func dragInteraction(_ interaction: UIDragInteraction, previewForLifting item: UIDragItem, session: UIDragSession) -> UITargetedDragPreview? {
+        let params = UIDragPreviewParameters()
+        params.backgroundColor = UIColor.clear
+        return UITargetedDragPreview(view: draggableUrlTextView, parameters: params)
+    }
+    
+    func dragInteraction(_ interaction: UIDragInteraction, sessionDidMove session: UIDragSession) {
+        for item in session.items {
+            item.previewProvider = {
+                guard let url = self.url else {
+                    return UIDragPreview(view: UIView())
+                }
+                return UIDragPreview(for: url)
+            }
+        }
+    }
+
 }
 
 private class URLTextField: AutocompleteTextField {


### PR DESCRIPTION
Fixes [issue 1393](https://github.com/mozilla-mobile/focus-ios/issues/1393)

Previously, the entire `URLBar` was assigned a `UILongPressGestureRecognizer` and a `UIDragInteraction`. This is bad because it can clash with other gestures - namely, the reload button's `UILongPressGestureRecognizer`.

Since the two `URLBar` methods are intended for the text box, I moved both methods to only work when the text box itself is pressed. This also meant moving the `UIDragInteractionDelegate` from the `BrowserViewController` to the `URLBar` in order to access the private text box for the drag interaction.

![aaa 1](https://user-images.githubusercontent.com/18453121/46513937-f5a0c000-c828-11e8-9462-dd8fc2395e04.gif)