### PR TITLE
Speed up UI tests by disabling the First Run UI by default

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -93,10 +93,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
 
         let prefIntroDone = UserDefaults.standard.integer(forKey: AppDelegate.prefIntroDone)
 
+        // Short circuit if we are testing. We special case the first run handling and completely
+        // skip the what's new handling. This logic could be put below but that is already way
+        // too complicated. Everything under this commen should really be refactored.
+        
         if AppInfo.isTesting() {
-            let firstRunViewController = IntroViewController()
-            firstRunViewController.modalPresentationStyle = .fullScreen
-            self.browserViewController.present(firstRunViewController, animated: false, completion: nil)
+            // Only show the First Run UI if the test asks for it.
+            if AppInfo.isFirstRunUIEnabled() {
+                let firstRunViewController = IntroViewController()
+                firstRunViewController.modalPresentationStyle = .fullScreen
+                self.browserViewController.present(firstRunViewController, animated: false, completion: nil)
+            }
             return true
         }
 

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -70,4 +70,8 @@ class AppInfo {
     open class func testRequestsReset() -> Bool {
         return ProcessInfo.processInfo.arguments.contains("testMode")
     }
+    
+    open class func isFirstRunUIEnabled() -> Bool {
+        return !ProcessInfo.processInfo.arguments.contains("disableFirstRunUI")
+    }
 }

