### PR TITLE
Fixes #1559: Update search suggestion telemetry

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -362,6 +362,7 @@ extension AppDelegate {
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockOther, withDefaultValue: Settings.getToggle(.blockOther))
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockFonts, withDefaultValue: Settings.getToggle(.blockFonts))
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.biometricLogin, withDefaultValue: Settings.getToggle(.biometricLogin))
+        telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.enableSearchSuggestions, withDefaultValue: Settings.getToggle(.enableSearchSuggestions))
 
         #if DEBUG
             telemetryConfig.updateChannel = "debug"

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -261,10 +261,9 @@ class OverlayView: UIView {
         
         if !Settings.getToggle(.enableSearchSuggestions) { return }
         if sender.getIndex() == 0 {
-            Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.searchSuggestions, object: TelemetryEventObject.searchSuggestionNotSelected)
-        }
-        else {
-            Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.searchSuggestions, object: TelemetryEventObject.searchSuggestionSelected)
+            Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionNotSelected)
+        } else {
+            Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionSelected)
         }
     }
     @objc private func didPressCopy() {

--- a/Blockzilla/SearchSuggestionsPromptView.swift
+++ b/Blockzilla/SearchSuggestionsPromptView.swift
@@ -115,11 +115,11 @@ class SearchSuggestionsPromptView: UIView {
     
     @objc private func didPressDisable() {
         delegate?.searchSuggestionsPromptView(self, didEnable: false)
-        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.searchSuggestions, object: TelemetryEventObject.searchSuggestionsOff)
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionsOff)
     }
     
     @objc private func didPressEnable() {
         delegate?.searchSuggestionsPromptView(self, didEnable: true)
-        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.searchSuggestions, object: TelemetryEventObject.searchSuggestionsOn)
+        Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionsOn)
     }
 }

--- a/Blockzilla/TelemetryIntegration.swift
+++ b/Blockzilla/TelemetryIntegration.swift
@@ -33,7 +33,6 @@ class TelemetryEventMethod {
     public static let drag = "drag"
     public static let drop = "drop"
     public static let siri = "siri"
-    public static let searchSuggestions = "search_suggestions"
 }
 
 class TelemetryEventObject {

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -786,7 +786,7 @@ extension URLBar: AutocompleteTextFieldDelegate {
         delegate?.urlBar(self, didSubmitText: autocompleteTextField.text ?? "")
         
         if Settings.getToggle(.enableSearchSuggestions) {
-            Telemetry.default.recordEvent(TelemetryEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.searchSuggestions, object: TelemetryEventObject.searchSuggestionNotSelected))
+            Telemetry.default.recordEvent(TelemetryEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionNotSelected))
         }
         
         return true


### PR DESCRIPTION
Modified telemetry to use 'click' instead of 'searchSuggestion' as method to more closely match Android.

| Event | category | method | object |
|-------|----------|--------|--------|
|Enable search suggestions from prompt| action | click | search_suggestions_on |
|Disable search suggestions from prompt | action | click | search_suggestions_off |
| Search suggestion selected instead of typed text/autocomplete| action | click | search_suggestion_selected |
| Typed text/autocomplete selected instead of search suggestion | action | click | search_suggestion_not_selected |

**Also added the status of the search suggestions toggle to the core ping.**

