### PR TITLE
For #2067 - Create test plan for refresh branch

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -619,6 +619,7 @@
 		D3E54FDD1DF0E0D6003E1AFF /* UIImageExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageExtensions.swift; sourceTree = "<group>"; };
 		D3E54FDF1DF0E221003E1AFF /* SearchSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsViewController.swift; sourceTree = "<group>"; };
 		D4341F802669342A00294A15 /* FullFunctionalTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FullFunctionalTests.xctestplan; sourceTree = "<group>"; };
+		D43A61BD26B4627100814232 /* SmokeTestRefresh.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SmokeTestRefresh.xctestplan; sourceTree = "<group>"; };
 		D47940D92664E15D00C286BB /* SmokeTest.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SmokeTest.xctestplan; sourceTree = "<group>"; };
 		D50939A81FBF807A005D4316 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		D597608B1F9FEFB300A2D212 /* TrackingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtection.swift; sourceTree = "<group>"; };
@@ -1181,6 +1182,7 @@
 		E4BF2DCA1BACE8CA00DA9D68 = {
 			isa = PBXGroup;
 			children = (
+				D43A61BD26B4627100814232 /* SmokeTestRefresh.xctestplan */,
 				D4341F802669342A00294A15 /* FullFunctionalTests.xctestplan */,
 				D47940D92664E15D00C286BB /* SmokeTest.xctestplan */,
 				C817A35222CE73B4002529FF /* Deferred */,

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
@@ -58,6 +58,9 @@
          <TestPlanReference
             reference = "container:FullFunctionalTests.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:SmokeTestRefresh.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/SmokeTestRefresh.xctestplan