--- a/XCUITest/AsianLocaleTest.swift
+++ b/XCUITest/AsianLocaleTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class AsianLocaleTest: BaseTestCase {
-
-	override func setUp() {
-		super.setUp()
-		dismissFirstRunUI()
-	}
-
-	override func tearDown() {
-		app.terminate()
-		super.tearDown()
-	}
-
 	func testSearchinLocale() {
         // Set search engine to Google
 		app.buttons["Settings"].tap()

--- a/XCUITest/BaseTestCase.swift
+++ b/XCUITest/BaseTestCase.swift
@@ -11,12 +11,13 @@ class BaseTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        app.launchArguments = ["testMode"]
+        app.launchArguments = ["testMode", "disableFirstRunUI"]
         app.launch()
     }
 
     override func tearDown() {
         super.tearDown()
+        app.terminate()
     }
 
     //If it is a first run, first run window should be gone

--- a/XCUITest/CollapsedURLTest.swift
+++ b/XCUITest/CollapsedURLTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class CollapsedURLTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testCheckCollapsedURL() {
         let app = XCUIApplication()
 

--- a/XCUITest/CopyTest.swift
+++ b/XCUITest/CopyTest.swift
@@ -7,17 +7,6 @@ import XCTest
 // Note: this test is tested as part of the base test case, and thus is disabled here.
 
 class CopyTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testCopyMenuItem() {
         let urlBarTextField = app.textFields["URLBar.urlText"]
         loadWebPage("http://localhost:6573/licenses.html")

--- a/XCUITest/DragAndDropTest.swift
+++ b/XCUITest/DragAndDropTest.swift
@@ -11,16 +11,6 @@ import XCTest
 class DragAndDropTest: BaseTestCase {
     let websiteWithSearchField = ["url": "https://developer.mozilla.org/en-US/search", "urlSearchField": "Search the docs"]
 
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testDragElement() {
         if UIDevice.current.userInterfaceIdiom == .pad {
             let urlBarTextField = app.textFields["URLBar.urlText"]

--- a/XCUITest/FindInPageTest.swift
+++ b/XCUITest/FindInPageTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class FindInPageTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testFindInPageURLBarElement() {
         // Navigate to website
         loadWebPage("http://localhost:6573/licenses.html\n")

--- a/XCUITest/OnboardingTest.swift
+++ b/XCUITest/OnboardingTest.swift
@@ -4,19 +4,33 @@
 
 import XCTest
 
-class OnboardingTest: BaseTestCase {
+class OnboardingTest: XCTestCase {
+    let app = XCUIApplication()
 
     override func setUp() {
         super.setUp()
+        continueAfterFailure = false
+        app.launchArguments = ["testMode"]
+        app.launch()
     }
 
     override func tearDown() {
-        app.terminate()
         super.tearDown()
+        app.terminate()
+    }
+
+    // Copied from BaseTestCase
+    private func waitforExistence(element: XCUIElement, file: String = #file, line: UInt = #line) {
+        expectation(for: NSPredicate(format: "exists == true"), evaluatedWith: element, handler: nil)
+        waitForExpectations(timeout: 30) {(error) -> Void in
+            if (error != nil) {
+                let message = "Failed to find \(element) after 30 seconds."
+                self.recordFailure(withDescription: message, inFile: file, atLine: Int(line), expected: true)
+            }
+        }
     }
 
     func testPressingDots() {
-
         let stackElement = app.otherElements["Intro.stackView"]
         let pageIndicatorButton1 = stackElement.children(matching: .button).matching(identifier: "page indicator").element(boundBy: 0)
         let pageIndicatorButton2 = stackElement.children(matching: .button).matching(identifier: "page indicator").element(boundBy: 1)

--- a/XCUITest/OpenInFocusTest.swift
+++ b/XCUITest/OpenInFocusTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class OpenInFocusTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func xtestOpenViaSafari() {
         waitforHittable(element: app.textFields["URLBar.urlText"]) // wait for app.label
         let sharedExtName = app.label.contains("Klar") ? "Firefox Klar" : "Firefox Focus" as String

--- a/XCUITest/PastenGoTest.swift
+++ b/XCUITest/PastenGoTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class PastenGoTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        XCUIApplication().terminate()
-        super.tearDown()
-    }
-
     // Test the clipboard contents are displayed/updated properly
     func testClipboard() {
         let app = XCUIApplication()

--- a/XCUITest/QuickAddAutocompleteURLTest.swift
+++ b/XCUITest/QuickAddAutocompleteURLTest.swift
@@ -5,16 +5,6 @@
 import XCTest
 
 class QuickAddAutocompleteURLTest: BaseTestCase {
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testURLContextMenu() {
 
         let urlBarTextField = app.textFields["URLBar.urlText"]

--- a/XCUITest/RequestDesktopTest.swift
+++ b/XCUITest/RequestDesktopTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class RequestDesktopTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testLongPressReloadButton() {
         let urlBarTextField = app.textFields["URLBar.urlText"]
 

--- a/XCUITest/SearchProviderTest.swift
+++ b/XCUITest/SearchProviderTest.swift
@@ -5,18 +5,6 @@
 import XCTest
 
 class SearchProviderTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-		app.terminate()
-        super.tearDown()
-    }
-
     func testGoogleSearchProvider() {
         searchProviderTestHelper(provider: "Google")
     }

--- a/XCUITest/SearchSuggestionsTest.swift
+++ b/XCUITest/SearchSuggestionsTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class SearchSuggestionsPromptTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func checkToggle(isOn: Bool) {
         let targetValue = isOn ? "1" : "0"
         XCTAssertEqual(app.tables.switches["BlockerToggle.enableSearchSuggestions"].value as! String, targetValue)

--- a/XCUITest/SettingAppearanceTest.swift
+++ b/XCUITest/SettingAppearanceTest.swift
@@ -5,16 +5,6 @@
 import XCTest
 
 class SettingAppearanceTest: BaseTestCase {
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     // Check for the basic appearance of the Settings Menu
     func testCheckSetting() {
         waitforHittable(element: app.buttons["Settings"])

--- a/XCUITest/TPSettingsTest.swift
+++ b/XCUITest/TPSettingsTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class TrackingProtectionSettings: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testInactiveSettings() {
 
         // Go to in-app settings

--- a/XCUITest/TPSidebarBadge.swift
+++ b/XCUITest/TPSidebarBadge.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class TrackingProtectionMenu: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testActiveProtectionSidebar() {
 
         // Visit https://www.mozilla.org

--- a/XCUITest/UserAgentTest.swift
+++ b/XCUITest/UserAgentTest.swift
@@ -6,16 +6,6 @@ import XCTest
 
 class UserAgentTest: BaseTestCase {
 
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testSignInWithGoogle() {
         loadWebPage("https://getpocket.com/")
         let btn = app.links["Sign up with Google"]

--- a/XCUITest/WebsiteAccessTest.swift
+++ b/XCUITest/WebsiteAccessTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class WebsiteAccessTests: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
-
     func testVisitWebsite() {
         // Check initial page
         checkForHomeScreen()

--- a/XCUITest/WebsiteMemoryTest.swift
+++ b/XCUITest/WebsiteMemoryTest.swift
@@ -5,17 +5,6 @@
 import XCTest
 
 class WebsiteMemoryTest: BaseTestCase {
-
-    override func setUp() {
-        super.setUp()
-        dismissFirstRunUI()
-    }
-
-    override func tearDown() {
-        XCUIApplication().terminate()
-        super.tearDown()
-    }
-
     func testGoogleTextField() {
         let app = XCUIApplication()
         var googleSearchField: XCUIElement = app.webViews.otherElements["Search"]


### PR DESCRIPTION
This patch optimizes UI tests by disabling the First Run UI when the app is running in a UI Test.

Tests that do want the First Run UI to be shown should remove the `disableFirstRunUI` flag. Currently only `OnboardingTest` does that since it is the only test that cares about the First Run UI. All the other UI tests simply dismiss it.

I think this has the potential to speed up the test suite, and thus CI builds, by at least a few minutes.
