### PR TITLE
#7306 ⁃ Remove references to UIWebview from Focus

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -954,7 +954,7 @@ extension BrowserViewController: URLBarDelegate {
 
         var actionItems = [items.findInPageItem]
 
-        webViewController.userAgentString == UserAgent.getDesktopUserAgent() ? actionItems.append(items.requestMobileItem) : actionItems.append(items.requestDesktopItem)
+        webViewController.userAgentString == UserAgent.desktopUserAgent() ? actionItems.append(items.requestMobileItem) : actionItems.append(items.requestDesktopItem)
 
         let pageActionsMenu = PhotonActionSheet(title: UIConstants.strings.pageActionsTitle, actions: [shareItems, actionItems], style: .overCurrentContext)
         presentPhotonActionSheet(pageActionsMenu, from: urlBar.pageActionsButton)
@@ -996,8 +996,8 @@ extension BrowserViewController: BrowserToolsetDelegate {
         urlBar.dismiss()
 
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let title = webViewController.userAgentString == UserAgent.getDesktopUserAgent() ? "Request Mobile Site" : "Request Desktop Site"
-        let object = webViewController.userAgentString == UserAgent.getDesktopUserAgent() ? TelemetryEventObject.requestMobile : TelemetryEventObject.requestDesktop
+        let title = webViewController.userAgentString == UserAgent.desktopUserAgent() ? "Request Mobile Site" : "Request Desktop Site"
+        let object = webViewController.userAgentString == UserAgent.desktopUserAgent() ? TelemetryEventObject.requestMobile : TelemetryEventObject.requestDesktop
 
         alert.addAction(UIAlertAction(title: title, style: .default, handler: { (action) in
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: object)

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -136,9 +136,9 @@ class WebViewController: UIViewController, WebController {
         UserDefaults.standard.set(false, forKey: TipManager.TipKey.requestDesktopTip)
     }
 
-    func resetUA() {
-        browserView.customUserAgent = userAgent?.browserUserAgent
-    }
+//    func resetUA() {
+//        browserView.customUserAgent = userAgent?.browserUserAgent
+//    }
 
     func stop() { browserView.stopLoading() }
 
@@ -154,6 +154,7 @@ class WebViewController: UIViewController, WebController {
         browserView.scrollView.delegate = self
         browserView.navigationDelegate = self
         browserView.uiDelegate = self
+        browserView.customUserAgent = userAgent?.getUserAgent()
 
         progressObserver = browserView.observe(\WKWebView.estimatedProgress) { (webView, value) in
             self.delegate?.webController(self, didUpdateEstimatedProgress: webView.estimatedProgress)
@@ -275,7 +276,7 @@ extension WebViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         delegate?.webControllerDidFinishNavigation(self)
-        self.resetUA()
+//        self.resetUA()
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -136,10 +136,6 @@ class WebViewController: UIViewController, WebController {
         UserDefaults.standard.set(false, forKey: TipManager.TipKey.requestDesktopTip)
     }
 
-//    func resetUA() {
-//        browserView.customUserAgent = userAgent?.browserUserAgent
-//    }
-
     func stop() { browserView.stopLoading() }
 
     private func setupWebview() {
@@ -276,7 +272,6 @@ extension WebViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         delegate?.webControllerDidFinishNavigation(self)
-//        self.resetUA()
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/Blockzilla/StringExtensions.swift
+++ b/Blockzilla/StringExtensions.swift
@@ -14,13 +14,4 @@ extension String {
 
         return true
     }
-
-    func isEmptyOrWhitespace() -> Bool {
-        // Check empty string
-        if self.isEmpty {
-            return true
-        }
-        // Trim and check empty string
-        return (self.trimmingCharacters(in: .whitespaces) == "")
-    }
 }

--- a/Blockzilla/StringExtensions.swift
+++ b/Blockzilla/StringExtensions.swift
@@ -14,4 +14,13 @@ extension String {
 
         return true
     }
+
+    func isEmptyOrWhitespace() -> Bool {
+        // Check empty string
+        if self.isEmpty {
+            return true
+        }
+        // Trim and check empty string
+        return (self.trimmingCharacters(in: .whitespaces) == "")
+    }
 }

--- a/Blockzilla/UserAgent.swift
+++ b/Blockzilla/UserAgent.swift
@@ -4,81 +4,6 @@
 
 import Foundation
 
-class UserAgent {
-    static let shared = UserAgent()
-
-    private var userDefaults: UserDefaults
-    private var isDesktopMode: Bool!
-
-    var browserUserAgent: String?
-
-    init(userDefaults: UserDefaults = UserDefaults.standard) {
-        self.userDefaults = userDefaults
-        setup()
-    }
-
-    func setup() {
-        isDesktopMode = false
-        if let cachedUserAgent = cachedUserAgent() {
-            setUserAgent(userAgent: cachedUserAgent)
-            return
-        }
-
-        let userAgent = UserAgent.mobileUserAgent()
-        userDefaults.set(userAgent, forKey: "UserAgent")
-        userDefaults.set(AppInfo.shortVersion, forKey: "LastFocusVersionNumber")
-        userDefaults.set(AppInfo.buildNumber, forKey: "LastFocusBuildNumber")
-        userDefaults.set(UIDevice.current.systemVersion, forKey: "LastDeviceSystemVersionNumber")
-
-        setUserAgent(userAgent: userAgent)
-    }
-
-    private func cachedUserAgent() -> String? {
-        let currentiOSVersion = UIDevice.current.systemVersion
-        let lastiOSVersion = userDefaults.string(forKey: "LastDeviceSystemVersionNumber")
-        let currentFocusVersion = AppInfo.shortVersion
-        let lastFocusVersion = userDefaults.string(forKey: "LastFocusVersionNumber")
-        let currentFocusBuild = AppInfo.buildNumber
-        let lastFocusBuild = userDefaults.string(forKey: "LastFocusBuildNumber")
-
-        if let focusUA = userDefaults.string(forKey: "UserAgent") {
-            if lastiOSVersion == currentiOSVersion
-                && lastFocusVersion == currentFocusVersion
-                && lastFocusBuild == currentFocusBuild {
-                return focusUA
-            }
-        }
-        return nil
-    }
-
-    public static func getDesktopUserAgent() -> String {
-        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15"
-        return String(userAgent)
-    }
-
-    public func getUserAgent() -> String? {
-        let userAgent = isDesktopMode ? UserAgent.getDesktopUserAgent() : userDefaults.string(forKey: "UserAgent")
-        return userAgent
-    }
-
-    private func setUserAgent(userAgent: String) {
-        userDefaults.register(defaults: ["UserAgent": userAgent])
-    }
-
-    public func changeUserAgent() {
-        if isDesktopMode {
-            setup()
-        } else {
-            setUserAgent(userAgent: UserAgent.getDesktopUserAgent())
-            isDesktopMode = true
-        }
-    }
-
-    public static func mobileUserAgent() -> String {
-        return UserAgentBuilder.defaultMobileUserAgent().userAgent()
-    }
-}
-
 struct UserAgentExtras {
     public static let uaBitSafari = "Safari/605.1.15"
     public static let uaBitMobile = "Mobile/15E148"
@@ -86,46 +11,90 @@ struct UserAgentExtras {
     public static let product = "Mozilla/5.0"
     public static let platform = "AppleWebKit/605.1.15"
     public static let platformDetails = "(KHTML, like Gecko)"
+    public static let systemInfoDesktop = "(Macintosh; Intel Mac OS X 10_15_4)"
+    public static let systemInfoMobile = "(\(UIDevice.current.model); CPU OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)"
     // For iPad, we need to append this to the default UA for google.com to show correct page
-    public static let uaBitGoogleIpad = "Version/13.0.3"
+    public static let uaBitGoogleIpad = "Version/13.1"
 }
 
-public struct UserAgentBuilder {
-    // User agent components
-    fileprivate var product = ""
-    fileprivate var systemInfo = ""
-    fileprivate var platform = ""
-    fileprivate var platformDetails = ""
-    fileprivate var extensions = ""
+enum UserAgentMode {
+    case desktop
+    case mobile
+}
 
-    init(product: String, systemInfo: String, platform: String, platformDetails: String, extensions: String) {
-        self.product = product
-        self.systemInfo = systemInfo
-        self.platform = platform
-        self.platformDetails = platformDetails
-        self.extensions = extensions
+class UserAgent {
+    static let shared = UserAgent()
+
+    private var userDefaults: UserDefaults
+    private var defaultUserAgentDesktop = false
+    private var forcedMode: UserAgentMode?
+
+//    var browserUserAgent: String?
+
+    init(userDefaults: UserDefaults = UserDefaults.standard) {
+        self.userDefaults = userDefaults
+        setup()
     }
 
-    public func userAgent() -> String {
-        let userAgentItems = [product, systemInfo, platform, platformDetails, extensions]
-        return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
+    func setup() {
+        if #available(iOS 15.0, *), UIDevice.current.userInterfaceIdiom == .pad {
+            defaultUserAgentDesktop = true
+        }
+//        if let cachedUserAgent = cachedUserAgent() {
+//            setUserAgent(userAgent: cachedUserAgent)
+//            return
+//        }
+//
+//        let userAgent = getUserAgent()
+//        userDefaults.set(userAgent, forKey: "UserAgent")
+//        userDefaults.set(AppInfo.shortVersion, forKey: "LastFocusVersionNumber")
+//        userDefaults.set(AppInfo.buildNumber, forKey: "LastFocusBuildNumber")
+//        userDefaults.set(UIDevice.current.systemVersion, forKey: "LastDeviceSystemVersionNumber")
+//
+//        setUserAgent(userAgent: userAgent)
     }
 
-    public func clone(product: String? = nil, systemInfo: String? = nil, platform: String? = nil, platformDetails: String? = nil, extensions: String? = nil) -> String {
-        let userAgentItems = [product ?? self.product, systemInfo ?? self.systemInfo, platform ?? self.platform, platformDetails ?? self.platformDetails, extensions ?? self.extensions]
-        return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
+//    private func cachedUserAgent() -> String? {
+//        let currentiOSVersion = UIDevice.current.systemVersion
+//        let lastiOSVersion = userDefaults.string(forKey: "LastDeviceSystemVersionNumber")
+//        let currentFocusVersion = AppInfo.shortVersion
+//        let lastFocusVersion = userDefaults.string(forKey: "LastFocusVersionNumber")
+//        let currentFocusBuild = AppInfo.buildNumber
+//        let lastFocusBuild = userDefaults.string(forKey: "LastFocusBuildNumber")
+//
+//        if let focusUA = userDefaults.string(forKey: "UserAgent") {
+//            if lastiOSVersion == currentiOSVersion
+//                && lastFocusVersion == currentFocusVersion
+//                && lastFocusBuild == currentFocusBuild {
+//                return focusUA
+//            }
+//        }
+//        return nil
+//    }
+//
+    public static func getDesktopUserAgent() -> String {
+        return "\(UserAgentExtras.product) \(UserAgentExtras.systemInfoDesktop) \(UserAgentExtras.platform) \(UserAgentExtras.platformDetails) \(UserAgentExtras.uaBitGoogleIpad) \(UserAgentExtras.uaBitSafari)"
     }
 
-    /// Helper method to remove the empty components from user agent string that contain only whitespaces or are just empty
-    private func removeEmptyComponentsAndJoin(uaItems: [String]) -> String {
-        return uaItems.filter { !$0.isEmptyOrWhitespace() }.joined(separator: " ")
+    public static func mobileUserAgent() -> String {
+        return "\(UserAgentExtras.product) \(UserAgentExtras.systemInfoMobile) \(UserAgentExtras.platform) \(UserAgentExtras.platformDetails) FxiOS/\(AppInfo.shortVersion)  \(UserAgentExtras.uaBitMobile) \(UserAgentExtras.uaBitSafari)"
     }
 
-    public static func defaultMobileUserAgent() -> UserAgentBuilder {
-        return UserAgentBuilder(product: UserAgentExtras.product, systemInfo: "(\(UIDevice.current.model); CPU OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)", platform: UserAgentExtras.platform, platformDetails: UserAgentExtras.platformDetails, extensions: "FxiOS/\(AppInfo.shortVersion)  \(UserAgentExtras.uaBitMobile) \(UserAgentExtras.uaBitSafari)")
+    public func getUserAgent() -> String {
+        let isDesktop: Bool = forcedMode == nil ? defaultUserAgentDesktop : forcedMode! == .desktop ? true : false
+        let userAgent = isDesktop ? UserAgent.getDesktopUserAgent() : UserAgent.mobileUserAgent()
+        return userAgent
     }
 
-    public static func defaultDesktopUserAgent() -> UserAgentBuilder {
-        return UserAgentBuilder(product: UserAgentExtras.product, systemInfo: "(Macintosh; Intel Mac OS X 10.15)", platform: UserAgentExtras.platform, platformDetails: UserAgentExtras.platformDetails, extensions: "FxiOS/\(AppInfo.shortVersion) \(UserAgentExtras.uaBitSafari)")
+//    private func setUserAgent(userAgent: String) {
+//        userDefaults.register(defaults: ["UserAgent": userAgent])
+//    }
+
+    public func changeUserAgent() {
+        guard forcedMode == nil else {
+            forcedMode = forcedMode == .desktop ? .mobile : .desktop
+            return
+        }
+        forcedMode = defaultUserAgentDesktop ? .mobile : .desktop
     }
 }

--- a/Blockzilla/UserAgent.swift
+++ b/Blockzilla/UserAgent.swift
@@ -24,12 +24,9 @@ enum UserAgentMode {
 
 class UserAgent {
     static let shared = UserAgent()
-
     private var userDefaults: UserDefaults
     private var defaultUserAgentDesktop = false
     private var forcedMode: UserAgentMode?
-
-//    var browserUserAgent: String?
 
     init(userDefaults: UserDefaults = UserDefaults.standard) {
         self.userDefaults = userDefaults
@@ -40,38 +37,8 @@ class UserAgent {
         if #available(iOS 15.0, *), UIDevice.current.userInterfaceIdiom == .pad {
             defaultUserAgentDesktop = true
         }
-//        if let cachedUserAgent = cachedUserAgent() {
-//            setUserAgent(userAgent: cachedUserAgent)
-//            return
-//        }
-//
-//        let userAgent = getUserAgent()
-//        userDefaults.set(userAgent, forKey: "UserAgent")
-//        userDefaults.set(AppInfo.shortVersion, forKey: "LastFocusVersionNumber")
-//        userDefaults.set(AppInfo.buildNumber, forKey: "LastFocusBuildNumber")
-//        userDefaults.set(UIDevice.current.systemVersion, forKey: "LastDeviceSystemVersionNumber")
-//
-//        setUserAgent(userAgent: userAgent)
     }
 
-//    private func cachedUserAgent() -> String? {
-//        let currentiOSVersion = UIDevice.current.systemVersion
-//        let lastiOSVersion = userDefaults.string(forKey: "LastDeviceSystemVersionNumber")
-//        let currentFocusVersion = AppInfo.shortVersion
-//        let lastFocusVersion = userDefaults.string(forKey: "LastFocusVersionNumber")
-//        let currentFocusBuild = AppInfo.buildNumber
-//        let lastFocusBuild = userDefaults.string(forKey: "LastFocusBuildNumber")
-//
-//        if let focusUA = userDefaults.string(forKey: "UserAgent") {
-//            if lastiOSVersion == currentiOSVersion
-//                && lastFocusVersion == currentFocusVersion
-//                && lastFocusBuild == currentFocusBuild {
-//                return focusUA
-//            }
-//        }
-//        return nil
-//    }
-//
     public static func getDesktopUserAgent() -> String {
         return "\(UserAgentExtras.product) \(UserAgentExtras.systemInfoDesktop) \(UserAgentExtras.platform) \(UserAgentExtras.platformDetails) \(UserAgentExtras.uaBitGoogleIpad) \(UserAgentExtras.uaBitSafari)"
     }
@@ -85,10 +52,6 @@ class UserAgent {
         let userAgent = isDesktop ? UserAgent.getDesktopUserAgent() : UserAgent.mobileUserAgent()
         return userAgent
     }
-
-//    private func setUserAgent(userAgent: String) {
-//        userDefaults.register(defaults: ["UserAgent": userAgent])
-//    }
 
     public func changeUserAgent() {
         guard forcedMode == nil else {

--- a/Blockzilla/UserAgent.swift
+++ b/Blockzilla/UserAgent.swift
@@ -34,7 +34,7 @@ class UserAgent {
     }
 
     func setup() {
-        if #available(iOS 15.0, *), UIDevice.current.userInterfaceIdiom == .pad {
+        if #available(iOS 13.0, *), UIDevice.current.userInterfaceIdiom == .pad {
             defaultUserAgentDesktop = true
         }
     }

--- a/Blockzilla/UserAgent.swift
+++ b/Blockzilla/UserAgent.swift
@@ -24,10 +24,7 @@ class UserAgent {
             return
         }
 
-        guard let userAgent = UserAgent.generateUserAgent() else {
-            return
-        }
-
+        let userAgent = UserAgent.mobileUserAgent()
         userDefaults.set(userAgent, forKey: "UserAgent")
         userDefaults.set(AppInfo.shortVersion, forKey: "LastFocusVersionNumber")
         userDefaults.set(AppInfo.buildNumber, forKey: "LastFocusBuildNumber")
@@ -54,41 +51,8 @@ class UserAgent {
         return nil
     }
 
-    private static func generateUserAgent() -> String? {
-        let webView = UIWebView()
-
-        let userAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent")!
-
-        // Extract the WebKit version and use it as the Safari version.
-        let webKitVersionRegex = try! NSRegularExpression(pattern: "AppleWebKit/([^ ]+) ", options: [])
-
-        let match = webKitVersionRegex.firstMatch(in: userAgent, options: [],
-                                                  range: NSRange(location: 0, length: userAgent.count))
-
-        if match == nil {
-            print("Error: Unable to determine WebKit version in UA.")
-            return userAgent     // Fall back to Safari's.
-        }
-
-        let webKitVersion = (userAgent as NSString).substring(with: match!.range(at: 1))
-
-        // Insert version before the Mobile/ section.
-        let mobileRange = (userAgent as NSString).range(of: "Mobile/")
-        if mobileRange.location == NSNotFound {
-            print("Error: Unable to find Mobile section in UA.")
-            return userAgent     // Fall back to Safari's.
-        }
-
-        let mutableUA = NSMutableString(string: userAgent)
-        mutableUA.insert("FxiOS/\(AppInfo.shortVersion) ", at: mobileRange.location)
-
-        let focusUA = "\(mutableUA) Safari/\(webKitVersion)"
-
-        return focusUA
-    }
-
     public static func getDesktopUserAgent() -> String {
-        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.12 (KHTML, like Gecko) Version/11.1 Safari/605.1.12"
+        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15"
         return String(userAgent)
     }
 
@@ -108,5 +72,60 @@ class UserAgent {
             setUserAgent(userAgent: UserAgent.getDesktopUserAgent())
             isDesktopMode = true
         }
+    }
+
+    public static func mobileUserAgent() -> String {
+        return UserAgentBuilder.defaultMobileUserAgent().userAgent()
+    }
+}
+
+struct UserAgentExtras {
+    public static let uaBitSafari = "Safari/605.1.15"
+    public static let uaBitMobile = "Mobile/15E148"
+    public static let uaBitFx = "FxiOS/\(AppInfo.shortVersion)"
+    public static let product = "Mozilla/5.0"
+    public static let platform = "AppleWebKit/605.1.15"
+    public static let platformDetails = "(KHTML, like Gecko)"
+    // For iPad, we need to append this to the default UA for google.com to show correct page
+    public static let uaBitGoogleIpad = "Version/13.0.3"
+}
+
+public struct UserAgentBuilder {
+    // User agent components
+    fileprivate var product = ""
+    fileprivate var systemInfo = ""
+    fileprivate var platform = ""
+    fileprivate var platformDetails = ""
+    fileprivate var extensions = ""
+
+    init(product: String, systemInfo: String, platform: String, platformDetails: String, extensions: String) {
+        self.product = product
+        self.systemInfo = systemInfo
+        self.platform = platform
+        self.platformDetails = platformDetails
+        self.extensions = extensions
+    }
+
+    public func userAgent() -> String {
+        let userAgentItems = [product, systemInfo, platform, platformDetails, extensions]
+        return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
+    }
+
+    public func clone(product: String? = nil, systemInfo: String? = nil, platform: String? = nil, platformDetails: String? = nil, extensions: String? = nil) -> String {
+        let userAgentItems = [product ?? self.product, systemInfo ?? self.systemInfo, platform ?? self.platform, platformDetails ?? self.platformDetails, extensions ?? self.extensions]
+        return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
+    }
+
+    /// Helper method to remove the empty components from user agent string that contain only whitespaces or are just empty
+    private func removeEmptyComponentsAndJoin(uaItems: [String]) -> String {
+        return uaItems.filter { !$0.isEmptyOrWhitespace() }.joined(separator: " ")
+    }
+
+    public static func defaultMobileUserAgent() -> UserAgentBuilder {
+        return UserAgentBuilder(product: UserAgentExtras.product, systemInfo: "(\(UIDevice.current.model); CPU OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)", platform: UserAgentExtras.platform, platformDetails: UserAgentExtras.platformDetails, extensions: "FxiOS/\(AppInfo.shortVersion)  \(UserAgentExtras.uaBitMobile) \(UserAgentExtras.uaBitSafari)")
+    }
+
+    public static func defaultDesktopUserAgent() -> UserAgentBuilder {
+        return UserAgentBuilder(product: UserAgentExtras.product, systemInfo: "(Macintosh; Intel Mac OS X 10.15)", platform: UserAgentExtras.platform, platformDetails: UserAgentExtras.platformDetails, extensions: "FxiOS/\(AppInfo.shortVersion) \(UserAgentExtras.uaBitSafari)")
     }
 }

--- a/Blockzilla/UserAgent.swift
+++ b/Blockzilla/UserAgent.swift
@@ -39,7 +39,7 @@ class UserAgent {
         }
     }
 
-    public static func getDesktopUserAgent() -> String {
+    public static func desktopUserAgent() -> String {
         return "\(UserAgentExtras.product) \(UserAgentExtras.systemInfoDesktop) \(UserAgentExtras.platform) \(UserAgentExtras.platformDetails) \(UserAgentExtras.uaBitGoogleIpad) \(UserAgentExtras.uaBitSafari)"
     }
 
@@ -49,7 +49,7 @@ class UserAgent {
 
     public func getUserAgent() -> String {
         let isDesktop: Bool = forcedMode == nil ? defaultUserAgentDesktop : forcedMode! == .desktop ? true : false
-        let userAgent = isDesktop ? UserAgent.getDesktopUserAgent() : UserAgent.mobileUserAgent()
+        let userAgent = isDesktop ? UserAgent.desktopUserAgent() : UserAgent.mobileUserAgent()
         return userAgent
     }
 

--- a/ClientTests/UserAgentTests.swift
+++ b/ClientTests/UserAgentTests.swift
@@ -12,54 +12,26 @@ import XCTest
 
 class UserAgentTests: XCTestCase {
     private let fakeUserAgent = "a-fake-browser"
-
-    private let mockUserDefaults = MockUserDefaults()
-
+    
     override func setUp() {
         super.setUp()
-        mockUserDefaults.clear()
+    }
+    
+    func testMobileUserAgent() {
+        let compare: (String) -> Bool = { ua in
+            let range = ua.range(of: "^Mozilla/5\\.0 \\(.+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\)", options: .regularExpression)
+            return range != nil
+        }
+        XCTAssertTrue(compare(UserAgent.mobileUserAgent()), "User agent computes correctly.")
     }
 
-    func testSetsCachedUserAgent() {
-        mockUserDefaults.set(UIDevice.current.systemVersion, forKey: "LastDeviceSystemVersionNumber")
-        mockUserDefaults.set(AppInfo.shortVersion, forKey: "LastFocusVersionNumber")
-        mockUserDefaults.set(AppInfo.buildNumber, forKey: "LastFocusBuildNumber")
-        mockUserDefaults.set(fakeUserAgent, forKey: "UserAgent")
-
-        _ = UserAgent(userDefaults: mockUserDefaults)
-        XCTAssertNotNil(mockUserDefaults.registerValue)
-        XCTAssertEqual(mockUserDefaults.registerValue!["UserAgent"] as? String, fakeUserAgent)
-    }
-
-    func testSetsGeneratedUserAgent() {
-        mockUserDefaults.removeObject(forKey: "LastDeviceSystemVersionNumber")
-        mockUserDefaults.removeObject(forKey: "LastFocusVersionNumber")
-        mockUserDefaults.removeObject(forKey: "LastFocusBuildNumber")
-        mockUserDefaults.removeObject(forKey: "UserAgent")
-
-        _ = UserAgent(userDefaults: mockUserDefaults)
-        XCTAssertNotNil(mockUserDefaults.registerValue)
-        XCTAssertNotNil(mockUserDefaults.string(forKey: "LastFocusVersionNumber"))
-        XCTAssertTrue(((mockUserDefaults.registerValue!["UserAgent"] as? String)?.contains("FxiOS"))!)
-    }
-
-    func testGetDesktopUserAgent() {
-        XCTAssertEqual(UserAgent.getDesktopUserAgent(), "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.12 (KHTML, like Gecko) Version/11.1 Safari/605.1.12")
-    }
-}
-
-private class MockUserDefaults: UserDefaults {
-    var registerValue: [String: Any]?
-
-    func clear() {
-        removeObject(forKey: "LastFocusVersionNumber")
-        removeObject(forKey: "LastFocusBuildNumber")
-        removeObject(forKey: "LastDeviceSystemVersionNumber")
-        removeObject(forKey: "UserAgent")
-        registerValue = nil
-    }
-
-    override func register(defaults registrationDictionary: [String: Any]) {
-        registerValue = registrationDictionary
+    func testDesktopUserAgent() {
+        let compare: (String) -> Bool = { ua in
+            let range = ua.range(of: "^Mozilla/5\\.0 \\(.+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) Version/[0-9\\.]+ Safari/[0-9\\.]", options: .regularExpression)
+            return range != nil
+        }
+        // Sample valid user agent string
+        // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15
+        XCTAssertTrue(compare(UserAgent.desktopUserAgent()), "Desktop user agent computes correctly.")
     }
 }


### PR DESCRIPTION
Aligning user agents that we use in Firefox iOS.
Focus was using older format. Below are the new version of user agents.
Also, removing tech debt that allows us to no longer rely on making a UIWebview to build a new user agent. 

Previously:
`Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/8.1.3 Mobile/15E148 Safari/605.1.15`

`Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/8.1.3 Mobile/15E148 Safari/605.1.15`

Now:     
`Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/8.1.3  Mobile/15E148 Safari/605.1.15`

`Mozilla/5.0 (iPhone; CPU OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/8.1.3  Mobile/15E148 Safari/605.1.15`