### PR TITLE
Closes #1543: Fix broken UI tests

### DIFF
--- a/ClientTests/UserAgentTests.swift
+++ b/ClientTests/UserAgentTests.swift
@@ -43,7 +43,7 @@ class UserAgentTests: XCTestCase {
         XCTAssertTrue(mockUserDefaults.synchronizeCalled)
         XCTAssertNotNil(mockUserDefaults.registerValue)
         XCTAssertNotNil(mockUserDefaults.string(forKey: "LastFocusVersionNumber"))
-        XCTAssertTrue(((mockUserDefaults.registerValue!["UserAgent"] as? String)?.contains(AppInfo.config.productName))!)
+        XCTAssertTrue(((mockUserDefaults.registerValue!["UserAgent"] as? String)?.contains("FxiOS"))!)
     }
 
     func testGetDesktopUserAgent() {

--- a/XCUITest/SearchProviderTest.swift
+++ b/XCUITest/SearchProviderTest.swift
@@ -43,7 +43,7 @@ class SearchProviderTest: BaseTestCase {
         let toast = app.staticTexts["Toast.label"]
         waitforNoExistence(element: toast)
 
-        XCTAssertTrue(app.tables.cells["MDN"].exists)
+        waitforExistence(element: app.tables.cells["MDN"])
         app.tables.cells["Wikipedia"].tap()
         
         waitforExistence(element: app.tables.cells["SettingsViewController.searchCell"])
@@ -51,7 +51,9 @@ class SearchProviderTest: BaseTestCase {
         
         // enter edit mode
         app.navigationBars.buttons["edit"].tap()
+        waitforExistence(element: app.tables.cells["MDN"].buttons["Delete MDN"])
         app.tables.cells["MDN"].buttons["Delete MDN"].tap()
+        waitforExistence(element: app.tables.cells["MDN"].buttons["Delete"])
         app.tables.cells["MDN"].buttons["Delete"].tap()
         
         // leave edit mode

--- a/XCUITest/SettingAppearanceTest.swift
+++ b/XCUITest/SettingAppearanceTest.swift
@@ -98,6 +98,7 @@ class SettingAppearanceTest: BaseTestCase {
         let reviewCell = app.cells["settingsViewController.rateFocus"]
         let safariApp = XCUIApplication(privateWithPath: nil, bundleID: "com.apple.mobilesafari")!
         
+        app.tables.firstMatch.swipeUp()
         waitforHittable(element: reviewCell)
         reviewCell.tap()
         waitforExistence(element: safariApp)

--- a/XCUITest/UserAgentTest.swift
+++ b/XCUITest/UserAgentTest.swift
@@ -16,11 +16,11 @@ class UserAgentTest: BaseTestCase {
         super.tearDown()
     }
 
-    func testSignUpWithGoogle() {
-        loadWebPage("getpocket.com")
-        let signUpButton = app.webViews.buttons["Sign Up with Google"]
-        waitforExistence(element: signUpButton)
-        signUpButton.tap()
+    func testSignInWithGoogle() {
+        loadWebPage("https://getpocket.com/login?s=homepage/")
+        let signInButton = app.webViews.buttons["Log In with Google"]
+        waitforExistence(element: signInButton)
+        signInButton.tap()
         waitForWebPageLoad()
         waitforNoExistence(element: app.webViews.staticTexts["Error: disallowed_useragent"])
     }


### PR DESCRIPTION
Note: this changes the "Sign Up with Google" test to be "Sign In with Google" since they both use the same Google API endpoint.