### PR TITLE
Improve slack notifications - show executed test plan on error

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -234,6 +234,7 @@ workflows:
         inputs:
         - channel: "#focus-ios-alerts"
         - message: "The build run the testPlan: $TEST_PLAN_NAME"
+        - messageOnError: "The build run the testPlan: $TEST_PLAN_NAME"
         - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
@@ -303,6 +304,7 @@ workflows:
         inputs:
         - channel: "#focus-ios-alerts"
         - message: "The build run the testPlan: $TEST_PLAN_NAME"
+        - messageOnError: "The build run the testPlan: $TEST_PLAN_NAME"
         - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
@@ -348,6 +350,13 @@ workflows:
         - scheme: Focus
         - simulator_device: iPad Air (4th generation)
     - deploy-to-bitrise-io@1: {}
+    - slack@3:
+        run_if: ".IsBuildFailed"
+        inputs:
+        - channel: "#focus-ios-alerts"
+        - message: "The build run the Full and Smoke tests for iPad"
+        - messageOnError: "The build run the Full and Smoke tests iPad"
+        - webhook_url: "$SLACK_WEBHOOK"
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x


### PR DESCRIPTION
We were showing the test plan info only on successful builds and for those we don't receive notifications. This PR adds the message to the failed builds.
Also, adding the notification to the build that runs the tests on  iPad.