### PR TITLE
Fixes #1919 - Disable the link to What's new (menu item)

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1443,3 +1443,12 @@ protocol WhatsNewDelegate {
     func shouldShowWhatsNew() -> Bool
     func didShowWhatsNew()
 }
+
+extension WhatsNewDelegate {
+    //Temporarily disable what's new button
+    
+    var shouldEnableWhatsNewButton: Bool {
+        return false
+    }
+}
+

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -378,6 +378,8 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         if whatsNew.shouldShowWhatsNew() {
             highlightsButton?.tintColor = UIConstants.colors.whatsNew
         }
+        
+        highlightsButton?.isEnabled  = whatsNew.shouldEnableWhatsNewButton
 
         view.addSubview(tableView)
         tableView.snp.makeConstraints { make in


### PR DESCRIPTION
This PR disables the link to What's new button.

<img width="485" alt="Screen Shot 2021-08-04 at 11 49 48 AM" src="https://user-images.githubusercontent.com/46751540/128167536-53890fa1-d1cc-4c4a-b32f-77f10d835851.png">
