### PR TITLE
Fix overlaps for #1437

### DIFF
--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -19,15 +19,25 @@ class HomeView: UIView {
     private let tipTitleLabel = SmartLabel()
     private let tipDescriptionLabel = SmartLabel()
     private let shieldLogo = UIImageView()
+    private let textLogo = UIImageView()
     
     let toolbar = HomeViewToolbar()
     let trackerStatsShareButton = UIButton()
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if UIDevice.current.orientation.isLandscape {
+            hideTextLogo()
+        } else {
+            showTextLogo()
+        }
+    }
     
     init(tipManager: TipManager? = nil) {
         super.init(frame: CGRect.zero)
         
         let wordmark = AppInfo.config.wordmark
-        let textLogo = UIImageView(image: wordmark)
+        textLogo.image = wordmark
         addSubview(textLogo)
 
         privateBrowsingDescription.textColor = .white
@@ -112,7 +122,7 @@ class HomeView: UIView {
         
         tipTitleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.bottom.equalTo(tipDescriptionLabel.snp.top).offset(-UIConstants.layout.homeViewTextOffset)
+            make.bottom.equalTo(tipDescriptionLabel.snp.top).offset(UIConstants.layout.homeViewTextOffset)
         }
         
         toolbar.snp.makeConstraints { make in
@@ -178,6 +188,14 @@ class HomeView: UIView {
         shieldLogo.isHidden = true
         trackerStatsLabel.isHidden = true
         trackerStatsShareButton.isHidden = true
+    }
+    
+    func hideTextLogo() {
+        textLogo.isHidden = true
+    }
+    
+    func showTextLogo() {
+        textLogo.isHidden = false
     }
     
     func showTextTip(_ tip: TipManager.Tip) {

--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -24,17 +24,15 @@ class HomeView: UIView {
     let toolbar = HomeViewToolbar()
     let trackerStatsShareButton = UIButton()
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        if UIDevice.current.orientation.isLandscape {
-            hideTextLogo()
-        } else {
-            showTextLogo()
-        }
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     init(tipManager: TipManager? = nil) {
         super.init(frame: CGRect.zero)
+        
+        rotated()
+        NotificationCenter.default.addObserver(self, selector: #selector(HomeView.rotated), name: UIDevice.orientationDidChangeNotification, object: nil)
         
         let wordmark = AppInfo.config.wordmark
         textLogo.image = wordmark
@@ -108,7 +106,7 @@ class HomeView: UIView {
         }
         
         tipView.snp.makeConstraints { make in
-            make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.shareTrackersBottomOffset)
+            make.centerY.equalToSuperview().offset(UIConstants.layout.shareTrackersHeight/3)
             make.height.equalTo(UIConstants.layout.shareTrackersHeight)
             make.centerX.equalToSuperview()
             make.width.greaterThanOrEqualTo(280)
@@ -190,11 +188,19 @@ class HomeView: UIView {
         trackerStatsShareButton.isHidden = true
     }
     
-    func hideTextLogo() {
+    @objc private func rotated() {
+        if UIDevice.current.orientation.isLandscape {
+            hideTextLogo()
+        } else {
+            showTextLogo()
+        }
+    }
+    
+    private func hideTextLogo() {
         textLogo.isHidden = true
     }
     
-    func showTextLogo() {
+    private func showTextLogo() {
         textLogo.isHidden = false
     }
     

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -213,7 +213,7 @@ struct UIConstants {
         static let separatorHeight: CGFloat = 0.5
         static let shareTrackersBottomOffset: CGFloat = -20
         static let shareTrackersHeight: CGFloat = 36
-        static let homeViewTextOffset: CGFloat = 5
+        static let homeViewTextOffset: CGFloat = 3
         static let homeViewLabelMinimumScale: CGFloat = 0.65
     }
 

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -213,7 +213,7 @@ struct UIConstants {
         static let separatorHeight: CGFloat = 0.5
         static let shareTrackersBottomOffset: CGFloat = -20
         static let shareTrackersHeight: CGFloat = 36
-        static let homeViewTextOffset: CGFloat = 3
+        static let homeViewTextOffset: CGFloat = 5
         static let homeViewLabelMinimumScale: CGFloat = 0.65
     }
 


### PR DESCRIPTION
Fix for #1437
I made the Firefox Focus logo hidden in the landscape orientation and moved the tips a little and made it more compact to accommodate for different keyboards

Before
<img width="889" alt="screen shot 2018-10-21 at 11 53 41" src="https://user-images.githubusercontent.com/17464685/47262642-6fbf8d00-d529-11e8-8c72-44c7e23ad376.png">
<img width="964" alt="screen shot 2018-10-21 at 11 54 12" src="https://user-images.githubusercontent.com/17464685/47262645-7bab4f00-d529-11e8-9fee-da961e69ffbd.png">
<img width="1026" alt="screen shot 2018-10-21 at 11 54 40" src="https://user-images.githubusercontent.com/17464685/47262646-7d751280-d529-11e8-99f8-c379b1749edb.png">

After
<img width="889" alt="screen shot 2018-10-21 at 11 50 43" src="https://user-images.githubusercontent.com/17464685/47262679-5c60f180-d52a-11e8-91e0-60f7f082f054.png">
<img width="964" alt="screen shot 2018-10-21 at 11 50 36" src="https://user-images.githubusercontent.com/17464685/47262680-5e2ab500-d52a-11e8-9ee2-6383572dc88e.png">
<img width="1026" alt="screen shot 2018-10-21 at 11 50 29" src="https://user-images.githubusercontent.com/17464685/47262683-608d0f00-d52a-11e8-832d-764452858c4e.png">