### PR TITLE
L10n follow up missing docker file

### DIFF
--- a/taskcluster/docker/requirements.txt
+++ b/taskcluster/docker/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp-retry
+PyYAML
+taskcluster

--- a/taskcluster/docker/requirements.txt
+++ b/taskcluster/docker/requirements.txt
@@ -1,3 +1,0 @@
-aiohttp-retry
-PyYAML
-taskcluster

--- a/taskcluster/docker/screenshots/Dockerfile
+++ b/taskcluster/docker/screenshots/Dockerfile
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM ubuntu:18.04
+
+MAINTAINER Johan Lorenzo "jlorenzo+docker@mozilla.com"
+
+# Add worker user
+RUN mkdir /builds && \
+    useradd -d /builds/worker -s /bin/bash -m worker && \
+    chown worker:worker /builds/worker && \
+    mkdir /builds/worker/artifacts && \
+    chown worker:worker /builds/worker/artifacts
+
+WORKDIR /builds/worker/
+
+
+ENV CURL='curl --location --retry 5' \
+    LANG='en_US.UTF-8' \
+    TERM='dumb'
+
+
+RUN apt-get update -qq \
+    # We need to install tzdata before all of the other packages. Otherwise it will show an interactive dialog that
+    # we cannot navigate while building the Docker image.
+    && apt-get install -y tzdata \
+    && apt-get install -y curl \
+                          git \
+                          locales \
+                          mercurial \
+                          python3 \
+                          python3-pip \
+    && apt-get clean
+
+RUN pip3 install --upgrade pip
+COPY requirements.txt ./
+RUN pip3 install -r requirements.txt
+
+RUN locale-gen "$LANG"
+
+# %include-run-task
+
+ENV SHELL=/bin/bash \
+    HOME=/builds/worker \
+    PATH="/builds/worker/.local/bin:$PATH"
+
+
+VOLUME /builds/worker/checkouts
+VOLUME /builds/worker/.cache
+
+
+# run-task expects to run as root
+USER root

--- a/taskcluster/docker/screenshots/requirements.txt
+++ b/taskcluster/docker/screenshots/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp-retry
+PyYAML
+taskcluster


### PR DESCRIPTION
I was sure I had added these files, but turns our that screenshots was in the gitignore file and so it was not pushed.

I triggered the hook and it was failing with: 
`[Errno 2] No such file or directory: u'/builds/worker/checkouts/src/taskcluster/docker/screenshots/Dockerfile'`

So I realized the complete docker folder was not in the repo. 
Hopefully this will fix that 