### PR TITLE
Fixes #1607: Change UI appearance of suggested part of search suggestions

### DIFF
--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -176,15 +176,13 @@ class OverlayView: UIView {
 		let attributedString = NSMutableAttributedString(string: localizedStringFormat, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
 		let phraseString = NSAttributedString(string: phrase, attributes: [.font: UIConstants.fonts.copyButtonQuery,
 																		   .foregroundColor: UIConstants.Photon.Grey10])
-		
 		if phrase != searchQuery {
 			let searchString = NSAttributedString(string: searchQuery, attributes: [.font: UIConstants.fonts.copyButtonQuery,
 																					.foregroundColor: UIConstants.Photon.Grey10])
 			// split suggestion into searchQuery and suggested part
 			let suggestion = phrase.components(separatedBy: searchQuery)
-			
 			// suggestion was split
-			if suggestion.count > 1{
+			if suggestion.count > 1 {
 				let restOfSuggestion = NSAttributedString(string: suggestion[1], attributes: [
 					.foregroundColor: UIConstants.colors.searchSuggestion])
 				attributedString.append(searchString)
@@ -192,7 +190,6 @@ class OverlayView: UIView {
 				return attributedString
 			}
 		}
-		
 		guard let range = attributedString.string.range(of: "%@") else { return phraseString }
 		
 		let replaceRange = NSRange(range, in: attributedString.string)

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -171,35 +171,35 @@ class OverlayView: UIView {
      - Returns: An NSAttributedString with `phrase` localized and styled appropriately.
      
      */
-    func getAttributedButtonTitle(phrase: String,
-                                  localizedStringFormat: String) -> NSAttributedString {
-        let attributedString = NSMutableAttributedString(string: localizedStringFormat, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
-        let phraseString = NSAttributedString(string: phrase, attributes: [.font: UIConstants.fonts.copyButtonQuery,
-                                                                           .foregroundColor: UIConstants.Photon.Grey10])
+	func getAttributedButtonTitle(phrase: String,
+								  localizedStringFormat: String) -> NSAttributedString {
+		let attributedString = NSMutableAttributedString(string: localizedStringFormat, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
+		let phraseString = NSAttributedString(string: phrase, attributes: [.font: UIConstants.fonts.copyButtonQuery,
+																		   .foregroundColor: UIConstants.Photon.Grey10])
 		
 		if phrase != searchQuery {
 			let searchString = NSAttributedString(string: searchQuery, attributes: [.font: UIConstants.fonts.copyButtonQuery,
-																			   .foregroundColor: UIConstants.Photon.Grey10])
+																					.foregroundColor: UIConstants.Photon.Grey10])
 			// split suggestion into searchQuery and suggested part
 			let suggestion = phrase.components(separatedBy: searchQuery)
 			
 			// suggestion was split
 			if suggestion.count > 1{
 				let restOfSuggestion = NSAttributedString(string: suggestion[1], attributes: [
-																						.foregroundColor: UIConstants.colors.searchSuggestion])
+					.foregroundColor: UIConstants.colors.searchSuggestion])
 				attributedString.append(searchString)
 				attributedString.append(restOfSuggestion)
 				return attributedString
 			}
 		}
 		
-        guard let range = attributedString.string.range(of: "%@") else { return phraseString }
-
-        let replaceRange = NSRange(range, in: attributedString.string)
-        attributedString.replaceCharacters(in: replaceRange, with: phraseString)
-
-        return attributedString
-    }
+		guard let range = attributedString.string.range(of: "%@") else { return phraseString }
+		
+		let replaceRange = NSRange(range, in: attributedString.string)
+		attributedString.replaceCharacters(in: replaceRange, with: phraseString)
+		
+		return attributedString
+	}
 
     func setAttributedButtonTitle(phrase: String, button: InsetButton, localizedStringFormat: String) {
 

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -191,10 +191,8 @@ class OverlayView: UIView {
 			}
 		}
 		guard let range = attributedString.string.range(of: "%@") else { return phraseString }
-		
 		let replaceRange = NSRange(range, in: attributedString.string)
 		attributedString.replaceCharacters(in: replaceRange, with: phraseString)
-		
 		return attributedString
 	}
 

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -176,7 +176,23 @@ class OverlayView: UIView {
         let attributedString = NSMutableAttributedString(string: localizedStringFormat, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
         let phraseString = NSAttributedString(string: phrase, attributes: [.font: UIConstants.fonts.copyButtonQuery,
                                                                            .foregroundColor: UIConstants.Photon.Grey10])
-
+		
+		if phrase != searchQuery {
+			let searchString = NSAttributedString(string: searchQuery, attributes: [.font: UIConstants.fonts.copyButtonQuery,
+																			   .foregroundColor: UIConstants.Photon.Grey10])
+			// split suggestion into searchQuery and suggested part
+			let suggestion = phrase.components(separatedBy: searchQuery)
+			
+			// suggestion was split
+			if suggestion.count > 1{
+				let restOfSuggestion = NSAttributedString(string: suggestion[1], attributes: [
+																						.foregroundColor: UIConstants.colors.searchSuggestion])
+				attributedString.append(searchString)
+				attributedString.append(restOfSuggestion)
+				return attributedString
+			}
+		}
+		
         guard let range = attributedString.string.range(of: "%@") else { return phraseString }
 
         let replaceRange = NSRange(range, in: attributedString.string)
@@ -189,7 +205,6 @@ class OverlayView: UIView {
 
         let attributedString = getAttributedButtonTitle(phrase: phrase,
                                                         localizedStringFormat: localizedStringFormat)
-
         button.setAttributedTitle(attributedString, for: .normal)
     }
 

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -41,6 +41,7 @@ struct UIConstants {
         static let navigationTitle = UIConstants.Photon.Grey10
         static let overlayBackground = UIColor(white: 0, alpha: 0.8)
         static let progressBar = UIColor(rgb: 0xC86DD7)
+		static let searchSuggestion = UIConstants.Photon.Grey10.withAlphaComponent(0.6)
         static let settingsButtonBorder = UIColor(rgb: 0x5F6368, alpha: 0.8)
         static let settingsTextLabel = UIConstants.Photon.Grey10
         static let settingsDetailLabel = UIConstants.Photon.Grey10.withAlphaComponent(0.6)


### PR DESCRIPTION
This PR contains a fix for #1607.

Now, the suggested part of search suggestions has different font & color from the search query part of the suggestion:
<img width="250" alt="screen shot 2018-12-20 at 5 26 34 pm" src="https://user-images.githubusercontent.com/26641473/50314410-bde70300-047c-11e9-9a4e-1d3f0bc5001d.png"> <img width="257" alt="screen shot 2018-12-20 at 5 26 53 pm" src="https://user-images.githubusercontent.com/26641473/50314412-be7f9980-047c-11e9-9c94-aaca40ee5ef8.png">
