### PR TITLE
Fix overlaps for #1437

### DIFF
--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -19,15 +19,22 @@ class HomeView: UIView {
     private let tipTitleLabel = SmartLabel()
     private let tipDescriptionLabel = SmartLabel()
     private let shieldLogo = UIImageView()
+    private let textLogo = UIImageView()
 
     let toolbar = HomeViewToolbar()
     let trackerStatsShareButton = UIButton()
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     init(tipManager: TipManager? = nil) {
         super.init(frame: CGRect.zero)
+        rotated()
+        NotificationCenter.default.addObserver(self, selector: #selector(HomeView.rotated), name: UIDevice.orientationDidChangeNotification, object: nil)
 
         let wordmark = AppInfo.config.wordmark
-        let textLogo = UIImageView(image: wordmark)
+        textLogo.image = wordmark
         addSubview(textLogo)
 
         privateBrowsingDescription.textColor = .white
@@ -89,16 +96,16 @@ class HomeView: UIView {
 
         privateBrowsingDescription.snp.makeConstraints { make in
             make.leading.trailing.equalTo(self)
-            make.top.equalTo(textLogo.snp.bottom).offset(25)
+            make.top.equalTo(textLogo.snp.bottom).offset(UIConstants.layout.homePrivateBrowsingDescriptionLabelTopOffset)
         }
 
         browseEraseRepeatTagline.snp.makeConstraints { make in
             make.leading.trailing.equalTo(self)
-            make.top.equalTo(privateBrowsingDescription.snp.bottom).offset(UIConstants.layout.homeViewTextOffset)
+            make.top.equalTo(privateBrowsingDescription.snp.bottom)
         }
 
         tipView.snp.makeConstraints { make in
-            make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.shareTrackersBottomOffset)
+            make.centerY.equalToSuperview().offset(UIConstants.layout.shareTrackersHeight/3)
             make.height.equalTo(UIConstants.layout.shareTrackersHeight)
             make.centerX.equalToSuperview()
             make.width.greaterThanOrEqualTo(280)
@@ -112,7 +119,7 @@ class HomeView: UIView {
 
         tipTitleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.bottom.equalTo(tipDescriptionLabel.snp.top).offset(-UIConstants.layout.homeViewTextOffset)
+            make.bottom.equalTo(tipDescriptionLabel.snp.top).offset(UIConstants.layout.homeTipTitleLableOffset)
         }
 
         toolbar.snp.makeConstraints { make in
@@ -178,6 +185,22 @@ class HomeView: UIView {
         shieldLogo.isHidden = true
         trackerStatsLabel.isHidden = true
         trackerStatsShareButton.isHidden = true
+    }
+
+    @objc private func rotated() {
+        if UIDevice.current.orientation.isLandscape {
+            hideTextLogo()
+        } else {
+            showTextLogo()
+        }
+    }
+
+    private func hideTextLogo() {
+        textLogo.isHidden = true
+    }
+
+    private func showTextLogo() {
+        textLogo.isHidden = false
     }
 
     func showTextTip(_ tip: TipManager.Tip) {

--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -105,7 +105,7 @@ class HomeView: UIView {
         }
 
         tipView.snp.makeConstraints { make in
-            make.centerY.equalToSuperview().offset(UIConstants.layout.shareTrackersHeight/3)
+            make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.shareTrackersBottomOffset)
             make.height.equalTo(UIConstants.layout.shareTrackersHeight)
             make.centerX.equalToSuperview()
             make.width.greaterThanOrEqualTo(280)

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -206,6 +206,8 @@ struct UIConstants {
         static let truncateCharactersLimit = 160
         static let truncateHeadCharactersCount = (truncateCharactersLimit - UIConstants.strings.truncateLeader.count) / 2
         static let truncateTailCharactersCount = Int(ceil(Double(truncateCharactersLimit - UIConstants.strings.truncateLeader.count) / 2.0))
+        static let homeTipTitleLableOffset: CGFloat = 3
+        static let homePrivateBrowsingDescriptionLabelTopOffset: CGFloat = 5
     }
 
     struct strings {


### PR DESCRIPTION
Continuing the work of @Botary 
Fixed overlapping issue and fixed padding for tips label on landscape and portrait.

iPhone 5s
![simulator screen shot - iphone 5s - 2019-01-29 at 00 05 57](https://user-images.githubusercontent.com/16319917/51887361-7592fd00-23b9-11e9-95b4-82fc7eab986b.png)

iPhone X
![simulator screen shot - iphone x - 2019-01-29 at 00 06 07](https://user-images.githubusercontent.com/16319917/51887364-775cc080-23b9-11e9-991a-f8ae09cd84c5.png)
![simulator screen shot - iphone x - 2019-01-29 at 00 09 54](https://user-images.githubusercontent.com/16319917/51887365-788ded80-23b9-11e9-9e2f-7cef297c3ace.png)
