### PR TITLE
Fix #1711 - Disable Pasteboard Access on every url change

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -95,6 +95,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
 
         if AppInfo.isTesting() {
             let firstRunViewController = IntroViewController()
+            firstRunViewController.modalPresentationStyle = .fullScreen
             self.browserViewController.present(firstRunViewController, animated: false, completion: nil)
             return true
         }

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -216,36 +216,25 @@ class OverlayView: UIView {
         searchQuery = suggestions[0]
         searchSuggestions = searchQuery.isEmpty ? [] : suggestions
         let searchSuggestionsPromptHidden = UserDefaults.standard.bool(forKey: SearchSuggestionsPromptView.respondedToSearchSuggestionsPrompt) || searchQuery.isEmpty
-        var copyButtonHidden = true
 
-        UIPasteboard.general.urlAsync() { handoffUrl in
-            DispatchQueue.main.async {
-                if let url = handoffUrl, url.isWebPage() {
-                    let attributedTitle = NSMutableAttributedString(string: UIConstants.strings.copiedLink, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
-                    let attributedCopiedUrl = NSMutableAttributedString(string: url.absoluteString, attributes: [.font: UIConstants.fonts.copyButtonQuery, .foregroundColor: UIConstants.Photon.Grey10])
-                    attributedTitle.append(attributedCopiedUrl)
-                    self.copyButton.setAttributedTitle(attributedTitle, for: .normal)
-                    copyButtonHidden = !url.isWebPage()
-                }
+        DispatchQueue.main.async {
+            self.updateSearchSuggestionsPrompt(hidden: searchSuggestionsPromptHidden)
 
-                self.updateSearchSuggestionsPrompt(hidden: searchSuggestionsPromptHidden)
+            // Hide the autocomplete button on home screen and when the user is typing
+            self.addToAutocompleteButton.animateHidden(hideAddToComplete, duration: 0)
+            self.topBorder.backgroundColor =  searchSuggestionsPromptHidden ? UIConstants.Photon.Grey90.withAlphaComponent(0.4) : UIColor(rgb: 0x42455A)
+            self.updateSearchButtons()
 
-                // Hide the autocomplete button on home screen and when the user is typing
-                self.addToAutocompleteButton.animateHidden(hideAddToComplete, duration: 0)
-                self.topBorder.backgroundColor =  searchSuggestionsPromptHidden ? UIConstants.Photon.Grey90.withAlphaComponent(0.4) : UIColor(rgb: 0x42455A)
-                self.updateSearchButtons()
-
-                let lastSearchButtonIndex = min(self.searchSuggestions.count, self.searchButtonGroup.count) - 1
-                self.updateFindInPageConstraints(
-                    findInPageHidden: hideFindInPage,
-                    lastSearchButtonIndex: lastSearchButtonIndex
-                )
-                self.updateCopyConstraints(
-                    copyButtonHidden: copyButtonHidden,
-                    findInPageHidden: hideFindInPage,
-                    lastSearchButtonIndex: lastSearchButtonIndex
-                )
-            }
+            let lastSearchButtonIndex = min(self.searchSuggestions.count, self.searchButtonGroup.count) - 1
+            self.updateFindInPageConstraints(
+                findInPageHidden: hideFindInPage,
+                lastSearchButtonIndex: lastSearchButtonIndex
+            )
+            self.updateCopyConstraints(
+                copyButtonHidden: true,
+                findInPageHidden: hideFindInPage,
+                lastSearchButtonIndex: lastSearchButtonIndex
+            )
         }
     }
 

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -216,38 +216,19 @@ class OverlayView: UIView {
         searchQuery = suggestions[0]
         searchSuggestions = searchQuery.isEmpty ? [] : suggestions
         let searchSuggestionsPromptHidden = UserDefaults.standard.bool(forKey: SearchSuggestionsPromptView.respondedToSearchSuggestionsPrompt) || searchQuery.isEmpty
-        var copyButtonHidden = true
-
-        
-//        if UIPasteboard.general.hasURLs {
-//            UIPasteboard.general.urlAsync() { handoffUrl in
-//                DispatchQueue.main.async {
-//                    if let url = handoffUrl, url.isWebPage() {
-//                        let attributedTitle = NSMutableAttributedString(string: UIConstants.strings.copiedLink, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
-//                        let attributedCopiedUrl = NSMutableAttributedString(string: url.absoluteString, attributes: [.font: UIConstants.fonts.copyButtonQuery, .foregroundColor: UIConstants.Photon.Grey10])
-//                        attributedTitle.append(attributedCopiedUrl)
-//                        self.copyButton.setAttributedTitle(attributedTitle, for: .normal)
-//                        copyButtonHidden = !url.isWebPage()
-//                    }
-//                }
-//            }
-//        }
-        
         DispatchQueue.main.async {
             self.updateSearchSuggestionsPrompt(hidden: searchSuggestionsPromptHidden)
-
             // Hide the autocomplete button on home screen and when the user is typing
             self.addToAutocompleteButton.animateHidden(hideAddToComplete, duration: 0)
             self.topBorder.backgroundColor =  searchSuggestionsPromptHidden ? UIConstants.Photon.Grey90.withAlphaComponent(0.4) : UIColor(rgb: 0x42455A)
             self.updateSearchButtons()
-
             let lastSearchButtonIndex = min(self.searchSuggestions.count, self.searchButtonGroup.count) - 1
             self.updateFindInPageConstraints(
                 findInPageHidden: hideFindInPage,
                 lastSearchButtonIndex: lastSearchButtonIndex
             )
             self.updateCopyConstraints(
-                copyButtonHidden: copyButtonHidden,
+                copyButtonHidden: true,
                 findInPageHidden: hideFindInPage,
                 lastSearchButtonIndex: lastSearchButtonIndex
             )

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -216,7 +216,23 @@ class OverlayView: UIView {
         searchQuery = suggestions[0]
         searchSuggestions = searchQuery.isEmpty ? [] : suggestions
         let searchSuggestionsPromptHidden = UserDefaults.standard.bool(forKey: SearchSuggestionsPromptView.respondedToSearchSuggestionsPrompt) || searchQuery.isEmpty
+        var copyButtonHidden = true
 
+        
+//        if UIPasteboard.general.hasURLs {
+//            UIPasteboard.general.urlAsync() { handoffUrl in
+//                DispatchQueue.main.async {
+//                    if let url = handoffUrl, url.isWebPage() {
+//                        let attributedTitle = NSMutableAttributedString(string: UIConstants.strings.copiedLink, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
+//                        let attributedCopiedUrl = NSMutableAttributedString(string: url.absoluteString, attributes: [.font: UIConstants.fonts.copyButtonQuery, .foregroundColor: UIConstants.Photon.Grey10])
+//                        attributedTitle.append(attributedCopiedUrl)
+//                        self.copyButton.setAttributedTitle(attributedTitle, for: .normal)
+//                        copyButtonHidden = !url.isWebPage()
+//                    }
+//                }
+//            }
+//        }
+        
         DispatchQueue.main.async {
             self.updateSearchSuggestionsPrompt(hidden: searchSuggestionsPromptHidden)
 
@@ -231,7 +247,7 @@ class OverlayView: UIView {
                 lastSearchButtonIndex: lastSearchButtonIndex
             )
             self.updateCopyConstraints(
-                copyButtonHidden: true,
+                copyButtonHidden: copyButtonHidden,
                 findInPageHidden: hideFindInPage,
                 lastSearchButtonIndex: lastSearchButtonIndex
             )

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -491,13 +491,10 @@ class URLBar: UIView {
 
     //Adds Menu Item
     func addCustomMenu() {
-        if #available(iOS 14.0, *) {
-            print(UIPasteboard.DetectionPattern.probableWebURL)
+        if UIPasteboard.general.hasURLs && urlText.isFirstResponder {
+            let lookupMenu = UIMenuItem(title: UIConstants.strings.urlPasteAndGo, action: #selector(pasteAndGoFromContextMenu))
+            UIMenuController.shared.menuItems = [lookupMenu]
         }
-//        if UIPasteboard.general.string != nil && urlText.isFirstResponder {
-        let lookupMenu = UIMenuItem(title: UIConstants.strings.urlPasteAndGo, action: #selector(pasteAndGoFromContextMenu))
-        UIMenuController.shared.menuItems = [lookupMenu]
-//        }
     }
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         addCustomMenu()

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -491,10 +491,13 @@ class URLBar: UIView {
 
     //Adds Menu Item
     func addCustomMenu() {
-        if UIPasteboard.general.string != nil && urlText.isFirstResponder {
-            let lookupMenu = UIMenuItem(title: UIConstants.strings.urlPasteAndGo, action: #selector(pasteAndGoFromContextMenu))
-            UIMenuController.shared.menuItems = [lookupMenu]
+        if #available(iOS 14.0, *) {
+            print(UIPasteboard.DetectionPattern.probableWebURL)
         }
+//        if UIPasteboard.general.string != nil && urlText.isFirstResponder {
+        let lookupMenu = UIMenuItem(title: UIConstants.strings.urlPasteAndGo, action: #selector(pasteAndGoFromContextMenu))
+        UIMenuController.shared.menuItems = [lookupMenu]
+//        }
     }
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         addCustomMenu()

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -491,7 +491,7 @@ class URLBar: UIView {
 
     //Adds Menu Item
     func addCustomMenu() {
-        if UIPasteboard.general.hasURLs && urlText.isFirstResponder {
+        if UIPasteboard.general.hasStrings && urlText.isFirstResponder {
             let lookupMenu = UIMenuItem(title: UIConstants.strings.urlPasteAndGo, action: #selector(pasteAndGoFromContextMenu))
             UIMenuController.shared.menuItems = [lookupMenu]
         }

--- a/XCUITest/CollapsedURLTest.swift
+++ b/XCUITest/CollapsedURLTest.swift
@@ -21,13 +21,12 @@ class CollapsedURLTest: BaseTestCase {
 
         // Go to mozilla.org
         loadWebPage("http://localhost:6573/licenses.html\n")
-        let searchOrEnterAddressTextField = app.textFields["Search or enter address"]
 
         // Wait for the website to load
         waitforExistence(element: app.webViews.otherElements["Licenses"])
         let webView = app.webViews.children(matching: .other).element
-        webView.swipeUp()
-        webView.swipeUp()
+        app.swipeUp()
+        app.swipeUp()
         let collapsedTruncatedurltextTextView = app.textViews["Collapsed.truncatedUrlText"]
         waitforExistence(element: collapsedTruncatedurltextTextView)
 
@@ -35,8 +34,8 @@ class CollapsedURLTest: BaseTestCase {
         XCTAssertEqual(collapsedTruncatedurltextTextView.value as? String, "localhost")
 
         // After swiping down, the collapsed URL should not be displayed
-        webView.swipeDown()
-        webView.swipeDown()
+        app.swipeDown()
+        app.swipeDown()
         waitforNoExistence(element: collapsedTruncatedurltextTextView)
         XCTAssertFalse(collapsedTruncatedurltextTextView.exists)
     }

--- a/XCUITest/SearchSuggestionsTest.swift
+++ b/XCUITest/SearchSuggestionsTest.swift
@@ -67,7 +67,10 @@ class SearchSuggestionsPromptTest: BaseTestCase {
 
         // Ensure prompt disappears
         waitforNoExistence(element: app.otherElements["SearchSuggestionsPromptView"])
-
+        
+        // Adding a delay in case of slow network
+        sleep(4)
+        
         // Ensure search suggestions are shown
         checkSuggestions()
 
@@ -97,7 +100,7 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         // Ensure only one search cell is shown
         let suggestion = app.buttons.matching(identifier: "OverlayView.searchButton").element(boundBy: 0)
         waitforExistence(element: suggestion)
-        XCTAssertEqual("Search for g", suggestion.label)
+        XCTAssert("Search for g" == suggestion.label || "g" == suggestion.label)
 
         // Check tapping on suggestion leads to correct page
         suggestion.tap()
@@ -119,8 +122,12 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         // Prompt should not display
         app.buttons["SettingsViewController.doneButton"].tap()
         typeInURLBar(text: "g")
-        waitforNoExistence(element: app.otherElements["SearchSuggestionsPromptView"])
 
+        // Adding a delay in case of slow network
+        sleep(4)
+
+        waitforNoExistence(element: app.otherElements["SearchSuggestionsPromptView"])
+        
         // Ensure search suggestions are shown
         checkSuggestions()
     }
@@ -139,6 +146,9 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         // Press enable
         app.buttons["SearchSuggestionsPromptView.enableButton"].tap()
 
+        // Adding a delay in case of slow network
+        sleep(4)
+        
         // Ensure prompt disappears
         waitforNoExistence(element: app.otherElements["SearchSuggestionsPromptView"])
 
@@ -153,9 +163,11 @@ class SearchSuggestionsPromptTest: BaseTestCase {
 
         // Ensure only one search cell is shown
         app.buttons["SettingsViewController.doneButton"].tap()
-        typeInURLBar(text: "g")
+        let urlBarTextField = app.textFields["URLBar.urlText"]
+        urlBarTextField.tap()
+        urlBarTextField.typeText("g")
         let suggestion = app.buttons.matching(identifier: "OverlayView.searchButton").element(boundBy: 0)
         waitforExistence(element: suggestion)
-        XCTAssertEqual("Search for g", suggestion.label)
+        XCTAssert("Search for g" == suggestion.label || "g" == suggestion.label)
     }
 }

--- a/XCUITest/WebsiteMemoryTest.swift
+++ b/XCUITest/WebsiteMemoryTest.swift
@@ -38,8 +38,7 @@ class WebsiteMemoryTest: BaseTestCase {
         googleSearchField.press(forDuration: 1.5)
         waitforExistence(element: app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
-        app.buttons["Google Search"].tap()
-
+        app.keyboards.buttons["Search"].tap()
         // wait for mozilla link to appear
         waitforExistence(element: app.links["Mozilla"].staticTexts["Mozilla"])
 


### PR DESCRIPTION
This is a draft PR to investigate best case scenario for fixing issue where we are checking the URL contents on every change from UIPasteboard a.k.a. clipboard. 

iOS 14 privacy focus keeps showing the notification that `Focus pasted from some app`

Apple actually has a new iOS14 api just to check if its a URL for paste and go. Although it needs more investigation. 

https://developer.apple.com/documentation/uikit/uipasteboard/detectionpattern?changes=latest_minor 

Update:

Instead of using iOS14 api I have decided to go with `hasURL` option which is available since iOS 10 to check paste and go. 
And have decided to remove the handoff portion of the code which is being called on every keystroke which feels too much. 

Links: https://developer.apple.com/documentation/uikit/uipasteboard/1829410-hasurls