### PR TITLE
Fixes #1921 - Site duplicate should not be allowed in "URL Autocomplete"

### DIFF
--- a/Blockzilla/Lib/DomainCompletion/DomainCompletion.swift
+++ b/Blockzilla/Lib/DomainCompletion/DomainCompletion.swift
@@ -52,7 +52,9 @@ class CustomCompletionSource: CustomAutocompleteSource {
         }
 
         var domains = getSuggestions()
-        guard !domains.contains(sanitizedSuggestion) else { return .error(.duplicateDomain) }
+        guard !domains.contains(where: { domain in
+            domain.compare(sanitizedSuggestion, options: .caseInsensitive) == .orderedSame
+        }) else { return .error(.duplicateDomain) }
 
         domains.append(sanitizedSuggestion)
         Settings.setCustomDomainSetting(domains: domains)

--- a/ClientTests/DomainCompletionTests.swift
+++ b/ClientTests/DomainCompletionTests.swift
@@ -17,6 +17,7 @@ class DomainCompletionTests: XCTestCase {
     private let HTTPS_DOMAIN = "https://example.com"
     private let WWWW_DOMAIN = "https://www.example.com"
     private let TEST_NO_PERIOD = "example"
+    private let TEST_CASE_INSENSITIVE = "https://www.EXAMPLE.com"
     
     func testAddCustomDomain() {
         addADomain(domain: SIMPLE_DOMAIN)
@@ -36,11 +37,13 @@ class DomainCompletionTests: XCTestCase {
     
     func testAddCustomDomainDuplicate() {
         Settings.setCustomDomainSetting(domains: [SIMPLE_DOMAIN])
-        switch CustomCompletionSource().add(suggestion: WWWW_DOMAIN) {
-        case .error(let error):
-            XCTAssertEqual(error, .duplicateDomain)
-        case .success:
-            XCTFail()
+        [WWWW_DOMAIN, TEST_CASE_INSENSITIVE].forEach {
+            switch CustomCompletionSource().add(suggestion: $0) {
+            case .error(let error):
+                XCTAssertEqual(error, .duplicateDomain)
+            case .success:
+                XCTFail()
+            }
         }
     }
     


### PR DESCRIPTION
Fixes #1921 I've added a test case for this issue and wrote a fix for it.

## Commit Message
Fixes #1921 - Site duplicate should not be allowed in "URL Autocomplete"
