### PR TITLE
Fix Issue 1478 - Fixes webview after settings button is tapped

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -535,8 +535,6 @@ class BrowserViewController: UIViewController {
     fileprivate func showSettings(shouldScrollToSiri: Bool = false) {
         guard let modalDelegate = modalDelegate else { return }
         
-        urlBar.shouldPresent = false
-        
         let settingsViewController = SettingsViewController(searchEngineManager: searchEngineManager, whatsNew: browserToolbar.toolset, shouldScrollToSiri: shouldScrollToSiri)
         let settingsNavController = UINavigationController(rootViewController: settingsViewController)
         settingsNavController.modalPresentationStyle = .formSheet


### PR DESCRIPTION
Fixes [issue #1478](https://github.com/mozilla-mobile/focus-ios/issues/1478)

The bug happens because `urlBar.shouldPresent` is set to false when opening the settings popup ([see here](https://github.com/mozilla-mobile/focus-ios/blob/316bf0a9a03d171cccab17489fe8385a209cebc7/Blockzilla/BrowserViewController.swift#L538)). When this variable is set to false, the `urlBar` object never calls the [delegate method to activate](https://github.com/mozilla-mobile/focus-ios/blob/316bf0a9a03d171cccab17489fe8385a209cebc7/Blockzilla/URLBar.swift#L815). 

The reason for this was to [prevent the application from displaying the overlay when launching from an extension](https://github.com/mozilla-mobile/focus-ios/pull/379). 

After the settings view was [changed to be presented as a modal](https://github.com/mozilla-mobile/focus-ios/commit/00c29d234baa6bcb9c55e3ef2bf7372f7b637e02#diff-93f8e8b1353c1dabb447526fe4178103), this functionality became unneeded so I removed it.

![fix 1](https://user-images.githubusercontent.com/18453121/47532384-3450f580-d87e-11e8-9b8d-3f7f0cf95d6f.gif)
