### PR TITLE
Fixes #1585: Fix autocomplete button

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -798,12 +798,12 @@ extension BrowserViewController: URLBarDelegate {
 
                     if userInputText == trimmedText {
                         let suggestions = suggestions ?? [trimmedText]
-                        self.overlayView.setSearchQuery(suggestions: suggestions, hideFindInPage: isOnHomeView || text.isEmpty)
+                        self.overlayView.setSearchQuery(suggestions: suggestions, hideFindInPage: isOnHomeView || text.isEmpty, hideAddToComplete: true)
                     }
                 })
             }
         } else {
-            overlayView.setSearchQuery(suggestions: [trimmedText], hideFindInPage: isOnHomeView || text.isEmpty)
+            overlayView.setSearchQuery(suggestions: [trimmedText], hideFindInPage: isOnHomeView || text.isEmpty, hideAddToComplete: true)
         }
     }
 
@@ -872,12 +872,12 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidFocus(_ urlBar: URLBar) {
-        overlayView.present()
+        let isOnHomeView = homeView != nil
+        overlayView.present(isOnHomeView: isOnHomeView)
         toggleURLBarBackground(isBright: false)
     }
 
     func urlBarDidActivate(_ urlBar: URLBar) {
-
         UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration, animations: {
             self.topURLBarConstraints.forEach { $0.activate() }
             self.urlBarContainer.alpha = 1

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -203,7 +203,7 @@ class OverlayView: UIView {
         }
     }
 
-    func setSearchQuery(suggestions: [String], hideFindInPage: Bool) {
+    func setSearchQuery(suggestions: [String], hideFindInPage: Bool, hideAddToComplete: Bool) {
         searchQuery = suggestions[0]
         searchSuggestions = searchQuery.isEmpty ? [] : suggestions
         let searchSuggestionsPromptHidden = UserDefaults.standard.bool(forKey: SearchSuggestionsPromptView.respondedToSearchSuggestionsPrompt) || searchQuery.isEmpty
@@ -222,7 +222,7 @@ class OverlayView: UIView {
                 self.updateSearchSuggestionsPrompt(hidden: searchSuggestionsPromptHidden)
 
                 // Hide the autocomplete button on home screen and when the user is typing
-                self.addToAutocompleteButton.animateHidden(self.searchButton.isHidden == self.searchQuery.isEmpty, duration: 0)
+                self.addToAutocompleteButton.animateHidden(hideAddToComplete, duration: 0)
                 self.topBorder.backgroundColor =  searchSuggestionsPromptHidden ? UIConstants.Photon.Grey90.withAlphaComponent(0.4) : UIColor(rgb: 0x42455A)
                 self.updateSearchButtons()
 
@@ -322,15 +322,15 @@ class OverlayView: UIView {
     }
 
     func dismiss() {
-        setSearchQuery(suggestions: [""], hideFindInPage: true)
+        setSearchQuery(suggestions: [""], hideFindInPage: true, hideAddToComplete: true)
         self.isUserInteractionEnabled = false
         animateHidden(true, duration: UIConstants.layout.overlayAnimationDuration) {
             self.isUserInteractionEnabled = true
         }
     }
 
-    func present() {
-        setSearchQuery(suggestions: [""], hideFindInPage: true)
+    func present(isOnHomeView: Bool) {
+        setSearchQuery(suggestions: [""], hideFindInPage: true, hideAddToComplete: false || isOnHomeView)
         self.isUserInteractionEnabled = false
         copyButton.isHidden = false
         addToAutocompleteButton.animateHidden(currentURL.isEmpty, duration: 0)


### PR DESCRIPTION
Trying to fix: #1585.

However, there is a strange case: when the user is on a website, after pressing the url bar and deleting all the texts, both the autocomplete button and the clear button still exist. It seems that the browser view controller doesn't count this action as "enter/clear".
<img width="362" alt="screen shot 2018-11-25 at 8 42 10 pm" src="https://user-images.githubusercontent.com/25020683/48988275-9e192500-f0f2-11e8-9e4c-423729d1898f.png">
<img width="368" alt="screen shot 2018-11-25 at 8 42 37 pm" src="https://user-images.githubusercontent.com/25020683/48988281-aa04e700-f0f2-11e8-88d6-56c429cdec49.png">

It works well if the user presses the clear button or types something first and then deletes everthing.
<img width="365" alt="screen shot 2018-11-25 at 8 45 40 pm" src="https://user-images.githubusercontent.com/25020683/48988355-17b11300-f0f3-11e8-877e-6181ebca24b3.png">

