### PR TITLE
Fixes #1827 - Move Glean from Carthage to Swift Package Manager

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -175,19 +175,19 @@
 		F7FF8B5B2194084000CCA80F /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FF8B5A2194084000CCA80F /* UIDeviceExtensions.swift */; };
 		F805722F1DBEE504004339C1 /* WebCacheUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F805722E1DBEE504004339C1 /* WebCacheUtils.swift */; };
 		F81DF84F2653477F00C83C61 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81DF84E2653477F00C83C61 /* AutocompleteTextField.swift */; };
-		F8324C2F264C807C007E4BFA /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F8324C2E264C807C007E4BFA /* SnapKit */; };
-		F8324C78264DA5F1007E4BFA /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F8324C77264DA5F1007E4BFA /* Sentry */; };
-		F8324CBA264DC8ED007E4BFA /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = F8324CB9264DC8ED007E4BFA /* Fuzi */; };
 		F8324CE4264EA223007E4BFA /* gpl.html in Resources */ = {isa = PBXBuildFile; fileRef = F8324CDF264EA223007E4BFA /* gpl.html */; };
 		F8324CE5264EA223007E4BFA /* licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE0264EA223007E4BFA /* licenses.html */; };
 		F8324CE6264EA223007E4BFA /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE1264EA223007E4BFA /* style.css */; };
 		F8324CE7264EA223007E4BFA /* rights-focus.html in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE2264EA223007E4BFA /* rights-focus.html */; };
 		F8324CE8264EA223007E4BFA /* rights-klar.html in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE3264EA223007E4BFA /* rights-klar.html */; };
-		F8324E0926556E45007E4BFA /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = F8324E0826556E45007E4BFA /* Telemetry */; };
 		F84AFE751DE77FE6005C4DD1 /* LaunchScreen.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE721DE77FE6005C4DD1 /* LaunchScreen.png */; };
 		F84AFE761DE77FE6005C4DD1 /* LaunchScreen@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE731DE77FE6005C4DD1 /* LaunchScreen@2x.png */; };
 		F84AFE771DE77FE6005C4DD1 /* LaunchScreen@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE741DE77FE6005C4DD1 /* LaunchScreen@3x.png */; };
-		F8624522265583EA0047D861 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = F8624521265583EA0047D861 /* Glean */; };
+		F85F7A292655AD5800395515 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A282655AD5800395515 /* SnapKit */; };
+		F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2A2655AD5800395515 /* Fuzi */; };
+		F85F7A2D2655AD5800395515 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2C2655AD5800395515 /* Sentry */; };
+		F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2E2655AD5800395515 /* Telemetry */; };
+		F85F7A352656885C00395515 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A342656885C00395515 /* Glean */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -247,6 +247,16 @@
 				E4BF2DF51BACE92400DA9D68 /* ContentBlocker.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F85F7A322655ADC000395515 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -957,21 +967,20 @@
 			files = (
 				163BFFE42124F8E10007CEBC /* IntentsUI.framework in Frameworks */,
 				163BFFE22124EBAF0007CEBC /* Intents.framework in Frameworks */,
-				F8324C2F264C807C007E4BFA /* SnapKit in Frameworks */,
 				E47F9AE71DB929D800A93285 /* AdSupport.framework in Frameworks */,
+				F85F7A292655AD5800395515 /* SnapKit in Frameworks */,
 				E47F9AE81DB929D800A93285 /* iAd.framework in Frameworks */,
-				F8324E0926556E45007E4BFA /* Telemetry in Frameworks */,
 				4285B8E0671F40DA543A2E58 /* AssetsLibrary.framework in Frameworks */,
+				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
 				A57245250F88CCA4993E55B2 /* CoreText.framework in Frameworks */,
 				2B36326E97D2E67E9C684B4B /* CoreTelephony.framework in Frameworks */,
-				D5D2F041252FA71B00761DC8 /* Glean.framework in Frameworks */,
 				2825C3665AB14081B262F767 /* SystemConfiguration.framework in Frameworks */,
