### PR TITLE
Fixes #673: Only display whats new for major releases

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -109,10 +109,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
         }
         
         // Don't highlight whats new on a fresh install (prefIntroDone == 0 on a fresh install)
-        if prefIntroDone != 0 && UserDefaults.standard.string(forKey: AppDelegate.prefWhatsNewDone) != AppInfo.shortVersion {
-            
-            let counter = UserDefaults.standard.integer(forKey: AppDelegate.prefWhatsNewCounter)
-            switch counter {
+        if let lastShownWhatsNew = UserDefaults.standard.string(forKey: AppDelegate.prefWhatsNewDone)?.first, let currentMajorRelease = AppInfo.shortVersion.first {
+            if prefIntroDone != 0 && lastShownWhatsNew != currentMajorRelease  {
+
+                let counter = UserDefaults.standard.integer(forKey: AppDelegate.prefWhatsNewCounter)
+                switch counter {
                 case 4:
                     // Shown three times, remove counter
                     UserDefaults.standard.set(AppInfo.shortVersion, forKey: AppDelegate.prefWhatsNewDone)
@@ -120,6 +121,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
                 default:
                     // Show highlight
                     UserDefaults.standard.set(counter+1, forKey: AppDelegate.prefWhatsNewCounter)
+                }
             }
         }
         

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -627,8 +627,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     
     @objc private func whatsNewClicked() {
         highlightsButton?.tintColor = UIColor.white
-        
-        guard let url = SupportUtils.URLForTopic(topic: "whats-new-focus-ios-7") else { return }
+
+        guard let versionNumber = AppInfo.shortVersion.first,
+        let url = SupportUtils.URLForTopic(topic: "whats-new-focus-ios-" + "\(versionNumber)") else { return }
         navigationController?.pushViewController(SettingsContentViewController(url: url), animated: true)
         
         whatsNew.didShowWhatsNew()


### PR DESCRIPTION
This is not quite as flexible as @Sdaswani had originally described in the issue, but based on how Mozilla operates for what's new (always having the same support URL structure, only having support articles for major releases), I think that this is a simple solution that will resolve one of our most complained about issues on the App Store (the what's new indicator showing when the article hasn't changed) and something that personally drives me insane. While this solution isn't infinitely flexible, it would correctly support every what's new Focus has ever had, so I think it's a justified solution.

This also improves developer workflow as it automatically supports the latest major release URL, so instead of having to change it for every single release, developers would only have to change it if there was a new URL that broke the historic trend of every single release Focus has ever had. 