### PR TITLE
Fixes #2130 - Update Bitrise steps to more recent versions

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,7 +24,7 @@ workflows:
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
+    - git-clone@6: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
         inputs:
@@ -84,22 +84,22 @@ workflows:
   release:
     steps:
     - certificate-and-profile-installer@1: {}
-    - xcode-archive@2:
+    - xcode-archive@3:
         inputs:
         - scheme: Focus
         - team_id: 43AQ936H96
         - export_method: app-store
         title: Build Focus
-    - deploy-to-itunesconnect-application-loader@0:
+    - deploy-to-itunesconnect-application-loader@1:
         inputs:
         - app_password: "$APPLE_ACCOUNT_PW"
         - itunescon_user: "$APPLE_ACCOUNT_ID"
-    - xcode-archive@2:
+    - xcode-archive@3:
         inputs:
         - scheme: Klar
         - export_method: app-store
         title: Build Klar
-    - deploy-to-itunesconnect-application-loader@0:
+    - deploy-to-itunesconnect-application-loader@1:
         inputs:
         - app_password: "$APPLE_ACCOUNT_PW"
         - itunescon_user: "$APPLE_ACCOUNT_ID"
@@ -116,22 +116,22 @@ workflows:
   refresh_release:
     steps:
     - certificate-and-profile-installer@1: {}
-    - xcode-archive@2:
+    - xcode-archive@3:
         inputs:
         - scheme: Focus
         - team_id: 43AQ936H96
         - export_method: app-store
         title: Build Focus
-    - deploy-to-itunesconnect-application-loader@0:
+    - deploy-to-itunesconnect-application-loader@1:
         inputs:
         - app_password: "$APPLE_ACCOUNT_PW"
         - itunescon_user: "$APPLE_ACCOUNT_ID"
-    - xcode-archive@2:
+    - xcode-archive@3:
         inputs:
         - scheme: Klar
         - export_method: app-store
         title: Build Klar
-    - deploy-to-itunesconnect-application-loader@0:
+    - deploy-to-itunesconnect-application-loader@1:
         inputs:
         - app_password: "$APPLE_ACCOUNT_PW"
         - itunescon_user: "$APPLE_ACCOUNT_ID"
@@ -177,7 +177,7 @@ workflows:
 
   runFocus:
     steps:
-    - git-clone@4: {}
+    - git-clone@6: {}
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
@@ -232,7 +232,7 @@ workflows:
 
   runKlar:
     steps:
-    - git-clone@4: {}
+    - git-clone@6: {}
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
@@ -289,7 +289,7 @@ workflows:
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
+    - git-clone@6: {}
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:


### PR DESCRIPTION
This patch updates the steps to the most recent versions. I'm specially interested in the `deploy-to-itunesconnect-application-loader` because we're seeing some odd intermittent errors when uploading builds through the `refresh_distribution` task.

We should probably move this to `main` too if this works. (Although there we have not had had issues with `deploy-to-itunesconnect-application-loader`.)