### PR TITLE
Fixes #1169: Add a test for the no internet connection page

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		2696EB04211F540600F0C73F /* SearchHistoryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */; };
 		2825C3665AB14081B262F767 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D051AC1857A0EEEBB833D15 /* SystemConfiguration.framework */; };
 		2B36326E97D2E67E9C684B4B /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80D9AA926EFBD788739486EB /* CoreTelephony.framework */; };
+		2D90088222041BC9008F06D9 /* NoInternetConnectionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D90088122041BC9008F06D9 /* NoInternetConnectionTest.swift */; };
 		2F2F84BCF076B21DE42D1F29 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C652A61E213D254A86DF5736 /* CoreMedia.framework */; };
 		30DFF98021810BF20055707C /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30DFF97F21810BF20055707C /* SearchSuggestClient.swift */; };
 		31421EB12176492A0015F48B /* TitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */; };
@@ -376,6 +377,7 @@
 		24433100219DA46F00778D02 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryUtils.swift; sourceTree = "<group>"; };
 		29B90C056305836CB297FF79 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
+		2D90088122041BC9008F06D9 /* NoInternetConnectionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoInternetConnectionTest.swift; sourceTree = "<group>"; };
 		30DFF97F21810BF20055707C /* SearchSuggestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProvider.swift; sourceTree = "<group>"; };
 		427B752EF11959F9C38B12D6 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -1018,6 +1020,7 @@
 				4F1284851FC5E242001A775B /* TPSettingsTest.swift */,
 				166E4BFA212F7DEC0029E2A5 /* UserAgentTest.swift */,
 				F74E8108218183F400D18535 /* SearchSuggestionsTest.swift */,
+				2D90088122041BC9008F06D9 /* NoInternetConnectionTest.swift */,
 			);
 			path = XCUITest;
 			sourceTree = "<group>";
@@ -1810,6 +1813,7 @@
 				4F582F7B1F44A10F006C744B /* OpenInFocusTest.swift in Sources */,
 				0BC928CE1E366A6E004AC581 /* AsianLocaleTest.swift in Sources */,
 				1D3FEEA120C0A73D00FFAA8C /* RequestDesktopTest.swift in Sources */,
+				2D90088222041BC9008F06D9 /* NoInternetConnectionTest.swift in Sources */,
 				4F1284861FC5E242001A775B /* TPSettingsTest.swift in Sources */,
 				4FE4E6F61FBB5E2C001BB779 /* TPSidebarBadge.swift in Sources */,
 				1DE6DA2220BF410400CE337B /* QuickAddAutocompleteURLTest.swift in Sources */,

--- a/XCUITest/NoInternetConnectionTest.swift
+++ b/XCUITest/NoInternetConnectionTest.swift
@@ -1,0 +1,54 @@
+//
+//  NoInternetConnectionTest.swift
+//  XCUITest
+//
+//  Created by Volodymyr Klymenko on 2019-02-01.
+//  Copyright © 2019 Mozilla. All rights reserved.
+//
+
+import XCTest
+import SystemConfiguration
+
+public class ReachabilityTest {
+	class func isConnectedToNetwork() -> Bool {
+		var zeroAddress = sockaddr_in()
+		zeroAddress.sin_len = UInt8(MemoryLayout.size(ofValue: zeroAddress))
+		zeroAddress.sin_family = sa_family_t(AF_INET)
+
+		let defaultRouteReachability = withUnsafePointer(to: &zeroAddress) {
+			$0.withMemoryRebound(to: sockaddr.self, capacity: 1) {zeroSockAddress in
+				SCNetworkReachabilityCreateWithAddress(nil, zeroSockAddress)
+			}
+		}
+
+		var flags = SCNetworkReachabilityFlags()
+		if !SCNetworkReachabilityGetFlags(defaultRouteReachability!, &flags) {
+			return false
+		}
+		let isReachable = (flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0
+		let needsConnection = (flags.rawValue & UInt32(kSCNetworkFlagsConnectionRequired)) != 0
+		return (isReachable && !needsConnection)
+	}
+}
+
+class NoInternetConnectionTest: BaseTestCase {
+	
+	override func setUp() {
+		super.setUp()
+		dismissFirstRunUI()
+	}
+
+	override func tearDown() {
+		app.terminate()
+		super.tearDown()
+	}
+
+	func testConnectivity() {
+		if !ReachabilityTest.isConnectedToNetwork() {
+			let app = XCUIApplication()
+			loadWebPage("mozilla.com")
+			let noInternetConnection = app.staticTexts["The Internet connection appears to be offline."]
+			XCTAssertEqual("The Internet connection appears to be offline.", noInternetConnection.label)
+		}
+	}
+}

--- a/XCUITest/NoInternetConnectionTest.swift
+++ b/XCUITest/NoInternetConnectionTest.swift
@@ -45,7 +45,6 @@ class NoInternetConnectionTest: BaseTestCase {
 
 	func testConnectivity() {
 		if !ReachabilityTest.isConnectedToNetwork() {
-			let app = XCUIApplication()
 			loadWebPage("mozilla.com")
 			let noInternetConnection = app.staticTexts["The Internet connection appears to be offline."]
 			XCTAssertEqual("The Internet connection appears to be offline.", noInternetConnection.label)


### PR DESCRIPTION
This PR contains a fix for #1164.

I added a XCUI test for this page. I learned that there is no way to turn off network on iOS Simulator programatically, so in order to use this test, you should turn off network on your computer, where you run the project.

Also, I added a check for the internet connectity. If there is no internet connectivity – test runs. In order to implement it, I referenced this [article](https://mobikul.com/check-internet-availability-swift/).

CC: @oliviabrown9 