### PR TITLE
Fixes #1927 - Refactor URLFixup.getURL

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		2696EB04211F540600F0C73F /* SearchHistoryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */; };
 		30DFF98021810BF20055707C /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30DFF97F21810BF20055707C /* SearchSuggestClient.swift */; };
 		31421EB12176492A0015F48B /* TitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */; };
+		3AEC0B3E267DE30A007B7850 /* URIFixupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEC0B3D267DE30A007B7850 /* URIFixupTests.swift */; };
 		4F1284861FC5E242001A775B /* TPSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1284851FC5E242001A775B /* TPSettingsTest.swift */; };
 		4F582F7B1F44A10F006C744B /* OpenInFocusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F582F7A1F44A10F006C744B /* OpenInFocusTest.swift */; };
 		4FE4E6F61FBB5E2C001BB779 /* TPSidebarBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE4E6F51FBB5E2C001BB779 /* TPSidebarBadge.swift */; };
@@ -369,6 +370,7 @@
 		29B90C056305836CB297FF79 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		30DFF97F21810BF20055707C /* SearchSuggestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProvider.swift; sourceTree = "<group>"; };
+		3AEC0B3D267DE30A007B7850 /* URIFixupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URIFixupTests.swift; sourceTree = "<group>"; };
 		427B752EF11959F9C38B12D6 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		4F1284851FC5E242001A775B /* TPSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPSettingsTest.swift; sourceTree = "<group>"; };
 		4F582F7A1F44A10F006C744B /* OpenInFocusTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenInFocusTest.swift; sourceTree = "<group>"; };
@@ -1158,6 +1160,7 @@
 				D831FEE1205247A400EAE19A /* BrowserViewControllerTests.swift */,
 				D8E0156D1FD9E40F00CA3B9F /* DomainCompletionTests.swift */,
 				D803D37320EF1A49001F2819 /* UserAgentTests.swift */,
+				3AEC0B3D267DE30A007B7850 /* URIFixupTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -1825,6 +1828,7 @@
 				D8E0155F1FCF409F00CA3B9F /* SearchEngineManagerTests.swift in Sources */,
 				D8E0156E1FD9E40F00CA3B9F /* DomainCompletionTests.swift in Sources */,
 				D025F225218B64D600B262D8 /* SearchEngineTests.swift in Sources */,
