### PR TITLE
Fixes #1473: Fixes constraints on settings table cell

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -60,9 +60,6 @@ class SettingsTableViewAccessoryCell: SettingsTableViewCell {
             }
         }
 
-        textLabel?.numberOfLines = 0
-        textLabel?.text = " "
-
         contentView.addSubview(accessoryLabel)
         contentView.addSubview(newLabel)
         contentView.addSubview(spacerView)
@@ -82,7 +79,7 @@ class SettingsTableViewAccessoryCell: SettingsTableViewCell {
 
         spacerView.snp.makeConstraints { make in
             make.top.bottom.leading.equalToSuperview()
-            make.trailing.equalTo(textLabel!.snp.leading)
+            make.width.equalTo(UIConstants.layout.settingsFirstTitleOffset)
         }
 
         newLabel.snp.makeConstraints { make in


### PR DESCRIPTION
Addresses issue described in: #1473 

Based on the implementation of the table headers, it seems like we can avoid making constraints based on textLabel and instead give the spacerView the same width as used for the table headers. 

Note: Noticed recent changes to master might be causing problems in displaying the settings table cells , created a separate issue for this here: #1592