### PR TITLE
[1441] - Fix duplicated URL on Gmail sharing

### DIFF
--- a/Blockzilla/OpenUtils.swift
+++ b/Blockzilla/OpenUtils.swift
@@ -18,9 +18,7 @@ class OpenUtils: NSObject {
     }
 
     func buildShareViewController(url: URL, printFormatter: UIPrintFormatter?) -> UIActivityViewController {
-        var activityItems: [Any] = [url]
-        
-        activityItems.append(self)
+        var activityItems: [Any] = [self]
 
         if let printFormatter = printFormatter {
             let printInfo = UIPrintInfo(dictionary: nil)


### PR DESCRIPTION
Issue: https://github.com/mozilla-mobile/focus-ios/issues/1441

Fixes the issue where the Gmail app was displaying the URL twice by removing the extra activity item URL since self is already being used, which also returns the same URL.