### PR TITLE
Fixes #1455: Fix Google AMP issues

### DIFF
--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -431,5 +431,6 @@ struct UIConstants {
         static let siriEraseTipDescription = "Add Siri shortcut"
         static let shareTrackersTipTitle = "%@ trackers blocked so far"
         static let encodingNameUTF8 = "utf-8"
+        static let googleAmpURLPrefix = "https://www.google.com/amp/s/"
     }
 }


### PR DESCRIPTION
Note: these changes were largely inspired by how Firefox iOS handles these WebView keyValue changes. Their code can be found [here](https://github.com/mozilla-mobile/firefox-ios/blob/6fb111410b9afd78e8ed4a0eb9d184e729d21f8a/Client/Frontend/Browser/BrowserViewController.swift#L840).

In the future we should update our logic to observe the rest of the KVO's they do, but we want to push a hotfix for this, so I'm trying to keep the diff count small.