### PR TITLE
Fix #1688 - Keyboard displayed during onboarding flow

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -106,7 +106,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
                 // Set the prefIntroVersion viewed number in the same context as the presentation.
                 UserDefaults.standard.set(AppDelegate.prefIntroVersion, forKey: AppDelegate.prefIntroDone)
                 UserDefaults.standard.set(AppInfo.shortVersion, forKey: AppDelegate.prefWhatsNewDone)
-                self.browserViewController.present(IntroViewController(), animated: false, completion: nil)
+                let introViewController = IntroViewController()
+                introViewController.modalPresentationStyle = .fullScreen
+                self.browserViewController.present(introViewController, animated: false, completion: nil)
             }
         }
 


### PR DESCRIPTION
We no longer see the keyboard when user first installs the app during onboarding. 
<img width="515" alt="image" src="https://user-images.githubusercontent.com/8919439/74973748-fd4b0f80-53f1-11ea-8b1f-068b112e18f6.png">

![image](https://user-images.githubusercontent.com/8919439/74975052-587e0180-53f4-11ea-9e9d-3366cbc5152a.png)

