### PR TITLE
Fixes #1649: Reloading tips after settings dismiss

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -302,6 +302,7 @@ class BrowserViewController: UIViewController {
     private func createHomeView() {
         let homeView: HomeView
         if TipManager.shared.shouldShowTips() {
+            tipManager?.loadTips()
             homeView = HomeView(tipManager: tipManager)
         } else {
             homeView = HomeView()
@@ -318,7 +319,7 @@ class BrowserViewController: UIViewController {
             homeView.removeFromSuperview()
         }
         self.homeView = homeView
-
+        homeView.setNeedsDisplay()
     }
 
     private func createURLBar() {

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -692,6 +692,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
 
     @objc private func dismissSettings() {
+        if let browserViewController = presentingViewController as? BrowserViewController {
+            browserViewController.refreshTipsDisplay()
+        }
         self.dismiss(animated: true, completion: nil)
     }
 

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -45,16 +45,20 @@ class TipManager {
         addAllTips()
     }
 
+    public func loadTips() {
+        possibleTips = [Tip]()
+        addAllTips()
+    }
+
     private func addAllTips() {
-        possibleTips.append(autocompleteTip)
-        possibleTips.append(sitesNotWorkingTip)
-        possibleTips.append(requestDesktopTip)
-        possibleTips.append(siriFavoriteTip)
-        possibleTips.append(siriEraseTip)
-        possibleTips.append(shareTrackersTip)
-        if laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
-            possibleTips.append(biometricTip)
-        }
+//        possibleTips.append(autocompleteTip)
+//        possibleTips.append(sitesNotWorkingTip)
+//        possibleTips.append(requestDesktopTip)
+//        possibleTips.append(siriFavoriteTip)
+//        possibleTips.append(siriEraseTip)
+//        possibleTips.append(shareTrackersTip)
+        possibleTips.append(biometricTip)
+
     }
 
     lazy var autocompleteTip = Tip(title: UIConstants.strings.autocompleteTipTitle, description: UIConstants.strings.autocompleteTipDescription, identifier: TipKey.autocompleteTip)
@@ -94,11 +98,14 @@ class TipManager {
 
     private func canShowTip(with id: String) -> Bool {
         let defaults = UserDefaults.standard
+
         switch id {
         case TipKey.siriFavoriteTip, TipKey.siriEraseTip:
             guard #available(iOS 12.0, *) else { return false }
         case TipKey.shareTrackersTip:
             guard UserDefaults.standard.integer(forKey: BrowserViewController.userDefaultsTrackersBlockedKey) >= 10 else { return false }
+        case TipKey.biometricTip:
+            return shouldShowBiometricTips()
         default:
             break
         }
@@ -107,5 +114,10 @@ class TipManager {
 
     func shouldShowTips() -> Bool {
         return NSLocale.current.identifier == "en_US" && !AppInfo.isKlar
+    }
+
+    func shouldShowBiometricTips() -> Bool {
+        let isBiometricLoginEnabled = Settings.getToggle(.biometricLogin)
+        return !isBiometricLoginEnabled && laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
     }
 }

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -51,12 +51,12 @@ class TipManager {
     }
 
     private func addAllTips() {
-//        possibleTips.append(autocompleteTip)
-//        possibleTips.append(sitesNotWorkingTip)
-//        possibleTips.append(requestDesktopTip)
-//        possibleTips.append(siriFavoriteTip)
-//        possibleTips.append(siriEraseTip)
-//        possibleTips.append(shareTrackersTip)
+        possibleTips.append(autocompleteTip)
+        possibleTips.append(sitesNotWorkingTip)
+        possibleTips.append(requestDesktopTip)
+        possibleTips.append(siriFavoriteTip)
+        possibleTips.append(siriEraseTip)
+        possibleTips.append(shareTrackersTip)
         possibleTips.append(biometricTip)
 
     }


### PR DESCRIPTION
While I'm looking for a solution to #1649 I noticed that the Biometric tips never show, even on my device with current release.

With this PR, I solve this problem and the refresh tips after dismiss settings.



