### PR TITLE
Fixes #1596: Swipe to go back removes search history in url bar

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1017,6 +1017,10 @@ extension BrowserViewController: BrowserToolsetDelegate {
     }
 
     func browserToolsetDidPressBack(_ browserToolset: BrowserToolset) {
+        webViewController.goBack()
+    }
+
+    private func handleNavigationBack() {
         guard let navigatingFromAmpSite = urlBar.url?.absoluteString.hasPrefix(UIConstants.strings.googleAmpURLPrefix) else { return }
 
         // Make sure our navigation is not pushed to the SearchHistoryUtils stack (since it already exists there)
@@ -1025,14 +1029,15 @@ extension BrowserViewController: BrowserToolsetDelegate {
         if !navigatingFromAmpSite {
             SearchHistoryUtils.goBack()
         }
-
-        webViewController.goBack()
     }
 
     func browserToolsetDidPressForward(_ browserToolset: BrowserToolset) {
+        webViewController.goForward()
+    }
+
+    private func handleNavigationForward() {
         // Make sure our navigation is not pushed to the SearchHistoryUtils stack (since it already exists there)
         SearchHistoryUtils.isFromURLBar = true
-        webViewController.goForward()
 
         // Check if we're navigating to an AMP site *after* the URL bar is updated. This is intentionally after the goForward call.
         guard let navigatingToAmpSite = urlBar.url?.absoluteString.hasPrefix(UIConstants.strings.googleAmpURLPrefix) else { return }
@@ -1308,6 +1313,14 @@ extension BrowserViewController: WebControllerDelegate {
         }
 
         return true
+    }
+
+    func webControllerDidNavigateBack(_ controller: WebController) {
+        handleNavigationBack()
+    }
+
+    func webControllerDidNavigateForward(_ controller: WebController) {
+        handleNavigationForward()
     }
 
     func webController(_ controller: WebController, stateDidChange state: BrowserState) {}

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1021,11 +1021,15 @@ extension BrowserViewController: BrowserToolsetDelegate {
     }
 
     private func handleNavigationBack() {
-        guard let navigatingFromAmpSite = urlBar.url?.absoluteString.hasPrefix(UIConstants.strings.googleAmpURLPrefix) else { return }
+        // Check if the previous site we were on was AMP
+        guard let navigatingFromAmpSite = SearchHistoryUtils.pullSearchFromStack()?.hasPrefix(UIConstants.strings.googleAmpURLPrefix) else {
+            return
+        }
 
         // Make sure our navigation is not pushed to the SearchHistoryUtils stack (since it already exists there)
         SearchHistoryUtils.isFromURLBar = true
 
+        // This function is now getting called after our new url is set!!
         if !navigatingFromAmpSite {
             SearchHistoryUtils.goBack()
         }
@@ -1039,7 +1043,7 @@ extension BrowserViewController: BrowserToolsetDelegate {
         // Make sure our navigation is not pushed to the SearchHistoryUtils stack (since it already exists there)
         SearchHistoryUtils.isFromURLBar = true
 
-        // Check if we're navigating to an AMP site *after* the URL bar is updated. This is intentionally after the goForward call.
+        // Check if we're navigating to an AMP site *after* the URL bar is updated. This is intentionally grabbing the NEW url
         guard let navigatingToAmpSite = urlBar.url?.absoluteString.hasPrefix(UIConstants.strings.googleAmpURLPrefix) else { return }
 
         if !navigatingToAmpSite {
@@ -1192,10 +1196,15 @@ extension BrowserViewController: WebControllerDelegate {
         }
     }
 
+    func webControllerDidReload(_ controller: WebController) {
+        SearchHistoryUtils.isReload = true
+    }
+
     func webControllerDidStartNavigation(_ controller: WebController) {
-        if !SearchHistoryUtils.isFromURLBar && !SearchHistoryUtils.isNavigating {
+        if !SearchHistoryUtils.isFromURLBar && !SearchHistoryUtils.isNavigating && !SearchHistoryUtils.isReload {
             SearchHistoryUtils.pushSearchToStack(with: (urlBar.url?.absoluteString)!)
         }
+        SearchHistoryUtils.isReload = false
         SearchHistoryUtils.isNavigating = false
         SearchHistoryUtils.isFromURLBar = false
         urlBar.isLoading = true

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -29,6 +29,7 @@ protocol WebControllerDelegate: class {
     func webControllerDidFinishNavigation(_ controller: WebController)
     func webControllerDidNavigateBack(_ controller: WebController)
     func webControllerDidNavigateForward(_ controller: WebController)
+    func webControllerDidReload(_ controller: WebController)
     func webControllerURLDidChange(_ controller: WebController, url: URL)
     func webController(_ controller: WebController, didFailNavigationWithError error: Error)
     func webController(_ controller: WebController, didUpdateCanGoBack canGoBack: Bool)
@@ -283,13 +284,18 @@ extension WebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         let present: (UIViewController) -> Void = { self.present($0, animated: true, completion: nil) }
 
-        if navigationAction.navigationType == .backForward {
-            let navigatingBack = webView.backForwardList.backList.filter { $0 == currentBackForwardItem }.count == 0
-            if navigatingBack {
-                delegate?.webControllerDidNavigateBack(self)
-            } else {
-                delegate?.webControllerDidNavigateForward(self)
-            }
+        switch navigationAction.navigationType {
+            case .backForward:
+                let navigatingBack = webView.backForwardList.backList.filter { $0 == currentBackForwardItem }.count == 0
+                if navigatingBack {
+                    delegate?.webControllerDidNavigateBack(self)
+                } else {
+                    delegate?.webControllerDidNavigateForward(self)
+                }
+            case .reload:
+                delegate?.webControllerDidReload(self)
+            default:
+                break
         }
 
         currentBackForwardItem = webView.backForwardList.currentItem

--- a/Blockzilla/SearchHistoryUtils.swift
+++ b/Blockzilla/SearchHistoryUtils.swift
@@ -28,6 +28,7 @@ class SearchHistoryUtils {
 
     static var isFromURLBar = false
     static var isNavigating = false
+    static var isReload = false
 
     static func pushSearchToStack(with searchedText: String) {
         var currentStack = [textSearched]()


### PR DESCRIPTION
We were not properly handling forward nor backward navigation when users swiped on the webview. We only handled the cases where the back and forward buttons were pressed. Adding a delegate function that's called when forward or backward navigation is detected means we can have one solution for both situations!