### PR TITLE
Modifies WKWebView to Use NonPersistant DataStore

### DIFF
--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -58,7 +58,7 @@ class WebViewController: UIViewController, WebController {
     
     weak var delegate: WebControllerDelegate?
 
-    private var browserView = WKWebView()
+    private var browserView: WKWebView!
     var onePasswordExtensionItem: NSExtensionItem!
     private var progressObserver: NSKeyValueObservation?
     private var urlObserver: NSKeyValueObservation?
@@ -98,7 +98,6 @@ class WebViewController: UIViewController, WebController {
         browserView.navigationDelegate = nil
         browserView.removeFromSuperview()
         trackingProtectionStatus = .on(TPPageStats())
-        browserView = WKWebView()
         setupWebview()
         self.browserView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
     }
@@ -133,6 +132,10 @@ class WebViewController: UIViewController, WebController {
     func stop() { browserView.stopLoading() }
 
     private func setupWebview() {
+        let wvConfig = WKWebViewConfiguration()
+        wvConfig.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        browserView = WKWebView(frame: .zero, configuration: wvConfig)
+        
         browserView.allowsBackForwardNavigationGestures = true
         browserView.allowsLinkPreview = false
         browserView.scrollView.clipsToBounds = false


### PR DESCRIPTION
Moves the initialization of browserView into the setUpWebView function
and uses a new WkWebView initialization function to specify the
non-persistant configuration. The reset function now just calls the
setUpWebView function and no longer initializes browserView.

Fixes: https://github.com/mozilla-mobile/focus-ios/issues/845