### PR TITLE
Fixes #1916 - Settings menu is not dismissed after opening a page via notes or external app

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -286,6 +286,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
 
             browserViewController.ensureBrowsingMode()
             browserViewController.deactivateUrlBarOnHomeView()
+            browserViewController.dismissSettings()
             browserViewController.submit(url: url)
             queuedUrl = nil
         } else if let text = queuedString {

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -284,6 +284,12 @@ class BrowserViewController: UIViewController {
     public func deactivateUrlBarOnHomeView() {
         urlBar.dismissTextField()
     }
+    
+    public func dismissSettings() {
+        if self.presentedViewController?.children.first is SettingsViewController {
+            self.presentedViewController?.children.first?.dismiss(animated: true, completion: nil)
+        }
+    }
 
     private func containWebView() {
         addChild(webViewController)


### PR DESCRIPTION
Fixes #1916 - Settings menu is not dismissed after opening a page via notes or external app