-				F8324C78264DA5F1007E4BFA /* Sentry in Frameworks */,
-				F8624522265583EA0047D861 /* Glean in Frameworks */,
+				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
 				34056D10515852F370C83A01 /* QuartzCore.framework in Frameworks */,
+				F85F7A2D2655AD5800395515 /* Sentry in Frameworks */,
 				5AFDBB0CF3A9FBA175D2B693 /* AVFoundation.framework in Frameworks */,
-				F8324CBA264DC8ED007E4BFA /* Fuzi in Frameworks */,
 				2F2F84BCF076B21DE42D1F29 /* CoreMedia.framework in Frameworks */,
+				F85F7A352656885C00395515 /* Glean in Frameworks */,
 				58BD00527359D003DADE601E /* CoreVideo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1453,7 +1462,7 @@
 				E4BF2DD01BACE8CA00DA9D68 /* Frameworks */,
 				E4BF2DD11BACE8CA00DA9D68 /* Resources */,
 				E4BF2DF91BACE92400DA9D68 /* Embed App Extensions */,
-				D38D693F1C471AC7003EF211 /* Run Script (Carthage) */,
+				F85F7A322655ADC000395515 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1464,10 +1473,11 @@
 			);
 			name = Blockzilla;
 			packageProductDependencies = (
-				F8324C2E264C807C007E4BFA /* SnapKit */,
-				F8324CB9264DC8ED007E4BFA /* Fuzi */,
-				F8324C77264DA5F1007E4BFA /* Sentry */,
-				F8624521265583EA0047D861 /* Glean */,
+				F85F7A282655AD5800395515 /* SnapKit */,
+				F85F7A2A2655AD5800395515 /* Fuzi */,
+				F85F7A2C2655AD5800395515 /* Sentry */,
+				F85F7A2E2655AD5800395515 /* Telemetry */,
+				F85F7A342656885C00395515 /* Glean */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1648,8 +1658,8 @@
 				F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */,
 				F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */,
 				F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
-				F8624520265583EA0047D861 /* XCRemoteSwiftPackageReference "glean-swift" */,
 				F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */,
+				F85F7A332656885C00395515 /* XCRemoteSwiftPackageReference "glean-swift" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -1760,20 +1770,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		D38D693F1C471AC7003EF211 /* Run Script (Carthage) */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script (Carthage)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
 		D5D067F9252F939600C35227 /* Glean */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -5204,14 +5200,6 @@
 				version = 3.1.3;
 			};
 		};
-		F8624520265583EA0047D861 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/badboy/glean-swift/";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 38.0.1;
-    	};
-    };
 		F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mozilla-mobile/telemetry-ios";
@@ -5220,33 +5208,41 @@
 				kind = branch;
 			};
 		};
+		F85F7A332656885C00395515 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/badboy/glean-swift/";
+			requirement = {
+				kind = exactVersion;
+				version = 38.0.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F8324C2E264C807C007E4BFA /* SnapKit */ = {
+		F85F7A282655AD5800395515 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
 		};
-		F8324C77264DA5F1007E4BFA /* Sentry */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
-			productName = Sentry;
-		};
-		F8324CB9264DC8ED007E4BFA /* Fuzi */ = {
+		F85F7A2A2655AD5800395515 /* Fuzi */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */;
 			productName = Fuzi;
 		};
-		F8624521265583EA0047D861 /* Glean */ = {
+		F85F7A2C2655AD5800395515 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F8624520265583EA0047D861 /* XCRemoteSwiftPackageReference "glean-swift" */;
-			productName = Glean;
+			package = F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
-		F8324E0826556E45007E4BFA /* Telemetry */ = {
+		F85F7A2E2655AD5800395515 /* Telemetry */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */;
 			productName = Telemetry;
+		};
+		F85F7A342656885C00395515 /* Glean */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F85F7A332656885C00395515 /* XCRemoteSwiftPackageReference "glean-swift" */;
+			productName = Glean;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -146,7 +146,6 @@
 		D5B10AAB1FD5EFA40044523A /* OnePasswordExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 747ADA1D1FCE0B7B00970132 /* OnePasswordExtension.framework */; };
 		D5D067FB252F945D00C35227 /* metrics.yaml in Resources */ = {isa = PBXBuildFile; fileRef = D5D067FA252F945D00C35227 /* metrics.yaml */; };
 		D5D2F02B252FA6AE00761DC8 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2F02A252FA6AE00761DC8 /* Metrics.swift */; };