+++ b/SmokeTestRefresh.xctestplan
@@ -1,0 +1,45 @@
+{
+  "configurations" : [
+    {
+      "id" : "7F02ED3B-5CF8-409D-8257-E00D35DD0E09",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "AsianLocaleTest",
+        "CollapsedURLTest",
+        "CopyTest",
+        "DragAndDropTest",
+        "FindInPageTest",
+        "PastenGoTest\/testClipboard()",
+        "QuickAddAutocompleteURLTest",
+        "RequestDesktopTest",
+        "SearchProviderTest",
+        "SearchSuggestionsPromptTest",
+        "SettingAppearanceTest\/testAddRemoveCustomDomain()",
+        "SettingAppearanceTest\/testDisableAutocomplete()",
+        "SettingAppearanceTest\/testOpenInSafari()",
+        "TrackingProtectionMenu\/testInactiveProtectionSidebar()",
+        "TrackingProtectionSettings",
+        "UserAgentTest",
+        "WebsiteAccessTests\/testAutocompleteCustomDomain()",
+        "WebsiteAccessTests\/testDisableAutocomplete()",
+        "WebsiteMemoryTest\/testGoogleTextField()"
+      ],
+      "target" : {
+        "containerPath" : "container:Blockzilla.xcodeproj",
+        "identifier" : "0BA39A821DD2B8E4005F970A",
+        "name" : "XCUITest"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -185,7 +185,8 @@ workflows:
             set -x
 
             # Check if the build goes to refresh branch then
-            # If not check if it is a scheduled or regular build
+            # check if it is a scheduled or regular build
+            # to select the testPlan to run
 
             if [[ $BITRISEIO_GIT_BRANCH_DEST == refresh ]]
             then
@@ -254,7 +255,8 @@ workflows:
             set -x
 
             # Check if the build goes to refresh branch then
-            # If not check if it is a scheduled or regular build
+            # check if it is a scheduled or regular build
+            # to select the testPlan to run
 
             if [[ $BITRISEIO_GIT_BRANCH_DEST == refresh ]]
             then

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -164,11 +164,6 @@ workflows:
         inputs:
         - access_token: "$FOCUS_PARALLEL"
     - deploy-to-bitrise-io@1: {}
-    - slack@3:
-        run_if: ".IsBuildFailed"
-        inputs:
-        - channel: "#focus-ios-alerts"
-        - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -188,7 +188,7 @@ workflows:
             # check if it is a scheduled or regular build
             # to select the testPlan to run
 
-            if [[ $BITRISEIO_GIT_BRANCH_DEST == refresh ]]
+            if [[ $BITRISEIO_GIT_BRANCH_DEST == refresh ]] || [[ $BITRISE_GIT_BRANCH == refresh ]]
             then
                 echo "PR for refresh branch"
                 envman add --key TEST_PLAN_NAME --value SmokeTestRefresh

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -189,16 +189,24 @@ workflows:
             # debug log
             set -x
 
-            # Check if the build is a scheduled build
+            # Check if the build goes to refresh branch then
+            # If not check if it is a scheduled or regular build
 
-            if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
+            if [[ $BITRISEIO_GIT_BRANCH_DEST == refresh ]]
             then
-                echo "Scheduled build, running Full Functional Tests"
-                envman add --key TEST_PLAN_NAME --value FullFunctionalTests
+                echo "PR for refresh branch"
+                envman add --key TEST_PLAN_NAME --value SmokeTestRefresh
             else
-                echo "Regular build, running Smoke Test"
-                envman add --key TEST_PLAN_NAME --value SmokeTest
+                if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
+                then
+                    echo "Scheduled build, running Full Functional Tests"
+                    envman add --key TEST_PLAN_NAME --value FullFunctionalTests
+                else
+                    echo "Regular build, running Smoke Test"
+                    envman add --key TEST_PLAN_NAME --value SmokeTest
+                fi
             fi
+
         - title: Check if build is scheduled or regular to set the test plan
     - script@1:
         inputs:
@@ -225,6 +233,12 @@ workflows:
             CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan $TEST_PLAN_NAME
         - scheme: Focus
     - deploy-to-bitrise-io@1: {}
+    - slack@3:
+        run_if: ".IsBuildFailed"
+        inputs:
+        - channel: "#focus-ios-alerts"
+        - message: "The build run the testPlan: $TEST_PLAN_NAME"
+        - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
@@ -244,15 +258,22 @@ workflows:
             # debug log
             set -x
 
-            # Check if the build is a scheduled build
+            # Check if the build goes to refresh branch then
+            # If not check if it is a scheduled or regular build
 
-            if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
+            if [[ $BITRISEIO_GIT_BRANCH_DEST == refresh ]]
             then
-                echo "Scheduled build, running Full Functional Tests"
-                envman add --key TEST_PLAN_NAME --value FullFunctionalTests
+                echo "PR for refresh branch"
+                envman add --key TEST_PLAN_NAME --value SmokeTestRefresh
             else
-                echo "Regular build, running Smoke Test"
-                envman add --key TEST_PLAN_NAME --value SmokeTest
+                if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
+                then
+                    echo "Scheduled build, running Full Functional Tests"
+                    envman add --key TEST_PLAN_NAME --value FullFunctionalTests
+                else
+                    echo "Regular build, running Smoke Test"
+                    envman add --key TEST_PLAN_NAME --value SmokeTest
+                fi
             fi
         - title: Check if build is scheduled or regular to set the test plan
     - script@1:
@@ -280,6 +301,12 @@ workflows:
             CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan "$TEST_PLAN_NAME"
         - scheme: Klar
     - deploy-to-bitrise-io@1: {}
+    - slack@3:
+        run_if: ".IsBuildFailed"
+        inputs:
+        - channel: "#focus-ios-alerts"
+        - message: "The build run the testPlan: $TEST_PLAN_NAME"
+        - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x


### PR DESCRIPTION
This PR is to do the work described in #2067 

The idea is to not to disable tests in general if they fail in the refresh branch. That would be a normal issue since the UI is going to change significantly.
Adding a test plan specific for that branch would allow us to disable tests only there and not for the main branch. That could cause missing regressions or new bugs. And also add tests specific for new features in the refresh branch