### PR TITLE
[1433] - Fix dynamic front on settings page

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -49,6 +49,17 @@ class SettingsTableViewAccessoryCell: SettingsTableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         newLabel.numberOfLines = 0
         newLabel.lineBreakMode = .byWordWrapping
+        setupDynamicFont()
+
+        if #available(iOS 10.0, *) {
+            newLabel.adjustsFontForContentSizeCategory = true
+            accessoryLabel.adjustsFontForContentSizeCategory = true
+        } else {
+            NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: nil, queue: nil)  { _ in
+                self.setupDynamicFont()
+            }
+        }
+        
         textLabel?.numberOfLines = 0
         textLabel?.text = " "
 
@@ -85,6 +96,11 @@ class SettingsTableViewAccessoryCell: SettingsTableViewCell {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupDynamicFont() {
+        newLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+        accessoryLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
     }
 }
 


### PR DESCRIPTION
Issue: https://github.com/mozilla-mobile/focus-ios/issues/1433

newLabel and accessoryLabel were not respecting the iOS Dynamic Font properties. This PR adds preferred font to both UILabels and fixes the issue.

This also adds a listener for when the font size changes, since adjustsFontForContentSizeCategory[1] only exists on iOS 10 and Focus has a deployment taget of iOS 9, an if #available was added to handle both situations

[1] https://developer.apple.com/documentation/uikit/uicontentsizecategoryadjusting/1771731-adjustsfontforcontentsizecategor?language=objc