-		D5D2F041252FA71B00761DC8 /* Glean.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5D067F0252F926E00C35227 /* Glean.framework */; };
 		D803D37420EF1A49001F2819 /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D803D37320EF1A49001F2819 /* UserAgentTests.swift */; };
 		D831FEE2205247A400EAE19A /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831FEE1205247A400EAE19A /* BrowserViewControllerTests.swift */; };
 		D8E0152C1FB4136E00CA3B9F /* AddSearchEngineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E0152B1FB4136E00CA3B9F /* AddSearchEngineViewController.swift */; };
@@ -189,6 +188,7 @@
 		F84AFE751DE77FE6005C4DD1 /* LaunchScreen.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE721DE77FE6005C4DD1 /* LaunchScreen.png */; };
 		F84AFE761DE77FE6005C4DD1 /* LaunchScreen@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE731DE77FE6005C4DD1 /* LaunchScreen@2x.png */; };
 		F84AFE771DE77FE6005C4DD1 /* LaunchScreen@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE741DE77FE6005C4DD1 /* LaunchScreen@3x.png */; };
+		F8624522265583EA0047D861 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = F8624521265583EA0047D861 /* Glean */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -633,7 +633,6 @@
 		D597608B1F9FEFB300A2D212 /* TrackingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtection.swift; sourceTree = "<group>"; };
 		D5ABA3D71FCC846800D5C060 /* AddCustomDomainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddCustomDomainViewController.swift; sourceTree = "<group>"; };
 		D5ABA3D81FCC846800D5C060 /* AutocompleteSettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteSettingViewController.swift; sourceTree = "<group>"; };
-		D5D067F0252F926E00C35227 /* Glean.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Glean.framework; path = Carthage/Build/iOS/Glean.framework; sourceTree = "<group>"; };
 		D5D067FA252F945D00C35227 /* metrics.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = metrics.yaml; sourceTree = "<group>"; };
 		D5D2F02A252FA6AE00761DC8 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		D803D37320EF1A49001F2819 /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
@@ -968,10 +967,10 @@
 				4285B8E0671F40DA543A2E58 /* AssetsLibrary.framework in Frameworks */,
 				A57245250F88CCA4993E55B2 /* CoreText.framework in Frameworks */,
 				2B36326E97D2E67E9C684B4B /* CoreTelephony.framework in Frameworks */,
-				D5D2F041252FA71B00761DC8 /* Glean.framework in Frameworks */,
 				D00A44111EB8F80A00DB0218 /* Telemetry.framework in Frameworks */,
 				2825C3665AB14081B262F767 /* SystemConfiguration.framework in Frameworks */,
 				F8324C78264DA5F1007E4BFA /* Sentry in Frameworks */,
+				F8624522265583EA0047D861 /* Glean in Frameworks */,
 				34056D10515852F370C83A01 /* QuartzCore.framework in Frameworks */,
 				5AFDBB0CF3A9FBA175D2B693 /* AVFoundation.framework in Frameworks */,
 				F8324CBA264DC8ED007E4BFA /* Fuzi in Frameworks */,
@@ -1157,7 +1156,6 @@
 		D77FE464056F274978E025ED /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D5D067F0252F926E00C35227 /* Glean.framework */,
 				163BFFE32124F8E10007CEBC /* IntentsUI.framework */,
 				163BFFE12124EBAF0007CEBC /* Intents.framework */,
 				747ADA1D1FCE0B7B00970132 /* OnePasswordExtension.framework */,
@@ -1474,6 +1472,7 @@
 				F8324C2E264C807C007E4BFA /* SnapKit */,
 				F8324CB9264DC8ED007E4BFA /* Fuzi */,
 				F8324C77264DA5F1007E4BFA /* Sentry */,
