### PR TITLE
l10n-follow-up-9-do-not-compress-artifacts-folder

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,7 +10,7 @@ trigger_map:
 - push_branch: v8.1.7
   workflow: release
 - pull_request_source_branch: "*"
-  workflow: runParallelTests
+  workflow: L10nScreenshotsTests
 - tag: "*"
   workflow: release
 - push_branch: refresh
@@ -392,7 +392,7 @@ workflows:
 
             echo "curl to Download derived data"
 
-            curl --location --retry 5 --output l10n-screenshots-dd.zip "$MOZ_DERIVED_DATA_PATH"
+            curl --location --retry 5 --output l10n-screenshots-dd.zip "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/CWFhvx6-QCWaPJoYMz9d0w/artifacts/public/build/target.zip"
 
             mkdir l10n-screenshots-dd
 
@@ -412,8 +412,11 @@ workflows:
             # workaround until 2.187 version is installed. Error with 2.186
             fastlane update_fastlane
 
+            MOZ_LOCALES="fr es"
+
             ./l10n-screenshots.sh --test-without-building $MOZ_LOCALES
             mkdir -p artifacts
+
             for locale in $(echo $MOZ_LOCALES); do
               # Only Focus for now
               zip -9 -j "$locale.zip" "l10n-screenshots/$locale/$locale/"*
@@ -422,7 +425,6 @@ workflows:
     - deploy-to-bitrise-io@1.10:
         inputs:
         - deploy_path: artifacts/
-        - is_compress: 'true'
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x


### PR DESCRIPTION
Screenshots are taken for each local on CI but they are stored in artifacts.zip instead we need each locale.zip in artifacts folder.
See what we have now: https://app.bitrise.io/build/06f3d3f7-7d2c-440a-8886-a1a61910ed57#?tab=artifacts
What we would need: https://app.bitrise.io/build/150d4a2e-0731-4cc4-8661-9bfff3c689f8#?tab=artifacts