### PR TITLE
Fixes #1844 - Include a SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Mozilla Security #
+
+- Mozilla cares about privacy and security. For more information please see: https://www.mozilla.org/security/
+
+- If you believe that you've found a security vulnerability, please report it in [Bugzilla under the Security: iOS](https://bugzilla.mozilla.org/enter_bug.cgi?product=Focus&components=Security:+iOS) component.
+
+- You can also send your report through email to [security@mozilla.org](mailto:security@mozilla.com).


### PR DESCRIPTION
This patch adds a simple security policy that explain where people can file security bugs for Focus iOS.