### PR TITLE
l10n-follow-up-7-bitrise-workaround-for-fastlane-issue

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -391,6 +391,9 @@ workflows:
             set -e
             # debug log
             set -x
+            # workaround until 2.187 version is installed. Error with 2.186
+            fastlane update_fastlane
+
             ./l10n-screenshots.sh --test-without-building $MOZ_LOCALES
             mkdir -p artifacts
             for locale in $(echo $MOZ_LOCALES); do


### PR DESCRIPTION
Same as for L10nBuild: https://github.com/mozilla-mobile/focus-ios/blob/main/bitrise.yml#L437 we need this workaround otherwise fastlane's version 2.186 always fails with SnapshotHelper not updated.
I faced this problem previously on firefox and got fixed with this.

Another small piece of issue #1979 