### PR TITLE
Fixes #1223: aligned animations for address bar with spec

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -326,7 +326,7 @@ class BrowserViewController: UIViewController {
         urlBar.delegate = self
         urlBar.toolsetDelegate = self
         urlBar.shrinkFromView = urlBarContainer
-        urlBar.showToolset = showsToolsetInURLBar
+        urlBar.shouldShowToolset = showsToolsetInURLBar
         mainContainerView.insertSubview(urlBar, aboveSubview: urlBarContainer)
 
         urlBar.snp.makeConstraints { make in
@@ -597,7 +597,7 @@ class BrowserViewController: UIViewController {
         browserToolbar.updateConstraints()
 
         coordinator.animate(alongsideTransition: { _ in
-            self.urlBar.showToolset = self.showsToolsetInURLBar
+            self.urlBar.shouldShowToolset = self.showsToolsetInURLBar
 
             if self.homeView == nil && self.scrollBarState != .expanded {
                 self.hideToolbars()
@@ -876,9 +876,7 @@ extension BrowserViewController: URLBarDelegate {
             self.urlBarContainer.alpha = 1
             self.updateFindInPageVisibility(visible: false)
             self.view.layoutIfNeeded()
-        }) { (_) in
-            self.urlBar.displayClearButton(shouldDisplay: true)
-        }
+        })
     }
 
     func urlBarDidDeactivate(_ urlBar: URLBar) {


### PR DESCRIPTION
This PR contains a fix for #1223 

I looked into what was causing the jumpy appearance of the animation. Most views that were hidden were being set to a width of 0, which since the views didn't clip to bounds made it look like the views were sliding off the screen. I edited the animations to hide the views while maintaining their position instead.

Before:
![previousanimation](https://user-images.githubusercontent.com/4400286/47379400-c911f280-d6c8-11e8-842b-b7672e42860b.gif)

After:
![displayanimation 2019-01-16 23_25_24](https://user-images.githubusercontent.com/7691482/51302222-9d13be00-19e6-11e9-9119-ab76b5878a00.gif)
![hideanimation 2019-01-16 23_25_30](https://user-images.githubusercontent.com/7691482/51302244-a69d2600-19e6-11e9-909e-8ec76169ad68.gif)

![landscapedisplayanimation 2019-01-16 23_25_43](https://user-images.githubusercontent.com/7691482/51302277-b9aff600-19e6-11e9-904d-468a173389a9.gif)
![landscapehideanimation 2019-01-16 23_25_14](https://user-images.githubusercontent.com/7691482/51302280-bc125000-19e6-11e9-9800-15c9c3950bf4.gif)