### PR TITLE
l10n-follow-up-4-update-L10nBuild-workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -409,14 +409,16 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            ./screenshots.sh en-US
+            # workaround until 2.187 version is installed. Error with 2.186
+            fastlane update_fastlane
+            ./l10n-screenshots.sh en-US
     - deploy-to-bitrise-io@1.10:
         inputs:
-        - deploy_path: screenshots-derived-data/
+        - deploy_path: l10n-screenshots-dd/
         - is_compress: 'true'
     - deploy-to-bitrise-io@1.10:
         inputs:
-        - deploy_path: screenshots/Focus/iPhone11/en-US
+        - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
     meta:
       bitrise.io:


### PR DESCRIPTION
Another thing I found is that I had correclty named the script to get screenshots in L10nScreenshotsTest workflow but not in the L10nBuild one.
This PR fixes that
Related to https://github.com/mozilla-mobile/focus-ios/issues/1979#issuecomment-889877529