### PR TITLE
Fixes Issue #1419 - Fix URLBar Single Tap Gesture Recognizer

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -69,7 +69,7 @@ class URLBar: UIView {
 
         let singleTap = UITapGestureRecognizer(target: self, action: #selector(didSingleTap(sender:)))
         singleTap.numberOfTapsRequired = 1
-        addGestureRecognizer(singleTap)
+        textAndLockContainer.addGestureRecognizer(singleTap)
 
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(urlBarDidLongPress))
         textAndLockContainer.addGestureRecognizer(longPress)


### PR DESCRIPTION
Fixes #1419 

Previously, tapping on any part of the ``URLBar`` will begin editing of the url text field. This changes it so that the text field will only start editing when it is tapped. 

![aaa](https://user-images.githubusercontent.com/18453121/46577247-45f65a00-c9b0-11e8-9c0d-7d6d7ece2e0b.gif)
