### PR TITLE
Force show toolbar when select location bar

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -640,6 +640,7 @@ class BrowserViewController: UIViewController {
     }
 
     @objc private func selectLocationBar() {
+        showToolbars()
         urlBar.activateTextField()
     }
 


### PR DESCRIPTION
When selecting the location bar using an external keyboard with a shortcut (CMD + L) if the url bar is not visible it would create a strange artefact. Fix it by forcing the show of the toolbar.

From this behaviour:
![focus-bad-behaviour](https://user-images.githubusercontent.com/111388/52048843-a0fa2100-254c-11e9-83d1-46008daeddf4.gif)

To this:
![foucs-good-behaviour](https://user-images.githubusercontent.com/111388/52048937-d56ddd00-254c-11e9-87ec-d53e4274f80c.gif)
