### PR TITLE
Fixes #1418: Rotation bug on iPhone

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -618,7 +618,7 @@ class BrowserViewController: UIViewController {
             self.urlBar.showToolset = self.showsToolsetInURLBar
 
             if self.homeView == nil && self.scrollBarState != .expanded {
-                self.urlBar.collapseUrlBar(expandAlpha: 0, collapseAlpha: 1)
+                self.hideToolbars()
             }
 
             self.browserToolbar.animateHidden(self.homeView != nil || self.showsToolsetInURLBar, duration: coordinator.transitionDuration, completion: {


### PR DESCRIPTION
Manually collapsing the urlBar leads to buggy constraints, hence why everywhere else in the code uses hideToolBars so they're properly updated. 