### PR TITLE
Fixes #1772 - Remove the AgileBits/onepassword-extension dependency

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -144,7 +144,6 @@
 		D597608C1F9FEFB300A2D212 /* TrackingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D597608B1F9FEFB300A2D212 /* TrackingProtection.swift */; };
 		D5ABA3D91FCC846800D5C060 /* AddCustomDomainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ABA3D71FCC846800D5C060 /* AddCustomDomainViewController.swift */; };
 		D5ABA3DA1FCC846800D5C060 /* AutocompleteSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ABA3D81FCC846800D5C060 /* AutocompleteSettingViewController.swift */; };
-		D5B10AAB1FD5EFA40044523A /* OnePasswordExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 747ADA1D1FCE0B7B00970132 /* OnePasswordExtension.framework */; };
 		D5D067FB252F945D00C35227 /* metrics.yaml in Resources */ = {isa = PBXBuildFile; fileRef = D5D067FA252F945D00C35227 /* metrics.yaml */; };
 		D5D2F02B252FA6AE00761DC8 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2F02A252FA6AE00761DC8 /* Metrics.swift */; };
 		D5D2F041252FA71B00761DC8 /* Glean.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5D067F0252F926E00C35227 /* Glean.framework */; };
@@ -460,7 +459,6 @@
 		746BD9251F75C43C00BE8DB9 /* DataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
 		746BD9271F75C45A00BE8DB9 /* DictionaryExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensions.swift; sourceTree = "<group>"; };
 		747ADA171FC38EFC00970132 /* IntroViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewController.swift; sourceTree = "<group>"; };
-		747ADA1D1FCE0B7B00970132 /* OnePasswordExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OnePasswordExtension.framework; path = Carthage/Build/iOS/OnePasswordExtension.framework; sourceTree = "<group>"; };
 		74CC0ADA1FAD28DB00972A78 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		74CC0ADB1FAD28DC00972A78 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		74CC0ADC1FAD28DD00972A78 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -961,7 +959,6 @@
 			files = (
 				163BFFE42124F8E10007CEBC /* IntentsUI.framework in Frameworks */,
 				163BFFE22124EBAF0007CEBC /* Intents.framework in Frameworks */,
-				D5B10AAB1FD5EFA40044523A /* OnePasswordExtension.framework in Frameworks */,
 				F8324C2F264C807C007E4BFA /* SnapKit in Frameworks */,
 				D3AAC2911EAE9146005B7E8C /* AutocompleteTextField.framework in Frameworks */,
 				E47F9AE71DB929D800A93285 /* AdSupport.framework in Frameworks */,
@@ -1161,7 +1158,6 @@
 				D5D067F0252F926E00C35227 /* Glean.framework */,
 				163BFFE32124F8E10007CEBC /* IntentsUI.framework */,
 				163BFFE12124EBAF0007CEBC /* Intents.framework */,
-				747ADA1D1FCE0B7B00970132 /* OnePasswordExtension.framework */,
 				746BD91B1F758BEC00BE8DB9 /* Carthage */,
 				D3AAC28C1EAE8F5A005B7E8C /* AutocompleteTextField.framework */,
 				E47F9AE51DB929D800A93285 /* AdSupport.framework */,
@@ -1773,7 +1769,6 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/AutocompleteTextField.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Telemetry.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/OnePasswordExtension.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Glean.framework",
 			);
 			name = "Run Script (Carthage)";

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -5,7 +5,6 @@
 import UIKit
 import WebKit
 import Telemetry
-import OnePasswordExtension
 import PassKit
 
 protocol BrowserState {
@@ -425,25 +424,5 @@ extension WebViewController: WKScriptMessageHandler {
                 self.trackingInformation = self.trackingInformation.create(byAddingListItem: listItem)
             }
         }
-    }
-}
-
-extension WebViewController {
-    func createPasswordManagerExtensionItem() {
-        OnePasswordExtension.shared().createExtensionItem(forWebView: browserView, completion: {(extensionItem, error) -> Void in
-            if extensionItem == nil {
-                return
-            }
-            // Set the 1Password extension item property
-            self.onePasswordExtensionItem = extensionItem
-        })
-    }
-
-    func fillPasswords(returnedItems: [AnyObject]) {
-        OnePasswordExtension.shared().fillReturnedItems(returnedItems, intoWebView: browserView, completion: { (success, returnedItemsError) -> Void in
-            if !success {
-                return
-            }
-        })
     }
 }