+				F8624521265583EA0047D861 /* Glean */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1654,6 +1653,7 @@
 				F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */,
 				F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */,
 				F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				F8624520265583EA0047D861 /* XCRemoteSwiftPackageReference "glean-swift" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -1772,7 +1772,6 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Telemetry.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/OnePasswordExtension.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Glean.framework",
 			);
 			name = "Run Script (Carthage)";
 			outputPaths = (
@@ -5211,6 +5210,14 @@
 				version = 3.1.3;
 			};
 		};
+		F8624520265583EA0047D861 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/badboy/glean-swift/";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 38.0.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -5228,6 +5235,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */;
 			productName = Fuzi;
+		};
+		F8624521265583EA0047D861 /* Glean */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8624520265583EA0047D861 /* XCRemoteSwiftPackageReference "glean-swift" */;
+			productName = Glean;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 github "mozilla-mobile/telemetry-ios" ~> 1.1
 github "AgileBits/onepassword-extension" "new/carthage+ios10"
-github "mozilla/glean" "v36.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "mozilla-services/shavar-prod-lists" "c938da47c4880a48ac40d535caff74dac1d4d77b"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "mozilla-services/shavar-prod-lists" "c938da47c4880a48ac40d535caff74dac1d4d77b"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
 github "AgileBits/onepassword-extension" "a614e290396346e3cb69e4951656eb8033390f8c"
 github "mozilla-mobile/telemetry-ios" "v1.1.2"
 github "mozilla-services/shavar-prod-lists" "c938da47c4880a48ac40d535caff74dac1d4d77b"
-github "mozilla/glean" "v36.0.0"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -37,7 +37,7 @@ workflows:
     - cache-push@2.0.5: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-12.2.x
+        stack: osx-xcode-12.5.x
   primary:
     steps:
     - activate-ssh-key@4:
@@ -100,7 +100,7 @@ workflows:
         - export_method: app-store
     meta:
       bitrise.io:
-        stack: osx-xcode-12.0.x
+        stack: osx-xcode-12.5.x
   primary-xcode-10:
     steps:
     - activate-ssh-key@3.1.1:
@@ -138,7 +138,7 @@ workflows:
             ./Carthage -> ./Carthage/Cachefile
     meta:
       bitrise.io:
-        stack: osx-xcode-12.0.x
+        stack: osx-xcode-12.5.x
   runTests:
     steps:
     - activate-ssh-key@4:
@@ -205,7 +205,7 @@ workflows:
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-12.4.x
+        stack: osx-xcode-12.5.x
   primary-nocache:
     steps:
     - activate-ssh-key@4:
@@ -262,7 +262,7 @@ workflows:
         - export_method: app-store
     meta:
       bitrise.io:
-        stack: osx-xcode-12.0.x
+        stack: osx-xcode-12.5.x
   clone and build dependencies:
     steps:
     - activate-ssh-key@4:
@@ -303,7 +303,7 @@ workflows:
         title: NPM, ContentBlockerGen
     meta:
       bitrise.io:
-        stack: osx-xcode-12.0.x
+        stack: osx-xcode-12.5.x
     description: Clones the repo and builds dependencies
   Set project version:
     steps:
@@ -333,7 +333,7 @@ workflows:
         title: Set OpenInFocus version numbers
     meta:
       bitrise.io:
-        stack: osx-xcode-12.0.x
+        stack: osx-xcode-12.5.x
     before_run: []
   release:
     steps:
@@ -359,7 +359,7 @@ workflows:
         - itunescon_user: "$APPLE_ACCOUNT_ID"
     meta:
       bitrise.io:
-        stack: osx-xcode-12.4.x
+        stack: osx-xcode-12.5.x
     before_run:
     - clone and build dependencies
     - Set project version
@@ -389,7 +389,7 @@ workflows:
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-12.4.x
+        stack: osx-xcode-12.5.x
   runFocus:
     steps:
     - git-clone@4: {}
@@ -445,7 +445,7 @@ workflows:
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-12.4.x
+        stack: osx-xcode-12.5.x
   runKlar:
     steps:
     - git-clone@4: {}
