### PR TITLE
L10n update snapshot helper to run fastlane

### DIFF
--- a/ScreenshotTests/SnapshotHelper.swift
+++ b/ScreenshotTests/SnapshotHelper.swift
@@ -302,4 +302,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.25]
+// SnapshotHelperVersion [1.26]

--- a/ScreenshotTests/SnapshotHelper.swift
+++ b/ScreenshotTests/SnapshotHelper.swift
@@ -4,14 +4,12 @@
 //
 //  Created by Felix Krause on 10/8/15.
 //
-
 // -----------------------------------------------------
 // IMPORTANT: When modifying this file, make sure to
 //            increment the version number at the very
 //            bottom of the file to notify users about
 //            the new SnapshotHelper.swift
 // -----------------------------------------------------
-
 import Foundation
 import XCTest
 
@@ -145,7 +143,6 @@ open class Snapshot: NSObject {
         }
 
         NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
-
         if Snapshot.waitForAnimations {
             sleep(1) // Waiting for the animation to be finished (kind of)
         }
@@ -193,16 +190,20 @@ open class Snapshot: NSObject {
     }
 
     class func fixLandscapeOrientation(image: UIImage) -> UIImage {
-        if #available(iOS 10.0, *) {
-            let format = UIGraphicsImageRendererFormat()
-            format.scale = image.scale
-            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-            return renderer.image { context in
-                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-            }
-        } else {
+        #if os(watchOS)
             return image
-        }
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
     }
 
     class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
@@ -302,4 +303,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.26]
+// SnapshotHelperVersion [1.27]

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,7 +10,7 @@ trigger_map:
 - push_branch: v8.1.7
   workflow: release
 - pull_request_source_branch: "*"
-  workflow: runParallelTests
+  workflow: L10nBuild
 - tag: "*"
   workflow: release
 - push_branch: refresh

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,7 +10,7 @@ trigger_map:
 - push_branch: v8.1.7
   workflow: release
 - pull_request_source_branch: "*"
-  workflow: L10nBuild
+  workflow: runParallelTests
 - tag: "*"
   workflow: release
 - push_branch: refresh


### PR DESCRIPTION
In order to run fastlane successfully the Snapshot helper file should be updated.
This PR updates that file so that the command works and the L10nBuild successes when it is triggered from the Hook.

This is another fix needed to complete the work in issue #1979 