### PR TITLE
Fixes #1541: URL Bar displays search instead of www.google.com after selecting search suggestion

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1114,7 +1114,7 @@ extension BrowserViewController: OverlayViewDelegate {
         if let url = searchEngineManager.activeEngine.urlForQuery(query) {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.selectQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
-            submit(url: url)
+            urlBar(urlBar, didSubmitText: query)
             urlBar.url = url
         }
 


### PR DESCRIPTION
This PR contains a fix for issue #1541.

As discussed in the issue, I changed the following line in the function `func overlayView(_ overlayView: OverlayView, didSearchForQuery query: String)`(**focus-ios/Blockzilla/BrowserViewController.swift**):
```
submit(url: url)
```
into
```
urlBar(urlBar, didSubmitText: query)
```

**Before**:
![focus-be4](https://user-images.githubusercontent.com/26641473/48284316-0eeeea80-e42d-11e8-801b-d73fd57f5d3a.gif) 

**After**:
![focus-fix](https://user-images.githubusercontent.com/26641473/48284116-7d7f7880-e42c-11e8-892e-5669c9234fb5.gif)
