### PR TITLE
Fixes #1441: Duplicate URL on Gmail sharing

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -913,7 +913,7 @@ extension BrowserViewController: URLBarDelegate {
         let utils = OpenUtils(url: url, webViewController: webViewController)
         let items = PageActionSheetItems(url: url)
         let sharePageItem = PhotonActionSheetItem(title: UIConstants.strings.sharePage, iconString: "icon_openwith_active") { action in
-            let shareVC = utils.buildShareViewController(url: url, printFormatter: self.webViewController.printFormatter)
+            let shareVC = utils.buildShareViewController()
             
             // Exact frame dimensions taken from presentPhotonActionSheet
             shareVC.popoverPresentationController?.sourceView = urlBar.pageActionsButton

--- a/Blockzilla/OpenUtils.swift
+++ b/Blockzilla/OpenUtils.swift
@@ -17,10 +17,8 @@ class OpenUtils: NSObject {
         self.webViewController = webViewController
     }
 
-    func buildShareViewController(url: URL, printFormatter: UIPrintFormatter?) -> UIActivityViewController {
-        var activityItems = [Any]()
-
-        activityItems.append(selectedURL)
+    func buildShareViewController() -> UIActivityViewController {
+        var activityItems: [Any] = [selectedURL]
 
         let printInfo = UIPrintInfo(dictionary: nil)
         printInfo.jobName = selectedURL.absoluteString

--- a/Blockzilla/OpenUtils.swift
+++ b/Blockzilla/OpenUtils.swift
@@ -18,20 +18,18 @@ class OpenUtils: NSObject {
     }
 
     func buildShareViewController(url: URL, printFormatter: UIPrintFormatter?) -> UIActivityViewController {
-        var activityItems: [Any] = [url]
-        
-        activityItems.append(self)
+        var activityItems = [Any]()
 
-        if let printFormatter = printFormatter {
-            let printInfo = UIPrintInfo(dictionary: nil)
-            printInfo.jobName = url.absoluteString
-            printInfo.outputType = .general
-            activityItems.append(printInfo)
+        activityItems.append(selectedURL)
 
-            let renderer = UIPrintPageRenderer()
-            renderer.addPrintFormatter(printFormatter, startingAtPageAt: 0)
-            activityItems.append(renderer)
-        }
+        let printInfo = UIPrintInfo(dictionary: nil)
+        printInfo.jobName = selectedURL.absoluteString
+        printInfo.outputType = .general
+        activityItems.append(printInfo)
+
+        let renderer = UIPrintPageRenderer()
+        renderer.addPrintFormatter(webViewController.printFormatter, startingAtPageAt: 0)
+        activityItems.append(renderer)
 
         if let title = webViewController.pageTitle {
             activityItems.append(TitleActivityItemProvider(title: title))


### PR DESCRIPTION
Please test on device for all share sheet actions to make sure this doesn't break any of them.