### PR TITLE
l10n follow up 3 fix naming error in taskcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -142,7 +142,7 @@ tasks:
                                             description: '${action.description}'
                                         else:
                                             name: "Decision Task for cron job ${cron.job_name}"
-                                            description: 'Created by a [cron task](https://focus-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
+                                            description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
                           provisionerId: "mobile-${level}"
                           workerType: "decision"
                           tags:


### PR DESCRIPTION
Error trying to rename everything to focus 🤦‍♀️ 
This hopefuflly fixes error in comment https://github.com/mozilla-mobile/focus-ios/issues/1979#issuecomment-889739402