### PR TITLE
Fixes #1924 - Use Bitrise Second Gen build machines

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,17 +1,22 @@
 ---
 format_version: '5'
-default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ios
+
+
 trigger_map:
 - push_branch: main
   workflow: runParallelTests
 - push_branch: v8.1.7
   workflow: release
-- pull_request_source_branch: '*'
+- pull_request_source_branch: "*"
   workflow: runParallelTests
-- tag: '*'
+- tag: "*"
   workflow: release
+
+
 workflows:
+
   clone-and-build-dependencies:
     description: Clones the repo and builds dependencies
     steps:
@@ -28,7 +33,8 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: g2.4core
+
+
   set-project-version:
     steps:
     - set-xcode-build-number@1:
@@ -54,28 +60,25 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: g2.4core
     before_run: []
+
+
   set-default-browser-entitlement:
     steps:
     - script@1:
         title: Set Default Web Browser Entitlement
         inputs:
-        - content: >-
+        - content: |-
             #!/usr/bin/env bash
-
             set -x
-
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
-            bool true" Focus.entitlements
-
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
-            bool true" Klar.entitlements
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: g2.4core
     before_run: []
+
+
   release:
     steps:
     - certificate-and-profile-installer@1: {}
@@ -87,8 +90,8 @@ workflows:
         title: Build Focus
     - deploy-to-itunesconnect-application-loader@0:
         inputs:
-        - app_password: $APPLE_ACCOUNT_PW
-        - itunescon_user: $APPLE_ACCOUNT_ID
+        - app_password: "$APPLE_ACCOUNT_PW"
+        - itunescon_user: "$APPLE_ACCOUNT_ID"
     - xcode-archive@2:
         inputs:
         - scheme: Klar
@@ -96,16 +99,18 @@ workflows:
         title: Build Klar
     - deploy-to-itunesconnect-application-loader@0:
         inputs:
-        - app_password: $APPLE_ACCOUNT_PW
-        - itunescon_user: $APPLE_ACCOUNT_ID
+        - app_password: "$APPLE_ACCOUNT_PW"
+        - itunescon_user: "$APPLE_ACCOUNT_ID"
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: g2.4core
+        machine_type_id: g2.8core
     before_run:
-    - clone-and-build-dependencies
-    - set-project-version
-    - set-default-browser-entitlement
+      - clone-and-build-dependencies
+      - set-project-version
+      - set-default-browser-entitlement
+
+
   runParallelTests:
     steps:
     - activate-ssh-key@4:
@@ -113,27 +118,29 @@ workflows:
     - cache-pull@2: {}
     - cache-push@2:
         inputs:
-        - cache_paths: /Users/vagrant/git
+        - cache_paths: "/Users/vagrant/git"
     - build-router-start@0:
         inputs:
         - wait_for_builds: 'true'
-        - access_token: $FOCUS_PARALLEL
+        - access_token: "$FOCUS_PARALLEL"
         - workflows: |-
             runFocus
             runKlar
     - build-router-wait@0:
         inputs:
-        - access_token: $FOCUS_PARALLEL
+        - access_token: "$FOCUS_PARALLEL"
     - deploy-to-bitrise-io@1: {}
     - slack@3:
-        run_if: .IsBuildFailed
+        run_if: ".IsBuildFailed"
         inputs:
-        - channel: '#focus-ios-alerts'
-        - webhook_url: $SLACK_WEBHOOK
+        - channel: "#focus-ios-alerts"
+        - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
         machine_type_id: g2.4core
+
+
   runFocus:
     steps:
     - git-clone@4: {}
@@ -143,45 +150,22 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            ./checkout.sh
-        title: ContentBlockerGen
-    - script@1:
-        title: Set Default Web Browser Entitlement
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
+            # fail if any commands fails
+            set -e
+            # debug log
             set -x
 
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
-            bool true" Focus.entitlements
+            # Check if the build is a scheduled build
 
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
-            bool true" Klar.entitlements
-    - xcode-build-for-simulator@0:
-        inputs:
-        - configuration: FocusDebug
-        - xcodebuild_options: >-
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO
-        - scheme: Focus
-    - xcode-test@2:
-        inputs:
-        - xcodebuild_test_options: >-
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2
-            -testPlan SmokeTest
-        - scheme: Focus
-    - deploy-to-bitrise-io@1: {}
-    meta:
-      bitrise.io:
-        stack: osx-xcode-12.5.x
-        machine_type_id: g2.8core
-  runKlar:
-    steps:
-    - git-clone@4: {}
-    - cache-pull@2: {}
-    - certificate-and-profile-installer@1: {}
+            if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
+            then
+                echo "Scheduled build, running Full Functional Tests"
+                envman add --key TEST_PLAN_NAME --value FullFunctionalTests
+            else
+                echo "Regular build, running Smoke Test"
+                envman add --key TEST_PLAN_NAME --value SmokeTest
+            fi
+        - title: Check if build is scheduled or regular to set the test plan
     - script@1:
         inputs:
         - content: |-
@@ -191,35 +175,82 @@ workflows:
     - script@1:
         title: Set Default Web Browser Entitlement
         inputs:
