### PR TITLE
Fixes #1999 - Include a post-clone script for Xcode Cloud

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -5,5 +5,5 @@
 # calls checkout.sh to pull in the blocklists.
 #
 
-./checkout.sh
+(cd .. && ./checkout.sh)
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./checkout.sh
+

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+#
+# This script is executed by Xcode Cloud after it clones the repository. It only
+# calls checkout.sh to pull in the blocklists.
+#
+
 ./checkout.sh
 


### PR DESCRIPTION
This patch introduces a `ci_scripts/ci_post_clone.sh` script for Xcode Cloud.