--- a/Blockzilla/OpenUtils.swift
+++ b/Blockzilla/OpenUtils.swift
@@ -2,14 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Foundation
+import UIKit
 import Telemetry
-import OnePasswordExtension
 
 class OpenUtils: NSObject {
     private let app = UIApplication.shared
     private let selectedURL: URL
-    private let browserFillIdentifier = "org.appextension.fill-browser-action"
     private let webViewController: WebViewController
 
     init(url: URL, webViewController: WebViewController) {
@@ -35,11 +33,6 @@ class OpenUtils: NSObject {
 
         let shareController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
 
-        // This needs to be ready by the time the share menu has been displayed and
-        // activityViewController(activityViewController:, activityType:) is called,
-        // which is after the user taps the button. So a million cycles away.
-        findLoginExtensionItem()
-
         shareController.popoverPresentationController?.permittedArrowDirections = .up
         shareController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
             if !completed {
@@ -51,64 +44,8 @@ class OpenUtils: NSObject {
             if let url = UIPasteboard.general.urls?.first {
                 UIPasteboard.general.urls = [url]
             }
-
-            if self.isPasswordManagerActivityType(activityType.map { $0.rawValue }) {
-                Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.show, object: TelemetryEventObject.autofill)
-                if let logins = returnedItems {
-                    self.fillPasswords(returnedItems: logins as [AnyObject])
-                    Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.autofill)
-                }
-            }
         }
         return shareController
     }
 }
 
-extension OpenUtils: UIActivityItemSource {
-    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        return selectedURL
-    }
-
-    // IMPORTANT: This method needs Swift compiler optimization DISABLED to prevent a nasty
-    // crash from happening in release builds. It seems as though the check for `nil` may
-    // get removed by the optimizer which leads to a crash when that happens.
-    @_semantics("optimize.sil.never") func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        // activityType actually is nil sometimes (in the simulator at least)
-        if activityType != nil && isPasswordManagerActivityType(activityType?.rawValue) {
-            return webViewController.onePasswordExtensionItem
-        } else {
-            return selectedURL
-        }
-    }
-
-    func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivity.ActivityType?) -> String {
-        if let type = activityType, isPasswordManagerActivityType(type.rawValue) {
-            return browserFillIdentifier
-        }
-        return activityType == nil ? browserFillIdentifier : kUTTypeURL as String
-    }
-}
-
-private extension OpenUtils {
-    func isPasswordManagerActivityType(_ activityType: String?) -> Bool {
-        // A 'password' substring covers the most cases, such as pwsafe and 1Password.
-        // com.agilebits.onepassword-ios.extension
-        // com.app77.ios.pwsafe2.find-login-action-password-actionExtension
-        // If your extension's bundle identifier does not contain "password", simply submit a pull request by adding your bundle identifier.
-        guard let activityType = activityType else { return false }
-        return (activityType.range(of: "password") != nil)
-            || (activityType == "com.lastpass.ilastpass.LastPassExt")
-            || (activityType == "in.sinew.Walletx.WalletxExt")
-            || (activityType == "com.8bit.bitwarden.find-login-action-extension")
-
-    }
-
-    func findLoginExtensionItem() {
-        // Add 1Password to share sheet
-        webViewController.createPasswordManagerExtensionItem()
-    }
-
-    func fillPasswords(returnedItems: [AnyObject]) {
-        webViewController.fillPasswords(returnedItems: returnedItems)
-    }
-}

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,3 @@
 github "mozilla-mobile/AutocompleteTextField" "master"
 github "mozilla-mobile/telemetry-ios" ~> 1.1
-github "AgileBits/onepassword-extension" "new/carthage+ios10"
 github "mozilla/glean" "v36.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
-github "AgileBits/onepassword-extension" "a614e290396346e3cb69e4951656eb8033390f8c"
 github "mozilla-mobile/AutocompleteTextField" "f5614c04a1fc3f2fa29fbb2e149e0083070fcf1b"
 github "mozilla-mobile/telemetry-ios" "v1.1.2"
 github "mozilla-services/shavar-prod-lists" "c938da47c4880a48ac40d535caff74dac1d4d77b"


### PR DESCRIPTION
This patch removes the `AgileBits/onepassword-extension` dependency. This was useful in the past when CredentialProviders did not exist.

Through this extension you could fill passwords from 1Password into the WKWebView which is now properly covered with the Credential Provider API. And independent of specific password managers.