### PR TITLE
Fixes #1523: Fix URL Bar Search text to match a search page when using forward and back navigation

### DIFF
--- a/Blockzilla/SearchHistoryUtils.swift
+++ b/Blockzilla/SearchHistoryUtils.swift
@@ -35,7 +35,17 @@ class SearchHistoryUtils {
         
         if let propertylistSearchesRead = UserDefaults.standard.object(forKey: "searchedHistory") as? [[String:Any]] {
             currentStack = propertylistSearchesRead.compactMap{ textSearched(dictionary: $0) }
-            
+			
+			// Check whether the lastSearch is the current search. If not, remove subsequent searches
+			if let lastSearch = currentStack.last, !lastSearch.isCurrentSearch{
+				for index in 0..<currentStack.count {
+					if currentStack[index].isCurrentSearch{
+						currentStack.removeSubrange(index+1..<currentStack.count)
+						break
+					}
+				}
+			}
+			
             for index in 0..<currentStack.count {
                 currentStack[index].isCurrentSearch = false
             }


### PR DESCRIPTION
This PR contains fix for issue #1523. 

On going to the new search, I added check whether the last search in SearchHistoryUtils stack is the current search. If it is not, it deletes the subsequent searches, so it won't mess up when going back and forward.

**Before:**
![focus-ios-before](https://user-images.githubusercontent.com/26641473/47948179-2cd6bf80-df02-11e8-8c08-9f0c4e527f94.gif)

**After:**
![focus-ios-fix](https://user-images.githubusercontent.com/26641473/47948159-d49fbd80-df01-11e8-9470-42aebc56d510.gif)