@@ -501,7 +501,7 @@ workflows:
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-12.4.x
+        stack: osx-xcode-12.5.x
 app:
   envs:
   - opts:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,9 +21,6 @@ workflows:
     - script@1.1.5:
         title: Do anything with Script step
     - certificate-and-profile-installer@1.9.3: {}
-    - carthage@3.1.4:
-        inputs:
-        - carthage_command: bootstrap
     - xcode-test@1.18.14:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"
@@ -46,27 +43,6 @@ workflows:
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
-        title: Workaround carthage lipo bug
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
-            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
-            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
-            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
-    - carthage@3.2:
-        inputs:
-        - carthage_options: " --platform ios --cache-builds"
-        - carthage_command: bootstrap
-    - script@1:
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
-            --value ''"
-        title: remove carthage lipo workaround
-    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -81,7 +57,6 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            ./Carthage -> ./Carthage/Cachefile
     - set-xcode-build-number@1:
         inputs:
         - plist_path: Blockzilla/Info.plist
@@ -122,10 +97,6 @@ workflows:
 
             ./build-disconnect.py
     - certificate-and-profile-installer@1.9.3: {}
-    - carthage@3.1.4:
-        inputs:
-        - carthage_options: "--platform ios"
-        - carthage_command: bootstrap
     - xcode-test@1.18.14:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"
@@ -135,7 +106,6 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            ./Carthage -> ./Carthage/Cachefile
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
@@ -146,27 +116,6 @@ workflows:
     - git-clone@4: {}
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
-    - script@1:
-        title: Workaround carthage lipo bug
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
-            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
-            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
-            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
-    - carthage@3.2:
-        inputs:
-        - carthage_options: "--platform ios"
-        - carthage_command: bootstrap
-    - script@1:
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
-            --value ''"
-        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: |-
@@ -201,7 +150,6 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
@@ -212,27 +160,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4: {}
     - certificate-and-profile-installer@1: {}
-    - script@1:
-        title: Workaround carthage lipo bug
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
-            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
-            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
-            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
-    - carthage@3.2:
-        inputs:
-        - carthage_options: " --platform ios --cache-builds"
-        - carthage_command: bootstrap
-    - script@1:
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
-            --value ''"
-        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: |-
@@ -269,27 +196,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4: {}
     - certificate-and-profile-installer@1: {}
-    - script@1:
-        title: Workaround carthage lipo bug
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
-            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
-            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
-            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
-    - carthage@3.2:
-        inputs:
-        - carthage_options: " --platform ios --cache-builds"
-        - carthage_command: bootstrap
-    - script@1:
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
-            --value ''"
-        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: |-
@@ -385,7 +291,6 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
@@ -396,27 +301,6 @@ workflows:
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
-        title: Workaround carthage lipo bug
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
-            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
-            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
-            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
-    - carthage@3.2:
-        inputs:
-        - carthage_options: "--platform ios"
-        - carthage_command: bootstrap
-    - script@1:
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
-            --value ''"
-        title: remove carthage lipo workaround
-    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -441,7 +325,6 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
@@ -452,27 +335,6 @@ workflows:
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
-        title: Workaround carthage lipo bug
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
-            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
-            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
-            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
-    - carthage@3.2:
-        inputs:
-        - carthage_options: "--platform ios"
-        - carthage_command: bootstrap
-    - script@1:
-        inputs:
-        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
-            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
-            --value ''"
-        title: remove carthage lipo workaround
-    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -497,7 +359,6 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,6 +21,9 @@ workflows:
     - script@1.1.5:
         title: Do anything with Script step
     - certificate-and-profile-installer@1.9.3: {}
+    - carthage@3.1.4:
+        inputs:
+        - carthage_command: bootstrap
     - xcode-test@1.18.14:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"
@@ -43,6 +46,27 @@ workflows:
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
+        title: Workaround carthage lipo bug
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
+            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
+            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
+            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
+    - carthage@3.2:
+        inputs:
+        - carthage_options: " --platform ios --cache-builds"
+        - carthage_command: bootstrap
+    - script@1:
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
+            --value ''"
+        title: remove carthage lipo workaround
+    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -57,6 +81,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
+            ./Carthage -> ./Carthage/Cachefile
     - set-xcode-build-number@1:
         inputs:
         - plist_path: Blockzilla/Info.plist
