### PR TITLE
Fixes #1985 - Page actions sheet is not dismissed after opening a page via notes or external app

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -286,6 +286,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
 
             browserViewController.ensureBrowsingMode()
             browserViewController.deactivateUrlBarOnHomeView()
+            browserViewController.dismissSettings()
             browserViewController.submit(url: url)
             queuedUrl = nil
         } else if let text = queuedString {

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -287,6 +287,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
             browserViewController.ensureBrowsingMode()
             browserViewController.deactivateUrlBarOnHomeView()
             browserViewController.dismissSettings()
+            browserViewController.dismissActionSheet()
             browserViewController.submit(url: url)
             queuedUrl = nil
         } else if let text = queuedString {

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -284,6 +284,12 @@ class BrowserViewController: UIViewController {
     public func deactivateUrlBarOnHomeView() {
         urlBar.dismissTextField()
     }
+    
+    public func dismissSettings() {
+        if self.presentedViewController?.children.first is SettingsViewController {
+            self.presentedViewController?.children.first?.dismiss(animated: true, completion: nil)
+        }
+    }
 
     private func containWebView() {
         addChild(webViewController)

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -290,6 +290,13 @@ class BrowserViewController: UIViewController {
             self.presentedViewController?.children.first?.dismiss(animated: true, completion: nil)
         }
     }
+    
+    public func dismissActionSheet() {
+        if self.presentedViewController is PhotonActionSheet {
+            self.presentedViewController?.dismiss(animated: true, completion: nil)
+            photonActionSheetDidDismiss()
+        }
+    }
 
     private func containWebView() {
         addChild(webViewController)


### PR DESCRIPTION
Fixes #1985 - Page actions sheet is not dismissed after opening a page via notes or external app