### PR TITLE
Add http and https CFBundleURLSchemes 

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -151,6 +151,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
         }
 
         let query = getQuery(url: url)
+        let isHttpScheme = scheme == "http" || scheme == "https"
 
         if host == "open-url" {
             let urlString = unescape(string: query["url"]) ?? ""
@@ -163,7 +164,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
             } else {
                 queuedUrl = url
             }
-        } else if host == "open-text" {
+        } else if host == "open-text" || isHttpScheme {
             let text = unescape(string: query["text"]) ?? ""
 
             if application.applicationState == .active {

--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -26,6 +26,8 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>$(BLOCKZILLA_URL_SCHEME)</string>
+				<string>http</string>
+				<string>https</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
Add http and https CFBundleURLSchemes and handle launching from those schemes for Apple default browser requirements.

Fixes Firefox Project Issue [7141](https://github.com/mozilla-mobile/firefox-ios/issues/7141)