### PR TITLE
Fixes #2039 - Fix incorrect locale codes in shipping_locales.txt

### DIFF
--- a/shipping_locales.txt
+++ b/shipping_locales.txt
@@ -17,7 +17,7 @@ el
 en-US
 eo
 es-AR
-es_CL
+es-CL
 es-ES
 es-MX
 eu
@@ -47,7 +47,7 @@ mr
 ms
 my
 nb-NO
-nb-NP
+ne-NP
 nl
 nn-NO
 pl


### PR DESCRIPTION
This patch fixes the `es-CL` and `ne-NP` locale codes in `shipping_locales.txt`. This should also be uplifted to the `refresh` branch.