### PR TITLE
Fixes #1550: Delete duplicates search suggestions.

### DIFF
--- a/Blockzilla/SearchSuggestClient.swift
+++ b/Blockzilla/SearchSuggestClient.swift
@@ -39,9 +39,8 @@ class SearchSuggestClient {
                 
                 if var suggestions = array[1] as? [String] {
                     if let searchWord = array[0] as? String {
-                        if !suggestions.contains(searchWord) {
-                            suggestions.insert(searchWord, at: 0)
-                        }
+                        suggestions = suggestions.filter { $0 != searchWord }
+                        suggestions.insert(searchWord, at: 0)
                     }
                     callback(suggestions, nil)
                     return

--- a/Blockzilla/SearchSuggestClient.swift
+++ b/Blockzilla/SearchSuggestClient.swift
@@ -39,7 +39,9 @@ class SearchSuggestClient {
                 
                 if var suggestions = array[1] as? [String] {
                     if let searchWord = array[0] as? String {
-                        suggestions.insert(searchWord, at: 0)
+                        if !suggestions.contains(searchWord) {
+                            suggestions.insert(searchWord, at: 0)
+                        }
                     }
                     callback(suggestions, nil)
                     return


### PR DESCRIPTION
Because Search Engine won't return duplicates, handle duplicate search suggestions by checking if the "search word" is already in the suggestions.
This fix might result in possible ordering issue, which I am not sure is desired or not:
<img width="377" alt="screen shot 2018-11-10 at 5 38 36 pm" src="https://user-images.githubusercontent.com/25020683/48306882-7da47480-e50f-11e8-9083-e9bf7a68b67c.png">