### PR TITLE
For #1823 - Add Slack Notification to Bitrise Workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -293,7 +293,7 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            ./checkout.sh
+            ./checko.sh
         title: ContentBlockerGen
     - xcode-build-for-simulator@0:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -276,6 +276,11 @@ workflows:
             $BITRISE_CACHE_DIR
             ./Carthage -> ./Carthage/Cachefile
     - deploy-to-bitrise-io@1: {}
+    - slack@3:
+        run_if: ".IsBuildFailed"
+        inputs:
+        - channel: "#firefox-ios-alerts"
+        - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -279,7 +279,7 @@ workflows:
     - slack@3:
         run_if: ".IsBuildFailed"
         inputs:
-        - channel: "#firefox-ios-alerts"
+        - channel: "#focus-ios-alerts"
         - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -293,7 +293,7 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            ./checko.sh
+            ./checkout.sh
         title: ContentBlockerGen
     - xcode-build-for-simulator@0:
         inputs:


### PR DESCRIPTION
Fixes #1823

Starting with a single notification when the build fails on `#firefox-ios-alerts` channel