### PR TITLE
Modifies Autocomplete URL Language

### DIFF
--- a/Blockzilla/AutocompleteCustomUrlViewController.swift
+++ b/Blockzilla/AutocompleteCustomUrlViewController.swift
@@ -49,7 +49,7 @@ class AutocompleteCustomUrlViewController: UIViewController {
     override func viewDidLoad() {
         view.backgroundColor = UIConstants.colors.background
 
-        title = UIConstants.strings.autocompleteCustomSectionLabel
+        title = UIConstants.strings.autocompleteManageSitesLabel
 
         tableView.dataSource = self
         tableView.delegate = self

--- a/Blockzilla/AutocompleteSettingViewController.swift
+++ b/Blockzilla/AutocompleteSettingViewController.swift
@@ -38,34 +38,10 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let labelText: String
-        var groupingOffset = 16
-
-        switch section {
-        case 0:
-            labelText = UIConstants.strings.autocompleteDefaultSectionTitle
-            groupingOffset = 3
-        case 1: labelText = UIConstants.strings.autocompleteCustomSectionTitle
-        default: fatalError("No title for section: \(section)")
-        }
-
-        // Hack: We want the header view's margin to match the cells, so we create an empty
-        // cell with a blank space as text to layout the text label. From there, we can define
-        // constraints for our custom label based on the cell's label.
+      
         let cell = UITableViewCell()
         cell.textLabel?.text = " "
         cell.backgroundColor = UIConstants.colors.background
-
-        let label = SmartLabel()
-        label.text = labelText
-        label.textColor = UIConstants.colors.tableSectionHeader
-        label.font = UIConstants.fonts.tableSectionHeader
-        cell.contentView.addSubview(label)
-
-        label.snp.makeConstraints { make in
-            make.leading.trailing.equalTo(cell.textLabel!)
-            make.centerY.equalTo(cell.textLabel!).offset(groupingOffset)
-        }
         return cell
     }
     
@@ -81,7 +57,7 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
         var cell: UITableViewCell
         if (indexPath.section == 0) {
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "enableCell")
-            cell.textLabel?.text = UIConstants.strings.autocompleteLabel
+            cell.textLabel?.text = UIConstants.strings.autocompleteTopSites
             
             let toggle = UISwitch()
             toggle.addTarget(self, action: #selector(defaultToggleSwitched(_:)), for: .valueChanged)
@@ -93,7 +69,7 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
         } else {
             if indexPath.row == 0 {
                 cell = UITableViewCell(style: .subtitle, reuseIdentifier: "enableCell")
-                cell.textLabel?.text = UIConstants.strings.autocompleteLabel
+                cell.textLabel?.text = UIConstants.strings.autocompleteMySites
 
                 let toggle = UISwitch()
                 toggle.addTarget(self, action: #selector(customToggleSwitched(_:)), for: .valueChanged)
@@ -105,7 +81,7 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
                 cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "newDomainCell")
                 cell.accessoryType = .disclosureIndicator
                 cell.accessibilityIdentifier = "customURLS"
-                cell.textLabel?.text = UIConstants.strings.autocompleteCustomSectionLabel
+                cell.textLabel?.text = UIConstants.strings.autocompleteManageSitesLabel
             }
         }
         
@@ -130,7 +106,7 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
         case 0:
             let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
             let learnMore = NSAttributedString(string: UIConstants.strings.learnMore, attributes: [.foregroundColor : UIConstants.colors.settingsLink])
-            let subtitle = NSMutableAttributedString(string: String(format: UIConstants.strings.autocompleteDefaultDescription, AppInfo.productName), attributes: [.foregroundColor : UIConstants.colors.settingsDetailLabel])
+            let subtitle = NSMutableAttributedString(string: String(format: UIConstants.strings.autocompleteTopSitesDesc, AppInfo.productName), attributes: [.foregroundColor : UIConstants.colors.settingsDetailLabel])
             let space = NSAttributedString(string: " ", attributes: [:])
             subtitle.append(space)
             subtitle.append(learnMore)
@@ -148,7 +124,7 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
         case 1:
             let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
             let learnMore = NSAttributedString(string: UIConstants.strings.learnMore, attributes: [.foregroundColor : UIConstants.colors.settingsLink])
-            let subtitle = NSMutableAttributedString(string: String(format: UIConstants.strings.autocompleteCustomDescription, AppInfo.productName), attributes: [.foregroundColor : UIConstants.colors.settingsDetailLabel])
+            let subtitle = NSMutableAttributedString(string: String(format: UIConstants.strings.autocompleteManageSitesDesc, AppInfo.productName), attributes: [.foregroundColor : UIConstants.colors.settingsDetailLabel])
             let space = NSAttributedString(string: " ", attributes: [:])
             subtitle.append(space)
             subtitle.append(learnMore)

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -376,13 +376,14 @@ struct UIConstants {
         static let done = NSLocalizedString("Done", value: "Done", comment: "Label on button to complete edits")
         static let cancelLabel = NSLocalizedString("Cancel", value: "Cancel", comment: "Label on button to cancel edits")
 
-        static let autocompleteLabel = NSLocalizedString("Autocomplete.defaultLabel", value: "Autocomplete", comment: "Label for enabling or disabling autocomplete")
+        static let autocompleteMySites = NSLocalizedString("Autocomplete.mySites", value: "My Sites", comment: "Label for enabling or disabling autocomplete")
+        static let autocompleteTopSites = NSLocalizedString("Autocomplete.topSites", value: "Top Sites", comment: "Label for enabling or disabling top sites")
         static let autocompleteDefaultSectionTitle = NSLocalizedString("Autocomplete.defaultTitle", value: "DEFAULT URL LIST", comment: "Title for the default URL list section")
-        static let autocompleteDefaultDescription = NSLocalizedString("Autocomplete.defaultDescriptoin", value: "Enable to have %@ autocomplete over 450 popular URLs in the address bar.", comment: "Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.")
+        static let autocompleteTopSitesDesc = NSLocalizedString("Autocomplete.defaultDescriptoin", value: "Enable to have %@ autocomplete over 450 popular URLs in the address bar.", comment: "Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.")
 
         static let autocompleteCustomSectionTitle = NSLocalizedString("Autocomplete.customTitle", value: "CUSTOM URL LIST", comment: "Title for the default URL list section")
-        static let autocompleteCustomSectionLabel = NSLocalizedString("Autocomplete.customLabel", value: "Custom URLs", comment: "Label for button taking you to your custom Autocomplete URL list")
-        static let autocompleteCustomDescription = NSLocalizedString("Autocomplete.customDescriptoin", value: "Add and manage custom autocomplete URLs.", comment: "Description for adding and managing custom autocomplete URLs")
+        static let autocompleteManageSitesLabel = NSLocalizedString("Autocomplete.manageSites", value: "Manage Sites", comment: "Label for button taking you to your custom Autocomplete URL list")
+        static let autocompleteManageSitesDesc = NSLocalizedString("Autocomplete.mySitesDesc", value: "Enable to have %@ autocomplete your favorite URLs.", comment: "Description for adding and managing custom autocomplete URLs")
         static let autocompleteCustomEnabled = NSLocalizedString("Autocomplete.enabled", value: "Enabled", comment: "label describing URL Autocomplete as enabled")
         static let autocompleteCustomDisabled = NSLocalizedString("Autocomplete.disabled", value: "Disabled", comment: "label describing URL Autocomplete as disabled")
 


### PR DESCRIPTION
Updates text to remove the CUSTOM URL and DEFAULT URL LIST section
texts and adds a new UIConstant string autocompleteTopSites for the switch
in the default URL list section. Additionally, modifies the custom URL list
items text from Autocomplete to My Sites.

Fixes: https://github.com/mozilla-mobile/focus-ios/issues/1387