### PR TITLE
Fixes #1833 - Make sure we pull in Glean from the official repository

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -5167,7 +5167,7 @@
 		};
 		F85F7A332656885C00395515 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/badboy/glean-swift/";
+			repositoryURL = "https://github.com/mozilla/glean-swift/";
 			requirement = {
 				kind = exactVersion;
 				version = 38.0.2;

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,52 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Fuzi",
+        "repositoryURL": "https://github.com/cezheng/Fuzi",
+        "state": {
+          "branch": null,
+          "revision": "f08c8323da21e985f3772610753bcfc652c2103f",
+          "version": "3.1.3"
+        }
+      },
+      {
+        "package": "Glean",
+        "repositoryURL": "https://github.com/mozilla/glean-swift/",
+        "state": {
+          "branch": null,
+          "revision": "bfc206651ba8559f6c54f51dd7d6561dc07531f4",
+          "version": "38.0.2"
+        }
+      },
+      {
+        "package": "Sentry",
+        "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
+        "state": {
+          "branch": null,
+          "revision": "80928b7e19a713fea798ba45c8bfda38096d7f30",
+          "version": "5.2.2"
+        }
+      },
+      {
+        "package": "SnapKit",
+        "repositoryURL": "https://github.com/SnapKit/SnapKit",
+        "state": {
+          "branch": null,
+          "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
+          "version": "5.0.1"
+        }
+      },
+      {
+        "package": "Telemetry",
+        "repositoryURL": "https://github.com/mozilla-mobile/telemetry-ios",
+        "state": {
+          "branch": "main",
+          "revision": "68f2d813320c9fda2fb4aee4548c64293500200a",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
This patch changes the origin of the `glean-swift` package from https://github.com/badboy/glean-swift/ to https://github.com/mozilla/glean-swift/

cc @badboy for awareness
