### PR TITLE
l10n-follow-up-6-wait-for-bitrise-api-response

### DIFF
--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -175,12 +175,15 @@ async def download_artifacts(client, build_slug, artifacts_directory):
 async def download_log(client, build_slug, artifacts_directory):
     suffix = "builds/{}/log".format(build_slug)
     url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
-    is_archived = False
 
-    while not is_archived:
+    while True:
         response = await do_http_request_json(client, url)
         if response["is_archived"] == True:
-            is_archived = True
+            log.info("Log is now ready")
+            break
+        else:
+            log.info("Log is still running. Waiting another minute...")
+            await asyncio.sleep(60)
 
     download_url = response["expiring_raw_log_url"]
     if download_url:

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -175,8 +175,13 @@ async def download_artifacts(client, build_slug, artifacts_directory):
 async def download_log(client, build_slug, artifacts_directory):
     suffix = "builds/{}/log".format(build_slug)
     url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
+    is_archived = False
 
-    response = await do_http_request_json(client, url)
+    while not is_archived:
+        response = await do_http_request_json(client, url)
+        if response["is_archived"] == True:
+            is_archived = True
+
     download_url = response["expiring_raw_log_url"]
     if download_url:
         await download_file(download_url, os.path.join(artifacts_directory, "bitrise.log"))


### PR DESCRIPTION
According to Bitrise they have introduced some changes in the API, so when we were doing the GET request to get the url to the build logs, it was not ready yet. With this solution we are polling until the json key we want is ready to be consumed. 

Related to issue #1979 