@@ -97,6 +122,10 @@ workflows:
 
             ./build-disconnect.py
     - certificate-and-profile-installer@1.9.3: {}
+    - carthage@3.1.4:
+        inputs:
+        - carthage_options: "--platform ios"
+        - carthage_command: bootstrap
     - xcode-test@1.18.14:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"
@@ -106,6 +135,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
+            ./Carthage -> ./Carthage/Cachefile
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
@@ -116,6 +146,27 @@ workflows:
     - git-clone@4: {}
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
+    - script@1:
+        title: Workaround carthage lipo bug
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
+            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
+            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
+            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
+    - carthage@3.2:
+        inputs:
+        - carthage_options: "--platform ios"
+        - carthage_command: bootstrap
+    - script@1:
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
+            --value ''"
+        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: |-
@@ -150,6 +201,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
+            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
@@ -160,6 +212,27 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4: {}
     - certificate-and-profile-installer@1: {}
+    - script@1:
+        title: Workaround carthage lipo bug
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
+            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
+            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
+            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
+    - carthage@3.2:
+        inputs:
+        - carthage_options: " --platform ios --cache-builds"
+        - carthage_command: bootstrap
+    - script@1:
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
+            --value ''"
+        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: |-
@@ -196,6 +269,27 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4: {}
     - certificate-and-profile-installer@1: {}
+    - script@1:
+        title: Workaround carthage lipo bug
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
+            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
+            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
+            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
+    - carthage@3.2:
+        inputs:
+        - carthage_options: " --platform ios --cache-builds"
+        - carthage_command: bootstrap
+    - script@1:
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
+            --value ''"
+        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: |-
@@ -291,6 +385,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
+            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
@@ -301,6 +396,27 @@ workflows:
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
+        title: Workaround carthage lipo bug
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
+            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
+            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
+            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
+    - carthage@3.2:
+        inputs:
+        - carthage_options: "--platform ios"
+        - carthage_command: bootstrap
+    - script@1:
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
+            --value ''"
+        title: remove carthage lipo workaround
+    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -325,6 +441,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
+            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
@@ -334,6 +451,27 @@ workflows:
     - git-clone@4: {}
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
+    - script@1:
+        title: Workaround carthage lipo bug
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\necho 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig\necho 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig\necho 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig\necho
+            'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig\necho 'GCC_TREAT_WARNINGS_AS_ERRORS=NO'
+            >> /tmp/tmp.xcconfig\nexport XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig\nenvman
+            add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig "
+    - carthage@3.2:
+        inputs:
+        - carthage_options: "--platform ios"
+        - carthage_command: bootstrap
+    - script@1:
+        inputs:
+        - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug
+            log\nset -x\n\n\nrm /tmp/tmp.xcconfig \nenvman add --key XCODE_XCCONFIG_FILE
+            --value ''"
+        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: |-
@@ -359,6 +497,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
+            ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:

--- a/checkout.sh
+++ b/checkout.sh
@@ -4,11 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-if [ "$1" == "--force" ]; then
-    rm -rf Carthage/*
-    rm -rf ~/Library/Caches/org.carthage.CarthageKit
-fi
 
-./carthage_command.sh
 
 (cd content-blocker-lib-ios/ContentBlockerGen && swift run)

--- a/checkout.sh
+++ b/checkout.sh
@@ -4,6 +4,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+if [ "$1" == "--force" ]; then
+    rm -rf Carthage/*
+    rm -rf ~/Library/Caches/org.carthage.CarthageKit
+fi
 
+./carthage_command.sh
 
 (cd content-blocker-lib-ios/ContentBlockerGen && swift run)


### PR DESCRIPTION
This patch uses the new Glean 38.0.1 Swift Package instead of the current Carthage dependency. It pulls in Glean from https://github.com/badboy/glean-swift which will soon move under the mozilla github repo. This is temporary and I filed #1833 to make sure we don't forget to do this.

> 🚨  **Important** - This patch will require Xcode 12.5. Included is a change to `bitrise.yml` to change the Xcode version in all workflows.