### PR TITLE
Add safeAreaLayoutGuide to SiriFavoriteViewController

### DIFF
--- a/Blockzilla/SiriFavoriteViewController.swift
+++ b/Blockzilla/SiriFavoriteViewController.swift
@@ -69,19 +69,20 @@ class SiriFavoriteViewController: UIViewController {
         
         inputLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(UIConstants.layout.siriUrlSectionPadding)
-            make.trailing.equalToSuperview()
-            make.leading.equalToSuperview().offset(UIConstants.layout.settingsTextPadding)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading).offset(UIConstants.layout.settingsTextPadding)
         }
         
         textInput.snp.makeConstraints { make in
             make.height.equalTo(UIConstants.layout.settingsSectionHeight)
-            make.leading.trailing.equalToSuperview()
+            make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing)
             make.top.equalTo(inputLabel.snp.bottom).offset(UIConstants.layout.settingsTextPadding)
         }
         
         inputDescription.snp.makeConstraints { make in
             make.top.equalTo(textInput.snp.bottom).offset(UIConstants.layout.settingsTextPadding)
-            make.leading.equalToSuperview().offset(UIConstants.layout.settingsTextPadding)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading).offset(UIConstants.layout.settingsTextPadding)
         }
         
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: UIConstants.strings.cancel, style: .plain, target: self, action: #selector(SiriFavoriteViewController.cancelTapped))


### PR DESCRIPTION
Before
<img width="964" alt="screen shot 2018-10-21 at 3 02 34" src="https://user-images.githubusercontent.com/17464685/47258954-fe0e2180-d4dd-11e8-8787-a46c1ffbc2c4.png">
After
<img width="964" alt="screen shot 2018-10-21 at 3 06 06" src="https://user-images.githubusercontent.com/17464685/47258987-4a596180-d4de-11e8-8f50-c4a5e64118a7.png">

