### PR TITLE
Disable cron decision tasks from being generated

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -98,7 +98,7 @@ tasks:
                   else: 'UNDEFINED'
           in:
               $if: >
-                tasks_for in ["action", "cron"]
+                tasks_for in ["action"]
                 || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "edited", "synchronize"])
                 || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/")
                 || (tasks_for == "github-release" && releaseAction == "published")


### PR DESCRIPTION
These are failing right now because .cron.yml is not present. Once that's been created, this should be reverted.