### PR TITLE
Adds Swiftlint Git Pre-Commit Hook

### DIFF
--- a/Blockzilla/IntroViewController.swift
+++ b/Blockzilla/IntroViewController.swift
@@ -296,8 +296,6 @@ class ScrollViewController: UIPageViewController, PageControlDelegate {
             make.width.equalTo(280)
             make.height.equalTo(212)
         }
-        
-        if (introView.alpha == 0) { return }
 
         let titleLabel = UILabel()
         titleLabel.numberOfLines = 2
@@ -326,7 +324,6 @@ class ScrollViewController: UIPageViewController, PageControlDelegate {
         textLabel.textColor = UIConstants.colors.firstRunMessage
         textLabel.font = UIConstants.fonts.firstRunMessage
 
-        if (textLabel.isHidden) { return}
         introView.addSubview(textLabel)
         textLabel.snp.makeConstraints({ (make) -> Void in
             make.top.equalTo(titleLabel.snp.bottom).offset(16)

--- a/Blockzilla/IntroViewController.swift
+++ b/Blockzilla/IntroViewController.swift
@@ -324,6 +324,7 @@ class ScrollViewController: UIPageViewController, PageControlDelegate {
         textLabel.textColor = UIConstants.colors.firstRunMessage
         textLabel.font = UIConstants.fonts.firstRunMessage
 
+        if (textLabel.isHidden) { return}
         introView.addSubview(textLabel)
         textLabel.snp.makeConstraints({ (make) -> Void in
             make.top.equalTo(titleLabel.snp.bottom).offset(16)

--- a/README.md
+++ b/README.md
@@ -33,21 +33,22 @@ Build Instructions for Master
 
 1. Install the latest [Xcode developer tools](https://developer.apple.com/xcode/downloads/) from Apple.
 2. Install [Carthage](https://github.com/Carthage/Carthage#installing-carthage).
-3. Clone the repository:
+3. Install [SwiftLint](https://github.com/realm/SwiftLint).
+4. Clone the repository:
 
   ```shell
   https://github.com/mozilla-mobile/focus-ios.git
   ```
 
-4. Pull in the project dependencies:
+5. Pull in the project dependencies:
 
   ```shell
   cd focus-ios
   ./checkout.sh
   ```
 
-5. Open `Blockzilla.xcodeproj` in Xcode.
-6. Build the `Focus` scheme in Xcode.
+6. Open `Blockzilla.xcodeproj` in Xcode.
+7. Build the `Focus` scheme in Xcode.
 
 Upcoming Release (Version 8.0)
 ------------------

--- a/checkout.sh
+++ b/checkout.sh
@@ -21,4 +21,7 @@ elif [ "$ver" -gt "27" ]; then
     ./build-disconnect3.py
 fi
 
+command -v swiftlint > /dev/null 2>&1 || { echo >&2 "swiftlint is not installed"; exit 1; }
+cp swiftlint.sh .git/hooks/pre-commit
+
 carthage bootstrap --platform iOS

--- a/swiftlint.sh
+++ b/swiftlint.sh
@@ -10,7 +10,7 @@ if [ $? -eq 1 ]; then
 fi
 
 swiftlint autocorrect -- $FILES
-swiftlint lint $FILES
+swiftlint lint --strict $FILES
 RESULT=$?
 git add .
 exit $RESULT

--- a/swiftlint.sh
+++ b/swiftlint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+command -v swiftlint > /dev/null 2>&1 || { echo >&2 "Swiftlint is not installed"; exit 1; }
+
+FILES=$( git diff --cached --diff-filter=d --name-only | grep ".swift$" )
+
+if [ $? -eq 1 ]; then
+	echo "No Staged Files For Linting"
+	exit 0
+fi
+
+swiftlint autocorrect -- $FILES
+swiftlint lint $FILES
+RESULT=$?
+git add .
+exit $RESULT
+
+
+
+


### PR DESCRIPTION
Adds a new bash script file which determines if swiftlint is installed
and runs swiftlint on the staged git files. First run performs an
autocorrect for simple fixes and then a second run of swiftlint
captures the exit status to determine if the commit should be
successful or not. README.md is updated for users to install swiftlint
as a requirement and the checkout script is updated to copy the new
bash script to a pre-commit hook.

Fixes: https://github.com/mozilla-mobile/focus-ios/issues/1546