### PR TITLE
Remove NSPhotoLibraryUsageDescription from Info.plist

### DIFF
--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -59,8 +59,6 @@
 	<string>This lets you take and upload videos.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This lets you save and upload photos.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>This lets you save and upload photos.</string>
 	<key>NSUserActivityTypes</key>
 	<dict>
 		<key>eraseAndOpen</key>

--- a/Blockzilla/en.lproj/InfoPlist.strings
+++ b/Blockzilla/en.lproj/InfoPlist.strings
@@ -13,6 +13,3 @@
 /* (No Comment) */
 "NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
 
-/* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "This lets you save and upload photos.";
-


### PR DESCRIPTION
Remove NSPhotoLibraryUsageDescription key value pair from info.plist and remove associated english string. We do not use the photo picker natively and no longer need this string. This removal is also a requirement for Apple default browser approval.

Fixes Firefox Project Issue [7140](https://github.com/mozilla-mobile/firefox-ios/issues/7140)