### PR TITLE
Fixes #2052 - Localize UIApplicationShortcutItemTitle with a key

### DIFF
--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -76,7 +76,7 @@
 			<key>UIApplicationShortcutItemIconFile</key>
 			<string>erase_quick_action</string>
 			<key>UIApplicationShortcutItemTitle</key>
-			<string>Erase and Open</string>
+			<string>UIApplicationShortcutItemTitle.EraseAndOpen</string>
 			<key>UIApplicationShortcutItemType</key>
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER).EraseAndOpen</string>
 		</dict>

--- a/Blockzilla/en.lproj/InfoPlist.strings
+++ b/Blockzilla/en.lproj/InfoPlist.strings
@@ -13,3 +13,6 @@
 /* (No Comment) */
 "NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
 
+/* This is the menu item that appears when you long press the Focus icon on the phone home screen. */
+"UIApplicationShortcutItemTitle.EraseAndOpen" = "Erase and Open";
+


### PR DESCRIPTION
This patch gives `UIApplicationShortcutItemTitle` in the main `Info.plist` a proper string key that can be referenced from the localized strings files.