+				3AEC0B3E267DE30A007B7850 /* URIFixupTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Blockzilla/URIFixup.swift
+++ b/Blockzilla/URIFixup.swift
@@ -15,7 +15,14 @@ class URIFixup {
         // all valid requests starting with "http://", "about:", etc.
         // Also check with a regular expression if there is a port in the url
         // this will be handle later in this function adding http prefix
-        if let url = URL(string: entry), url.scheme != nil, trimmed.range(of: ":") == nil, trimmed.range(of: "\\b:[0-9]{1,5}", options: .regularExpression) == nil {
+        if let url = URL(string: trimmed), url.scheme != nil, trimmed.range(of: "\\b:[0-9]{1,5}", options: .regularExpression) == nil {
+            
+            //check for top-level domain if scheme is "http://" or "https://"
+            if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://") {
+                if trimmed.range(of: ".") == nil {
+                    return nil
+                }
+            }
             return url
         }
 

--- a/ClientTests/URIFixupTests.swift
+++ b/ClientTests/URIFixupTests.swift
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+#if FOCUS
+@testable import Firefox_Focus
+#else
+@testable import Firefox_Klar
+#endif
+
+class URIFixupTests: XCTestCase {
+    
+    private let customSchemeURLs = ["firefox://",
+                                    "dns://192.168.1.1/ftp.example.org?type=A",
+                                    "feed://example.com/rss.xml",
+                                    "git://github.com/user/project-name.git",
+                                    "mailto:jsmith@example.com",
+                                    "smb://workgroup;user:password@server/share/folder/file.txt",
+                                    "view-source:http://en.wikipedia.org/wiki/URI_scheme"]
+    
+    private let httpSchemeURLs = ["http://mozilla.org//fire_fire",
+                                  "http://mozilla.org//fire_fire/",
+                                  "http://mozilla.org//fire_fire_(firefox)",
+                                  "http://mozilla.org//fire_fire_(firefox)_(browser)",
+                                  "http://www.mozilla.org/wpstyle/?p=364",
+                                  "http://www.mozilla.org/foo/?bar=baz&inga=42&quux",
+                                  "http://✪gg.ff/123",
+                                  "http://userid:password@mozilla.org:8080",
+                                  "http://userid:password@mozilla.org:8080/",
+                                  "http://userid@mozilla.org",
+                                  "http://userid@mozilla.org/",
+                                  "http://userid@mozilla.org:8080",
+                                  "http://userid@mozilla.org:8080/",
+                                  "http://userid:password@mozilla.org",
+                                  "http://userid:password@mozilla.org/",
+                                  "http://➡.mo/王",
+                                  "http://⌘.mo",
+                                  "http://⌘.mo/",
+                                  "http://mozilla.org/blah_(wikipedia)#cite-1",
+                                  "http://mozilla.org/blah_(wikipedia)_blah#cite-1",
+                                  "http://mozilla.org/unicode_(✪)_in_parens",
+                                  "http://mozilla.org/(firefox)?after=parens",
+                                  "http://☺.mozilla.org/",
+                                  "http://code.mozilla.org/users/#&firefox=browser",
+                                  "http://f.co",
+                                  "http://moz.fir/?q=Test%20URL-encoded%20fire",
+                                  "http://مثال.إختبار",
+                                  "http://王涵.王涵",
+                                  "http://-.~_!$&'()*+,;=:%40:80%2f::::::@mozilla.org",
+                                  "http://6662.net",
+                                  "http://f.i-r.ef",
+                                  "http://266.315.245.345",
+                                  "http://266.315.245.345:100"]
+    
+    private let invalidURLs = ["http://mozilla",
+                               "http:// shouldfail.com",
+                               "http://0123456789",
+                               "mo zilla.com",
+                               "www.firefox .com",
+                               "http://fire fox.com",
+                               "mozilla",
+                               "http://[2001:db8:85a3::8a2e:370:7334]",
+                               ":/#?&@%+~"]
+    
+    func testValidURLsForHttpAndHttpsSchemes() {
+        httpSchemeURLs.forEach {
+            XCTAssertNotNil(URIFixup.getURL(entry: $0), "\($0) is not a valid URL")
+            
+            let httpsSchemeURL = $0.replacingOccurrences(of: "http", with: "https")
+            XCTAssertNotNil(URIFixup.getURL(entry: httpsSchemeURL), "\(httpsSchemeURL) is not a valid URL")
+        }
+    }
+    
+    func testValidURLsForNoSchemes() {
+        httpSchemeURLs.forEach {
+            let noSchemeURL = $0.replacingOccurrences(of: "http", with: "")
+            XCTAssertNotNil(URIFixup.getURL(entry: noSchemeURL), "\(noSchemeURL) is not a valid URL")
+        }
+    }
+    
+    func testCustomSchemes() {
+        customSchemeURLs.forEach {
+            XCTAssertNotNil(URIFixup.getURL(entry: $0), "\($0) is not a valid URL")
+        }
+    }
+    
+    func testInvalidURLs() {
+        invalidURLs.forEach {
+            XCTAssertNil(URIFixup.getURL(entry: $0), "\($0) is a valid URL")
+        }
+    }
+    
+}


### PR DESCRIPTION
Fixes #1927 

Removed `trimmed.range(of: ":")` from `if let url = URL(string: entry), url.scheme != nil, trimmed.range(of: ":") == nil, trimmed.range(of: "\\b:[0-9]{1,5}", options: .regularExpression) == nil`

if `url.scheme` is not nil then `trimmed.range(of: ":")` is not nil since all URI schemes contain ":".

Added a check for a top level domain since that is required for any _http_ / _https_ schemes.

Now the `getURL(entry: String)` method recognises custom schemes such as `firefox://`