### PR TITLE
l10n - Add cache step to L10nBuild

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -378,6 +378,9 @@ workflows:
         inputs:
         - deploy_path: artifacts/
         - is_compress: 'true'
+    envs:
+    - opts:
+        is_expand: false
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
@@ -420,6 +423,10 @@ workflows:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
+    - cache-push@2.3: {}
+    envs:
+    - opts:
+        is_expand: false
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -378,9 +378,6 @@ workflows:
         inputs:
         - deploy_path: artifacts/
         - is_compress: 'true'
-    envs:
-    - opts:
-        is_expand: false
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
@@ -424,9 +421,6 @@ workflows:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
     - cache-push@2.3: {}
-    envs:
-    - opts:
-        is_expand: false
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x


### PR DESCRIPTION
Let's add the cache step just in case is needed in order to retrieve the logs with the specific key needed for #1979 