### PR TITLE
Fixing #1223, jumpy animation in address bar while browsing 

### DIFF
--- a/Blockzilla/SearchEngineManager.swift
+++ b/Blockzilla/SearchEngineManager.swift
@@ -131,7 +131,7 @@ class SearchEngineManager {
         self.engines.append(contentsOf: customEngines)
 
         // Set default search engine pref
-        if prefs.string(forKey: SearchEngineManager.prefKeyEngine) == nil {
+         if prefs.string(forKey: SearchEngineManager.prefKeyEngine) == nil {
             prefs.set(self.engines.first?.name, forKey: SearchEngineManager.prefKeyEngine)
         }
 

--- a/Blockzilla/SearchEngineManager.swift
+++ b/Blockzilla/SearchEngineManager.swift
@@ -131,7 +131,7 @@ class SearchEngineManager {
         self.engines.append(contentsOf: customEngines)
 
         // Set default search engine pref
-         if prefs.string(forKey: SearchEngineManager.prefKeyEngine) == nil {
+        if prefs.string(forKey: SearchEngineManager.prefKeyEngine) == nil {
             prefs.set(self.engines.first?.name, forKey: SearchEngineManager.prefKeyEngine)
         }
 

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -621,11 +621,9 @@ class URLBar: UIView {
         if inBrowsingMode {
             shieldIcon.animateHidden(false, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
             deleteButton.animateHidden(false, duration: UIConstants.layout.urlBarTransitionAnimationDuration)
-        } else {
-            deactivate()
         }
 
-        self.layoutIfNeeded()
+        deactivate()
 
         UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration, animations: {
             if self.inBrowsingMode {


### PR DESCRIPTION
## Addressing #1223
This is an initial PR to try to address the animation issues in the url bar 
The jumpy animation that showed up on my machine, animated: 
<img src="https://user-images.githubusercontent.com/20709220/51094458-f4edc300-1761-11e9-8515-6c9a7b518793.gif" width="300" />

After: 
<img src="https://user-images.githubusercontent.com/20709220/51094481-4302c680-1762-11e9-832b-32852ed53821.gif" width="300" />


This change attempts to address the instant expansion of the url bar at the beginning of the animation. 








