### PR TITLE
Fixes #2043 - Search suggestions trimmed characters

### DIFF
--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -172,27 +172,47 @@ class OverlayView: UIView {
      
      */
 	func getAttributedButtonTitle(phrase: String, localizedStringFormat: String) -> NSAttributedString {
-		let attributedString = NSMutableAttributedString(string: localizedStringFormat, attributes: [.foregroundColor: UIConstants.Photon.Grey10])
-		let phraseString = NSAttributedString(string: phrase, attributes: [.font: UIConstants.fonts.copyButtonQuery,
-																		   .foregroundColor: UIConstants.Photon.Grey10])
+		let localizedAttributedStringFormat =
+            NSMutableAttributedString(
+                string: localizedStringFormat,
+                attributes: [.foregroundColor: UIConstants.Photon.Grey10]
+            )
+        
+		let phraseAttributedString =
+            NSAttributedString(
+                string: phrase,
+                attributes: [.font: UIConstants.fonts.copyButtonQuery,
+                             .foregroundColor: UIConstants.Photon.Grey10]
+            )
+        
 		if phrase != searchQuery {
-			let searchString = NSAttributedString(string: searchQuery, attributes: [.font: UIConstants.fonts.copyButtonQuery,
-																					.foregroundColor: UIConstants.Photon.Grey10])
+			let searchAttributedString =
+                NSAttributedString(
+                    string: searchQuery,
+                    attributes: [.font: UIConstants.fonts.copyButtonQuery,
+                                 .foregroundColor: UIConstants.Photon.Grey10]
+                )
+            
 			// split suggestion into searchQuery and suggested part
-			let suggestion = phrase.components(separatedBy: searchQuery)
+            let suggestion = phrase.deletingPrefix(searchQuery)
 			// suggestion was split
-			if suggestion.count > 1 {
-				let restOfSuggestion = NSAttributedString(string: suggestion[1], attributes: [
-					.foregroundColor: UIConstants.colors.searchSuggestion])
-				attributedString.append(searchString)
-				attributedString.append(restOfSuggestion)
-				return attributedString
+			if !suggestion.isEmpty {
+				let restOfSuggestion =
+                    NSAttributedString(
+                        string: suggestion,
+                        attributes: [.foregroundColor: UIConstants.colors.searchSuggestion]
+                    )
+				localizedAttributedStringFormat.append(searchAttributedString)
+				localizedAttributedStringFormat.append(restOfSuggestion)
+				return localizedAttributedStringFormat
 			}
 		}
-		guard let range = attributedString.string.range(of: "%@") else { return phraseString }
-		let replaceRange = NSRange(range, in: attributedString.string)
-		attributedString.replaceCharacters(in: replaceRange, with: phraseString)
-		return attributedString
+        
+		guard let range = localizedAttributedStringFormat.string.range(of: "%@") else { return phraseAttributedString }
+		let replaceRange = NSRange(range, in: localizedAttributedStringFormat.string)
+		localizedAttributedStringFormat.replaceCharacters(in: replaceRange, with: phraseAttributedString)
+        
+		return localizedAttributedStringFormat
 	}
 
     func setAttributedButtonTitle(phrase: String, button: InsetButton, localizedStringFormat: String) {

--- a/Blockzilla/StringExtensions.swift
+++ b/Blockzilla/StringExtensions.swift
@@ -14,4 +14,9 @@ extension String {
 
         return true
     }
+    
+    func deletingPrefix(_ prefix: String) -> String {
+        guard self.hasPrefix(prefix) else { return self }
+        return String(self.dropFirst(prefix.count))
+    }
 }


### PR DESCRIPTION
Fix attributed string logic. If the search key was found multiple times, the `components(sparatedBy:)` method will return an array with `count > 2`. A supposition was made it will always return 2.

<img src="https://user-images.githubusercontent.com/26011662/128995876-9be2a661-379d-49ae-8ad4-36e513118e65.PNG" width="400">


