### PR TITLE
Fixes #1272: Fixed timing for URLBarContainer background transition

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -657,11 +657,11 @@ class BrowserViewController: UIViewController {
 
     private func toggleURLBarBackground(isBright: Bool) {
         if urlBar.isEditing {
-            urlBarContainer.color = .editing
+            urlBarContainer.barState = .editing
         } else if case .on = trackingProtectionStatus {
-            urlBarContainer.color = .bright
+            urlBarContainer.barState = .bright
         } else {
-            urlBarContainer.color = .dark
+            urlBarContainer.barState = .dark
         }
     }
 


### PR DESCRIPTION
This PR contains a fix for #1272 

I reviewed the transition between background views in URLBarContainer.swift and noticed that the bar was flashing due to the simultaneous alpha transition of the background views. I initially tried batching the two animations in the same transition block, however that didn't produce the desired outcome (it still flashed). The solution I went with was to make sure that one of the background views is always visible during the transition, so that the webpage behind the URLBarContainer is never displayed. 

Below are gifs of the transitions after the changes from this PR:
![brighttoediting](https://user-images.githubusercontent.com/7691482/50749429-ac7b5600-11f3-11e9-8a09-d231df9c75e1.gif)
![brighttodark](https://user-images.githubusercontent.com/7691482/50749431-b1400a00-11f3-11e9-9c30-266d2b774b50.gif)
![darktoediting](https://user-images.githubusercontent.com/7691482/50749440-bc933580-11f3-11e9-81f7-7bc8c6984355.gif)
![darktobright](https://user-images.githubusercontent.com/7691482/50749436-b735eb00-11f3-11e9-9492-07bda65e661d.gif)
