### PR TITLE
Fixes #2098 - Manually sync the trackingProtection.labelDescription string

### DIFF
--- a/Blockzilla/ar.lproj/Localizable.strings
+++ b/Blockzilla/ar.lproj/Localizable.strings
@@ -550,6 +550,9 @@
 /* Title for the tracking settings page to change what trackers are blocked. */
 "trackingProtection.label" = "الحماية من التعقّب";
 
+/* Description/subtitle for the tracking protection label. */
+"trackingProtection.labelDescription" = "يمكن بتعطيل هذا إصلاح مشاكل بعض المواقع";
+
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "اطّلع على المزيد";
 

--- a/Blockzilla/ca.lproj/Localizable.strings
+++ b/Blockzilla/ca.lproj/Localizable.strings
@@ -550,6 +550,9 @@
 /* Title for the tracking settings page to change what trackers are blocked. */
 "trackingProtection.label" = "Protecció contra el seguiment";
 
+/* Description/subtitle for the tracking protection label. */
+"trackingProtection.labelDescription" = "Si es desactiva, pot ser que s'arreglin problemes amb alguns llocs"
+
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "Més informació";
 

--- a/Blockzilla/ca.lproj/Localizable.strings
+++ b/Blockzilla/ca.lproj/Localizable.strings
@@ -551,7 +551,7 @@
 "trackingProtection.label" = "Protecció contra el seguiment";
 
 /* Description/subtitle for the tracking protection label. */
-"trackingProtection.labelDescription" = "Si es desactiva, pot ser que s'arreglin problemes amb alguns llocs"
+"trackingProtection.labelDescription" = "Si es desactiva, pot ser que s'arreglin problemes amb alguns llocs";
 
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "Més informació";

--- a/Blockzilla/el.lproj/Localizable.strings
+++ b/Blockzilla/el.lproj/Localizable.strings
@@ -551,7 +551,7 @@
 "trackingProtection.label" = "Προστασία από καταγραφή";
 
 /* Description/subtitle for the tracking protection label. */
-"trackingProtection.labelDescription" = "Η απενεργοποίηση αυτού ενδέχεται να διορθώσει μερικά προβλήματα ιστοσελίδων"
+"trackingProtection.labelDescription" = "Η απενεργοποίηση αυτού ενδέχεται να διορθώσει μερικά προβλήματα ιστοσελίδων";
 
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "Μάθετε περισσότερα";

--- a/Blockzilla/el.lproj/Localizable.strings
+++ b/Blockzilla/el.lproj/Localizable.strings
@@ -550,6 +550,9 @@
 /* Title for the tracking settings page to change what trackers are blocked. */
 "trackingProtection.label" = "Προστασία από καταγραφή";
 
+/* Description/subtitle for the tracking protection label. */
+"trackingProtection.labelDescription" = "Η απενεργοποίηση αυτού ενδέχεται να διορθώσει μερικά προβλήματα ιστοσελίδων"
+
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "Μάθετε περισσότερα";
 

--- a/Blockzilla/es-MX.lproj/Localizable.strings
+++ b/Blockzilla/es-MX.lproj/Localizable.strings
@@ -553,6 +553,9 @@
 /* Title for the tracking settings page to change what trackers are blocked. */
 "trackingProtection.label" = "Protección de rastreo";
 
+/* Description/subtitle for the tracking protection label. */
+"trackingProtection.labelDescription" = "Desactivar esto podría solucionar algunos problemas del sitio";
+
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "Saber más";
 

--- a/Blockzilla/fa.lproj/Localizable.strings
+++ b/Blockzilla/fa.lproj/Localizable.strings
@@ -550,6 +550,9 @@
 /* Title for the tracking settings page to change what trackers are blocked. */
 "trackingProtection.label" = "محافظت در برابر رهگیری";
 
+/* Description/subtitle for the tracking protection label. */
+"trackingProtection.labelDescription" = "خاموش کردن این ممکن است چند مشکل را برطرف کند"
+
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "اطلاعات بیشتر";
 

--- a/Blockzilla/fa.lproj/Localizable.strings
+++ b/Blockzilla/fa.lproj/Localizable.strings
@@ -551,7 +551,7 @@
 "trackingProtection.label" = "محافظت در برابر رهگیری";
 
 /* Description/subtitle for the tracking protection label. */
-"trackingProtection.labelDescription" = "خاموش کردن این ممکن است چند مشکل را برطرف کند"
+"trackingProtection.labelDescription" = "خاموش کردن این ممکن است چند مشکل را برطرف کند";
 
 /* Text for the button to learn more about Tracking Protection. */
 "trackingProtection.learnMore" = "اطلاعات بیشتر";


### PR DESCRIPTION
This patch manually moves back the `trackingProtection.labelDescription` into the .`strings` files where it was missing.