-        - content: >-
+        - content: |-
             #!/usr/bin/env bash
-
             set -x
-
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
-            bool true" Focus.entitlements
-
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
-            bool true" Klar.entitlements
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
     - xcode-build-for-simulator@0:
         inputs:
         - configuration: FocusDebug
-        - xcodebuild_options: >-
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO
+        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        - scheme: Focus
+    - xcode-test@2:
+        inputs:
+        - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan $TEST_PLAN_NAME
+        - scheme: Focus
+    - deploy-to-bitrise-io@1: {}
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.5.x
+        machine_type_id: g2.8core
+
+  runKlar:
+    steps:
+    - git-clone@4: {}
+    - cache-pull@2: {}
+    - certificate-and-profile-installer@1: {}
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            # Check if the build is a scheduled build
+
+            if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
+            then
+                echo "Scheduled build, running Full Functional Tests"
+                envman add --key TEST_PLAN_NAME --value FullFunctionalTests
+            else
+                echo "Regular build, running Smoke Test"
+                envman add --key TEST_PLAN_NAME --value SmokeTest
+            fi
+        - title: Check if build is scheduled or regular to set the test plan
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            ./checkout.sh
+        title: ContentBlockerGen
+    - script@1:
+        title: Set Default Web Browser Entitlement
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -x
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
+    - xcode-build-for-simulator@0:
+        inputs:
+        - configuration: FocusDebug
+        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         - scheme: Klar
     - xcode-test@2:
         inputs:
-        - xcodebuild_test_options: >-
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2
-            -testPlan SmokeTest
+        - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan "$TEST_PLAN_NAME"
         - scheme: Klar
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
         machine_type_id: g2.8core
+
 app:
   envs:
   - opts:
@@ -228,6 +259,3 @@ app:
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: app-store
-meta:
-  bitrise.io:
-    machine_type_id: elite

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,22 +1,17 @@
 ---
 format_version: '5'
-default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
 project_type: ios
-
-
 trigger_map:
 - push_branch: main
   workflow: runParallelTests
 - push_branch: v8.1.7
   workflow: release
-- pull_request_source_branch: "*"
+- pull_request_source_branch: '*'
   workflow: runParallelTests
-- tag: "*"
+- tag: '*'
   workflow: release
-
-
 workflows:
-
   clone-and-build-dependencies:
     description: Clones the repo and builds dependencies
     steps:
@@ -33,8 +28,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-
-
+        machine_type_id: g2.4core
   set-project-version:
     steps:
     - set-xcode-build-number@1:
@@ -60,25 +54,28 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
+        machine_type_id: g2.4core
     before_run: []
-
-
   set-default-browser-entitlement:
     steps:
     - script@1:
         title: Set Default Web Browser Entitlement
         inputs:
-        - content: |-
+        - content: >-
             #!/usr/bin/env bash
+
             set -x
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
+
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
+            bool true" Focus.entitlements
+
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
+            bool true" Klar.entitlements
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
+        machine_type_id: g2.4core
     before_run: []
-
-
   release:
     steps:
     - certificate-and-profile-installer@1: {}
@@ -90,8 +87,8 @@ workflows:
         title: Build Focus
     - deploy-to-itunesconnect-application-loader@0:
         inputs:
-        - app_password: "$APPLE_ACCOUNT_PW"
-        - itunescon_user: "$APPLE_ACCOUNT_ID"
+        - app_password: $APPLE_ACCOUNT_PW
+        - itunescon_user: $APPLE_ACCOUNT_ID
     - xcode-archive@2:
         inputs:
         - scheme: Klar
@@ -99,17 +96,16 @@ workflows:
         title: Build Klar
     - deploy-to-itunesconnect-application-loader@0:
         inputs:
-        - app_password: "$APPLE_ACCOUNT_PW"
-        - itunescon_user: "$APPLE_ACCOUNT_ID"
+        - app_password: $APPLE_ACCOUNT_PW
+        - itunescon_user: $APPLE_ACCOUNT_ID
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
+        machine_type_id: g2.4core
     before_run:
-      - clone-and-build-dependencies
-      - set-project-version
-      - set-default-browser-entitlement
-
-
+    - clone-and-build-dependencies
+    - set-project-version
+    - set-default-browser-entitlement
   runParallelTests:
     steps:
     - activate-ssh-key@4:
@@ -117,28 +113,27 @@ workflows:
     - cache-pull@2: {}
     - cache-push@2:
         inputs:
-        - cache_paths: "/Users/vagrant/git"
+        - cache_paths: /Users/vagrant/git
     - build-router-start@0:
         inputs:
         - wait_for_builds: 'true'
-        - access_token: "$FOCUS_PARALLEL"
+        - access_token: $FOCUS_PARALLEL
         - workflows: |-
             runFocus
             runKlar
     - build-router-wait@0:
         inputs:
-        - access_token: "$FOCUS_PARALLEL"
+        - access_token: $FOCUS_PARALLEL
     - deploy-to-bitrise-io@1: {}
     - slack@3:
-        run_if: ".IsBuildFailed"
+        run_if: .IsBuildFailed
         inputs:
