### PR TITLE
Fixes #1269 - Youtube Drag and Drop links bug (#1469)

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -707,6 +707,12 @@ class BrowserViewController: UIViewController {
     private func setNumberOfLifetimeTrackersBlocked(numberOfTrackers: Int) {
         UserDefaults.standard.set(numberOfTrackers, forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
     }
+    
+    func updateURLBar() {
+        if webViewController.url?.absoluteString != "about:blank" {
+            urlBar.url = webViewController.url
+        }
+    }
 }
 
 extension BrowserViewController: UIDropInteractionDelegate {
@@ -1134,20 +1140,19 @@ extension BrowserViewController: WebControllerDelegate {
         browserToolbar.color = .loading
         toggleURLBarBackground(isBright: false)
         showToolbars()
-        
-        if webViewController.url?.absoluteString != "about:blank" {
-            urlBar.url = webViewController.url
-        }
+        updateURLBar()
     }
 
     func webControllerDidFinishNavigation(_ controller: WebController) {
-        if webViewController.url?.absoluteString != "about:blank" {
-            urlBar.url = webViewController.url
-        }
+        updateURLBar()
         urlBar.isLoading = false
         toggleToolbarBackground()
         toggleURLBarBackground(isBright: !urlBar.isEditing)
         urlBar.progressBar.hideProgressBar()
+    }
+    
+    func webControllerURLDidChange(_ controller: WebController) {
+        updateURLBar()
     }
 
     func webController(_ controller: WebController, didFailNavigationWithError error: Error) {

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -27,6 +27,7 @@ protocol WebControllerDelegate: class {
     func webControllerDidStartProvisionalNavigation(_ controller: WebController)
     func webControllerDidStartNavigation(_ controller: WebController)
     func webControllerDidFinishNavigation(_ controller: WebController)
+    func webControllerURLDidChange(_ controller: WebController)
     func webController(_ controller: WebController, didFailNavigationWithError error: Error)
     func webController(_ controller: WebController, didUpdateCanGoBack canGoBack: Bool)
     func webController(_ controller: WebController, didUpdateCanGoForward canGoForward: Bool)
@@ -54,6 +55,7 @@ class WebViewController: UIViewController, WebController {
     private var browserView = WKWebView()
     var onePasswordExtensionItem: NSExtensionItem!
     private var progressObserver: NSKeyValueObservation?
+    private var urlObserver: NSKeyValueObservation?
     private var userAgent: UserAgent?
     private var trackingProtectionStatus = TrackingProtectionStatus.on(TPPageStats()) {
         didSet {
@@ -134,6 +136,10 @@ class WebViewController: UIViewController, WebController {
 
         progressObserver = browserView.observe(\WKWebView.estimatedProgress) { (webView, value) in
             self.delegate?.webController(self, didUpdateEstimatedProgress: webView.estimatedProgress)
+        }
+        
+        urlObserver = browserView.observe(\WKWebView.url, options: .new) { (webview, value) in
+            self.delegate?.webControllerURLDidChange(self)
         }
 
         setupBlockLists()


### PR DESCRIPTION
Issue: https://github.com/mozilla-mobile/focus-ios/issues/1269

A new delegate “webControllerURLDidChange” was added to keep track of when the URL changes since WKWebView’s delegate “didCommit navigation” or “didFinish navigation” might not be triggered when tapping on links.