### PR TITLE
Closes #1375: Create Multiple search buttons

### DIFF
--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -16,7 +16,7 @@ protocol OverlayViewDelegate: class {
 class OverlayView: UIView {
     weak var delegate: OverlayViewDelegate?
     private var searchButtonGroup = [InsetButton]()
-    private let searchSuggestionsCount = 5
+    private let searchSuggestionsCount = 4 // Five search buttons in total since indexing starts from 0.
     private var presented = false
     private var searchQuery = ""
     private let copyButton = UIButton()
@@ -28,7 +28,7 @@ class OverlayView: UIView {
         super.init(frame: CGRect.zero)
         KeyboardHelper.defaultHelper.addDelegate(delegate: self)
         
-        for _ in 1...self.searchSuggestionsCount {
+        for _ in 0...self.searchSuggestionsCount {
             let searchButton = InsetButton()
             searchButton.isHidden = true
             searchButton.accessibilityIdentifier = "OverlayView.searchButton"
@@ -58,7 +58,7 @@ class OverlayView: UIView {
         self.searchButtonGroup[0].snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(safeAreaLayoutGuide)
         }
-        for i in 1...self.searchSuggestionsCount - 1 {
+        for i in 1...self.searchSuggestionsCount {
             self.searchButtonGroup[i].snp.makeConstraints { make in
                 make.top.equalTo(searchButtonGroup[i - 1].snp.bottom)
                 make.leading.trailing.equalTo(safeAreaLayoutGuide)
@@ -81,7 +81,7 @@ class OverlayView: UIView {
         addSubview(findInPageButton)
         
         findInPageButton.snp.makeConstraints { make in
-            make.top.equalTo(searchButtonGroup[searchSuggestionsCount - 1].snp.bottom)
+            make.top.equalTo(searchButtonGroup[searchSuggestionsCount].snp.bottom)
             make.leading.trailing.equalTo(safeAreaLayoutGuide)
             make.height.equalTo(56)
         }
@@ -206,7 +206,7 @@ class OverlayView: UIView {
             } else if findInPageButton.isHidden {
                 copyButton.snp.remakeConstraints { make in
                     make.leading.trailing.equalTo(safeAreaLayoutGuide)
-                    make.top.equalTo(searchButtonGroup[searchSuggestionsCount - 1].snp.bottom)
+                    make.top.equalTo(searchButtonGroup[searchSuggestionsCount].snp.bottom)
                     make.height.equalTo(56)
                 }
             } else {

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -16,8 +16,7 @@ protocol OverlayViewDelegate: class {
 class OverlayView: UIView {
     weak var delegate: OverlayViewDelegate?
     private var searchButtonGroup = [InsetButton]()
-    // TODO: Decide how many buttons
-    private let searchButtonNumber = 4
+    private let searchSuggestionsCount = 5
     private var presented = false
     private var searchQuery = ""
     private let copyButton = UIButton()
@@ -29,7 +28,7 @@ class OverlayView: UIView {
         super.init(frame: CGRect.zero)
         KeyboardHelper.defaultHelper.addDelegate(delegate: self)
         
-        for _ in 0...self.searchButtonNumber {
+        for _ in 1...self.searchSuggestionsCount {
             let searchButton = InsetButton()
             searchButton.isHidden = true
             searchButton.accessibilityIdentifier = "OverlayView.searchButton"
@@ -59,7 +58,7 @@ class OverlayView: UIView {
         self.searchButtonGroup[0].snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(safeAreaLayoutGuide)
         }
-        for i in 1...self.searchButtonNumber {
+        for i in 1...self.searchSuggestionsCount - 1 {
             self.searchButtonGroup[i].snp.makeConstraints { make in
                 make.top.equalTo(searchButtonGroup[i - 1].snp.bottom)
                 make.leading.trailing.equalTo(safeAreaLayoutGuide)
@@ -82,7 +81,7 @@ class OverlayView: UIView {
         addSubview(findInPageButton)
         
         findInPageButton.snp.makeConstraints { make in
-            make.top.equalTo(searchButtonGroup[searchButtonNumber].snp.bottom)
+            make.top.equalTo(searchButtonGroup[searchSuggestionsCount - 1].snp.bottom)
             make.leading.trailing.equalTo(safeAreaLayoutGuide)
             make.height.equalTo(56)
         }
@@ -207,7 +206,7 @@ class OverlayView: UIView {
             } else if findInPageButton.isHidden {
                 copyButton.snp.remakeConstraints { make in
                     make.leading.trailing.equalTo(safeAreaLayoutGuide)
-                    make.top.equalTo(searchButtonGroup[searchButtonNumber].snp.bottom)
+                    make.top.equalTo(searchButtonGroup[searchSuggestionsCount - 1].snp.bottom)
                     make.height.equalTo(56)
                 }
             } else {

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -15,7 +15,9 @@ protocol OverlayViewDelegate: class {
 
 class OverlayView: UIView {
     weak var delegate: OverlayViewDelegate?
-    private let searchButton = InsetButton()
+    private var searchButtonGroup = [InsetButton]()
+    // TODO: Decide how many buttons
+    private let searchButtonNumber = 4
     private var presented = false
     private var searchQuery = ""
     private let copyButton = UIButton()
@@ -27,17 +29,21 @@ class OverlayView: UIView {
         super.init(frame: CGRect.zero)
         KeyboardHelper.defaultHelper.addDelegate(delegate: self)
         
-        searchButton.isHidden = true
-        searchButton.accessibilityIdentifier = "OverlayView.searchButton"
-        searchButton.alpha = 0
-        searchButton.setImage(#imageLiteral(resourceName: "icon_searchfor"), for: .normal)
-        searchButton.setImage(#imageLiteral(resourceName: "icon_searchfor"), for: .highlighted)
-        searchButton.backgroundColor = UIConstants.colors.background
-        searchButton.titleLabel?.font = UIConstants.fonts.searchButton
-        searchButton.backgroundColor = UIConstants.colors.background
-        setUpOverlayButton(button: searchButton)
-        searchButton.addTarget(self, action: #selector(didPressSearch), for: .touchUpInside)
-        addSubview(searchButton)
+        for _ in 0...self.searchButtonNumber {
+            let searchButton = InsetButton()
+            searchButton.isHidden = true
+            searchButton.accessibilityIdentifier = "OverlayView.searchButton"
+            searchButton.alpha = 0
+            searchButton.setImage(#imageLiteral(resourceName: "icon_searchfor"), for: .normal)
+            searchButton.setImage(#imageLiteral(resourceName: "icon_searchfor"), for: .highlighted)
+            searchButton.backgroundColor = UIConstants.colors.background
+            searchButton.titleLabel?.font = UIConstants.fonts.searchButton
+            searchButton.backgroundColor = UIConstants.colors.background
+            setUpOverlayButton(button: searchButton)
+            searchButton.addTarget(self, action: #selector(didPressSearch), for: .touchUpInside)
+            self.searchButtonGroup.append(searchButton)
+            addSubview(searchButton)
+        }
         
         topBorder.isHidden = true
         topBorder.alpha = 0
@@ -46,12 +52,19 @@ class OverlayView: UIView {
         
         topBorder.snp.makeConstraints { make in
             make.leading.trailing.equalTo(self)
-            make.top.equalTo(searchButton.snp.top)
+            make.top.equalTo(searchButtonGroup[0].snp.top)
             make.height.equalTo(1)
         }
 
-        searchButton.snp.makeConstraints { make in
+        self.searchButtonGroup[0].snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(safeAreaLayoutGuide)
+        }
+        for i in 1...self.searchButtonNumber {
+            self.searchButtonGroup[i].snp.makeConstraints { make in
+                make.top.equalTo(searchButtonGroup[i - 1].snp.bottom)
+                make.leading.trailing.equalTo(safeAreaLayoutGuide)
+                make.height.equalTo(56)
+            }
         }
         
         let padding = UIConstants.layout.searchButtonInset
@@ -69,7 +82,7 @@ class OverlayView: UIView {
         addSubview(findInPageButton)
         
         findInPageButton.snp.makeConstraints { make in
-            make.top.equalTo(searchButton.snp.bottom)
+            make.top.equalTo(searchButtonGroup[searchButtonNumber].snp.bottom)
             make.leading.trailing.equalTo(safeAreaLayoutGuide)
             make.height.equalTo(56)
         }
@@ -162,10 +175,12 @@ class OverlayView: UIView {
                 }
                 
                 // Show or hide the search button depending on whether there's entered text.
-                if self.searchButton.isHidden != query.isEmpty {
+                if self.searchButtonGroup[0].isHidden != query.isEmpty {
                     let duration = animated ? UIConstants.layout.searchButtonAnimationDuration : 0
                     self.topBorder.animateHidden(query.isEmpty, duration: duration)
-                    self.searchButton.animateHidden(query.isEmpty, duration: duration)
+                    self.searchButtonGroup.forEach { searchButton in
+                        searchButton.animateHidden(query.isEmpty, duration: duration)
+                    }
                     self.findInPageButton.animateHidden(query.isEmpty || hideFindInPage, duration: duration, completion: {
                         self.updateCopyConstraint(showCopyButton: showCopyButton)
                     })
@@ -173,7 +188,9 @@ class OverlayView: UIView {
                     self.updateCopyConstraint(showCopyButton: showCopyButton)
                 }
 
-                self.setAttributedButtonTitle(phrase: query, button: self.searchButton, localizedStringFormat: UIConstants.strings.searchButton)
+                self.searchButtonGroup.forEach { searchButton in
+                    self.setAttributedButtonTitle(phrase: query, button: searchButton, localizedStringFormat: UIConstants.strings.searchButton)
+                }
                 self.setAttributedButtonTitle(phrase: query, button: self.findInPageButton, localizedStringFormat: UIConstants.strings.findInPageButton)
             }
         }
@@ -182,7 +199,7 @@ class OverlayView: UIView {
     fileprivate func updateCopyConstraint(showCopyButton: Bool) {
         if showCopyButton {
             copyButton.isHidden = false
-            if searchButton.isHidden || searchQuery.isEmpty {
+            if searchButtonGroup[0].isHidden || searchQuery.isEmpty {
                 copyButton.snp.remakeConstraints { make in
                     make.top.leading.trailing.equalTo(safeAreaLayoutGuide)
                     make.height.equalTo(56)
@@ -190,7 +207,7 @@ class OverlayView: UIView {
             } else if findInPageButton.isHidden {
                 copyButton.snp.remakeConstraints { make in
                     make.leading.trailing.equalTo(safeAreaLayoutGuide)
-                    make.top.equalTo(searchButton.snp.bottom)
+                    make.top.equalTo(searchButtonGroup[searchButtonNumber].snp.bottom)
                     make.height.equalTo(56)
                 }
             } else {


### PR DESCRIPTION
I attempted to create multiple search buttons by replacing a single search button with a list of button groups in "OverlayView.swift".
The following is what I got:
<img width="372" alt="screen shot 2018-10-08 at 11 31 37 am" src="https://user-images.githubusercontent.com/25020683/46618680-3715c180-caee-11e8-858e-0e6931d038a4.png">
 
<img width="378" alt="screen shot 2018-10-08 at 11 31 53 am" src="https://user-images.githubusercontent.com/25020683/46618691-3b41df00-caee-11e8-91c7-c2f8cae9952a.png">

There are some possible issues:
1. Since I am new to Swift, I am not familiar with syntactic sugar or some smart tricks. Some of my codes are C style, so they seemed to be inconsistent with other parts. For example, I think Swift developer hardly use for-loops, is there any smart trick?
2. So far I have hardcoded how many search buttons we want by specifying a private variable named "searchButtonNumber" on line 20 in "OverlayView" class. The default value is 4. (5 buttons in total since indexes start with 0. Again, is it normal in Swift or should I start with 1?) In most devices, this number works well, but I think the final goal is to create a dynamic list. Any suggestions on this part?
3. I noticed that original searchButton has an identifier named "OverlayView.searchButton", which is called during testing. This part might be overwritten in the future.