-        - channel: "#focus-ios-alerts"
-        - webhook_url: "$SLACK_WEBHOOK"
+        - channel: '#focus-ios-alerts'
+        - webhook_url: $SLACK_WEBHOOK
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-
-
+        machine_type_id: g2.4core
   runFocus:
     steps:
     - git-clone@4: {}
@@ -153,27 +148,35 @@ workflows:
     - script@1:
         title: Set Default Web Browser Entitlement
         inputs:
-        - content: |-
+        - content: >-
             #!/usr/bin/env bash
+
             set -x
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
+
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
+            bool true" Focus.entitlements
+
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
+            bool true" Klar.entitlements
     - xcode-build-for-simulator@0:
         inputs:
         - configuration: FocusDebug
-        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        - xcodebuild_options: >-
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO
         - scheme: Focus
     - xcode-test@2:
         inputs:
-        - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan SmokeTest
+        - xcodebuild_test_options: >-
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2
+            -testPlan SmokeTest
         - scheme: Focus
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-
-
+        machine_type_id: g2.8core
   runKlar:
     steps:
     - git-clone@4: {}
@@ -188,27 +191,35 @@ workflows:
     - script@1:
         title: Set Default Web Browser Entitlement
         inputs:
-        - content: |-
+        - content: >-
             #!/usr/bin/env bash
+
             set -x
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
+
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
+            bool true" Focus.entitlements
+
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser
+            bool true" Klar.entitlements
     - xcode-build-for-simulator@0:
         inputs:
         - configuration: FocusDebug
-        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        - xcodebuild_options: >-
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO
         - scheme: Klar
     - xcode-test@2:
         inputs:
-        - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan SmokeTest
+        - xcodebuild_test_options: >-
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2
+            -testPlan SmokeTest
         - scheme: Klar
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-
-
+        machine_type_id: g2.8core
 app:
   envs:
   - opts:
@@ -217,3 +228,6 @@ app:
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: app-store
+meta:
+  bitrise.io:
+    machine_type_id: elite

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -104,6 +104,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
+        machine_type_id: g2.8core
     before_run:
       - clone-and-build-dependencies
       - set-project-version
@@ -137,6 +138,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
+        machine_type_id: standard
 
 
   runFocus:
@@ -219,4 +221,3 @@ app:
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: app-store
-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -104,7 +104,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: g2.8core
     before_run:
       - clone-and-build-dependencies
       - set-project-version
@@ -138,7 +137,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: g2.4core
 
 
   runFocus:
@@ -150,26 +148,6 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-            # Check if the build is a scheduled build
-
-            if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
-            then
-                echo "Scheduled build, running Full Functional Tests"
-                envman add --key TEST_PLAN_NAME --value FullFunctionalTests
-            else
-                echo "Regular build, running Smoke Test"
-                envman add --key TEST_PLAN_NAME --value SmokeTest
-            fi
-        - title: Check if build is scheduled or regular to set the test plan
-    - script@1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
             ./checkout.sh
         title: ContentBlockerGen
     - script@1:
@@ -188,13 +166,14 @@ workflows:
     - xcode-test@2:
         inputs:
         - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan $TEST_PLAN_NAME
+            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan SmokeTest
         - scheme: Focus
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
         machine_type_id: g2.8core
+
 
   runKlar:
     steps:
@@ -205,26 +184,6 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-            # Check if the build is a scheduled build
-
-            if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
-            then
-                echo "Scheduled build, running Full Functional Tests"
-                envman add --key TEST_PLAN_NAME --value FullFunctionalTests
-            else
-                echo "Regular build, running Smoke Test"
-                envman add --key TEST_PLAN_NAME --value SmokeTest
-            fi
-        - title: Check if build is scheduled or regular to set the test plan
-    - script@1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
             ./checkout.sh
         title: ContentBlockerGen
     - script@1:
@@ -243,13 +202,14 @@ workflows:
     - xcode-test@2:
         inputs:
         - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan "$TEST_PLAN_NAME"
+            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan SmokeTest
         - scheme: Klar
     - deploy-to-bitrise-io@1: {}
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
         machine_type_id: g2.8core
+
 
 app:
   envs:
@@ -259,3 +219,4 @@ app:
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: app-store
+


### PR DESCRIPTION
This patch upgrades the build machines for the Focus workflows to the new Elite machines. Our build times are a good amount faster now. I set the `runParallelTasks` workflow to the cheapest Gen1 (since it just kicks off the tasks and then waits for those) and the `runKlar`/`runFocus` workflows to use an _Elite Gen2_.

Old configuration:

<img width="904" alt="Screen Shot 2021-06-10 at 4 04 58 PM" src="https://user-images.githubusercontent.com/28052/121590591-7a92fd00-ca06-11eb-8e99-29fc4f00f915.png">

New configuration:

<img width="806" alt="Screen Shot 2021-06-10 at 4 05 37 PM" src="https://user-images.githubusercontent.com/28052/121590617-8383ce80-ca06-11eb-8694-78250e71d792.png">

Better build times and lower Bitrise credit usage. At least compared to the credits we would with the current machines.

