### PR TITLE
Fixes issue #1689

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -584,6 +584,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             if toggle.label == UIConstants.strings.labelSendAnonymousUsageData ||
                 toggle.label == UIConstants.strings.settingsSearchSuggestions {
                 height += 10
+                if toggle.label == UIConstants.strings.settingsSearchSuggestions && UIDevice.current.userInterfaceIdiom == .pad {
+                    height += 15
+                }
             }
         }
 


### PR DESCRIPTION
Bugfix: #1689.
Learn more link Label is overlapping the text in Settings menu for iPad devices