### PR TITLE
Append `/` to domain completions only when no `/` is present.

### DIFF
--- a/Blockzilla/Lib/DomainCompletion/DomainCompletion.swift
+++ b/Blockzilla/Lib/DomainCompletion/DomainCompletion.swift
@@ -132,6 +132,9 @@ class DomainCompletion: AutocompleteTextFieldCompletionSource {
             let matchedDomain = domainWithDotPrefix[range...]
 
             if matchedDomain.contains(".") {
+                if matchedDomain.contains("/") {
+                    return String(matchedDomain)
+                }
                 return matchedDomain + "/"
             }
         }


### PR DESCRIPTION
Domain completions currently append `/` to all matched domains. This leads to unexpected
behavior when the completion isn't just a domain, but contains a path as well. This patch
changes the behavior to append a `/` only if no `/` is present in the matchedDomain string.
If such a character is present, we can safely leave the string unaltered.

Closes #2004.

## Commit Message
Fixes #2004 - Custom autocompletions have a / suffix