### PR TITLE
Fixes 1434 - Google AMP Copy Address

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1157,6 +1157,11 @@ extension BrowserViewController: OverlayViewDelegate {
 }
 
 extension BrowserViewController: WebControllerDelegate {
+
+    func webController(_ controller: WebController, didOpenAMPURL url: URL) {
+        urlBar.url = url
+    }
+
     func webControllerDidStartProvisionalNavigation(_ controller: WebController) {
         urlBar.dismiss()
         updateFindInPageVisibility(visible: false)

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -38,6 +38,7 @@ protocol WebControllerDelegate: class {
     func webControllerShouldScrollToTop(_ controller: WebController) -> Bool
     func webController(_ controller: WebController, didUpdateTrackingProtectionStatus trackingStatus: TrackingProtectionStatus)
     func webController(_ controller: WebController, didUpdateFindInPageResults currentResult: Int?, totalResults: Int?)
+    func webController(_ controller: WebController, didOpenAMPURL url: URL)
 }
 
 class WebViewController: UIViewController, WebController {
@@ -87,6 +88,7 @@ class WebViewController: UIViewController, WebController {
         trackingProtectionStatus = .on(TPPageStats())
         browserView = WKWebView()
         setupWebview()
+        self.browserView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
     }
 
     // Browser proxy methods
@@ -197,6 +199,18 @@ class WebViewController: UIViewController, WebController {
     
     func evaluate(_ javascript: String, completion: ((Any?, Error?) -> Void)?) {
         browserView.evaluateJavaScript(javascript, completionHandler: completion)
+    }
+
+    override func viewDidLoad() {
+        self.browserView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
+    }
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == #keyPath(WKWebView.url) {
+            if let url = browserView.url {
+                self.delegate?.webController(self, didOpenAMPURL: url)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This fix a problem when the user was trying to copy the address of a google amp website and it doesn't show the correct URL.


