### PR TITLE
Fixes #2161 - Show the home screen tips for all English locales

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -57,8 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
         UserDefaults.standard.set(currentLaunchCount + 1, forKey: UIConstants.strings.userDefaultsLaunchCountKey)
 
         // Set original default values for showing tips
-        let tipDefaults = [TipManager.TipKey.autocompleteTip: true,
-                           TipManager.TipKey.sitesNotWorkingTip: true,
+        let tipDefaults = [TipManager.TipKey.sitesNotWorkingTip: true,
                            TipManager.TipKey.siriFavoriteTip: true,
                            TipManager.TipKey.biometricTip: true,
                            TipManager.TipKey.shareTrackersTip: true,

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -985,7 +985,6 @@ extension BrowserViewController: URLBarDelegate {
     func urlBarDidLongPress(_ urlBar: URLBar) {
         let customURLItem = PhotonActionSheetItem(title: UIConstants.strings.customURLMenuButton, iconString: "icon_link") { action in
             urlBar.addCustomURL()
-            UserDefaults.standard.set(false, forKey: TipManager.TipKey.autocompleteTip)
         }
         var actions = [PhotonActionSheetItem]()
         if let clipboardString = UIPasteboard.general.string {

--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -148,7 +148,7 @@ class HomeView: UIView {
             case TipManager.TipKey.shareTrackersTip:
                 hideTextTip()
                 let numberOfTrackersBlocked = UserDefaults.standard.integer(forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
-                showTrackerStatsShareButton(text: String(format: tip.title, String(numberOfTrackersBlocked)))
+                showTrackerStatsShareButton(text: String(format: tip.description!, String(numberOfTrackersBlocked)))
                 Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.show, object: TelemetryEventObject.trackerStatsShareButton)
             default:
                 hideTrackerStatsShareButton()

--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -213,8 +213,6 @@ class HomeView: UIView {
         tipDescriptionLabel.isHidden = false
 
         switch tip.identifier {
-        case TipManager.TipKey.autocompleteTip:
-            Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.show, object: TelemetryEventObject.autocompleteTip)
         case TipManager.TipKey.biometricTip:
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.show, object: TelemetryEventObject.biometricTip)
         case TipManager.TipKey.requestDesktopTip:

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -107,7 +107,7 @@ class TipManager {
     }
 
     func shouldShowTips() -> Bool {
-        return NSLocale.current.identifier == "en_US" && !AppInfo.isKlar
+        return NSLocale.current.languageCode == "en" && !AppInfo.isKlar
     }
     
     func getNextTip() -> Tip? {

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -72,7 +72,8 @@ class TipManager {
     lazy var siriEraseTip = Tip(title: UIConstants.strings.siriEraseTipTitle, description: UIConstants.strings.siriEraseTipDescription, identifier: TipKey.siriEraseTip, showVc: true)
 
     let numberOfTrackersBlocked = UserDefaults.standard.integer(forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
-    lazy var shareTrackersTip = Tip(title: String(format: UIConstants.strings.shareTrackersTipTitle, String(numberOfTrackersBlocked)), identifier: TipKey.shareTrackersTip)
+
+    lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, description: String(format: UIConstants.strings.shareTrackersTipDescription, String(numberOfTrackersBlocked)), identifier: TipKey.shareTrackersTip)
 
     func fetchTip() -> Tip? {
         guard Settings.getToggle(.showHomeScreenTips) else { return shareTrackersTip }

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -26,7 +26,6 @@ class TipManager {
     }
 
     class TipKey {
-        static let autocompleteTip = "autocompleteTip"
         static let sitesNotWorkingTip = "sitesNotWorkingTip"
         static let biometricTip = "biometricTip"
         static let siriFavoriteTip = "siriFavoriteTip"

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -71,9 +71,15 @@ class TipManager {
 
     lazy var siriEraseTip = Tip(title: UIConstants.strings.siriEraseTipTitle, description: UIConstants.strings.siriEraseTipDescription, identifier: TipKey.siriEraseTip, showVc: true)
 
-    let numberOfTrackersBlocked = UserDefaults.standard.integer(forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
-
-    lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, description: String(format: UIConstants.strings.shareTrackersTipDescription, String(numberOfTrackersBlocked)), identifier: TipKey.shareTrackersTip)
+    /// Return a string representing the trackers tip. It will include the current number of trackers blocked, formatted as a decimal.    
+    func shareTrackersDescription() -> String {
+        let numberOfTrackersBlocked = NSNumber(integerLiteral: UserDefaults.standard.integer(forKey: BrowserViewController.userDefaultsTrackersBlockedKey))
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return String(format: UIConstants.strings.shareTrackersTipDescription, formatter.string(from: numberOfTrackersBlocked) ?? "0")
+    }
+    
+    lazy var shareTrackersTip = Tip(title: UIConstants.strings.shareTrackersTipTitle, description: shareTrackersDescription(), identifier: TipKey.shareTrackersTip)
 
     func fetchTip() -> Tip? {
         guard Settings.getToggle(.showHomeScreenTips) else { return shareTrackersTip }

--- a/Blockzilla/TipManager.swift
+++ b/Blockzilla/TipManager.swift
@@ -46,7 +46,6 @@ class TipManager {
     }
 
     private func addAllTips() {
-        possibleTips.append(autocompleteTip)
         possibleTips.append(sitesNotWorkingTip)
         possibleTips.append(requestDesktopTip)
         possibleTips.append(siriFavoriteTip)
@@ -56,8 +55,6 @@ class TipManager {
             possibleTips.append(biometricTip)
         }
     }
-
-    lazy var autocompleteTip = Tip(title: UIConstants.strings.autocompleteTipTitle, description: UIConstants.strings.autocompleteTipDescription, identifier: TipKey.autocompleteTip)
 
     lazy var sitesNotWorkingTip = Tip(title: UIConstants.strings.sitesNotWorkingTipTitle, description: UIConstants.strings.sitesNotWorkingTipDescription, identifier: TipKey.sitesNotWorkingTip)
 

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -505,9 +505,9 @@ struct UIConstants {
         static let biometricTipTouchIdDescription = "Turn on Touch ID"
         static let requestDesktopTipTitle = "Want to see the full desktop version of a site?"
         static let requestDesktopTipDescription = "Page Actions > Request Desktop Site"
-        static let siriFavoriteTipTitle = "Ask Siri to open a favorite site:"
-        static let siriFavoriteTipDescription = "Add a site"
-        static let siriEraseTipTitle = String(format: "Ask Siri to erase %@ history:", AppInfo.productName)
+        static let siriFavoriteTipTitle = "“Siri, open my favorite site.”"
+        static let siriFavoriteTipDescription = "Add Siri shortcut"
+        static let siriEraseTipTitle = String(format: "“Siri, erase my %@ session.”", AppInfo.productName)
         static let siriEraseTipDescription = "Add Siri shortcut"
         static let shareTrackersTipTitle = "%@ trackers blocked so far"
         static let sumoTopicWhatsNew = "whats-new-focus-ios-8"

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -500,7 +500,7 @@ struct UIConstants {
         static let findInPageNotification = "Notification.findInPage"
         static let sitesNotWorkingTipTitle = "Site missing content or acting strange?"
         static let sitesNotWorkingTipDescription = "Try turning off Tracking Protection"
-        static let biometricTipTitle = String(format: "Lock %@ even when a site is open:", AppInfo.productName)
+        static let biometricTipTitle = String(format: "Lock %@ when a site is open:", AppInfo.productName)
         static let biometricTipFaceIdDescription = "Turn on Face ID"
         static let biometricTipTouchIdDescription = "Turn on Touch ID"
         static let requestDesktopTipTitle = "Get the full desktop site instead:"

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -498,7 +498,7 @@ struct UIConstants {
         static let requestDesktopNotification = "Notification.requestDesktop"
         static let requestMobileNotification = "Notification.requestMobile"
         static let findInPageNotification = "Notification.findInPage"
-        static let sitesNotWorkingTipTitle = "Site acting strange?"
+        static let sitesNotWorkingTipTitle = "Site missing content or acting strange?"
         static let sitesNotWorkingTipDescription = "Try turning off Tracking Protection"
         static let biometricTipTitle = String(format: "Lock %@ even when a site is open:", AppInfo.productName)
         static let biometricTipFaceIdDescription = "Turn on Face ID"

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -503,7 +503,7 @@ struct UIConstants {
         static let biometricTipTitle = String(format: "Lock %@ when a site is open:", AppInfo.productName)
         static let biometricTipFaceIdDescription = "Turn on Face ID"
         static let biometricTipTouchIdDescription = "Turn on Touch ID"
-        static let requestDesktopTipTitle = "Get the full desktop site instead:"
+        static let requestDesktopTipTitle = "Want to see the full desktop version of a site?"
         static let requestDesktopTipDescription = "Page Actions > Request Desktop Site"
         static let siriFavoriteTipTitle = "Ask Siri to open a favorite site:"
         static let siriFavoriteTipDescription = "Add a site"

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -498,8 +498,6 @@ struct UIConstants {
         static let requestDesktopNotification = "Notification.requestDesktop"
         static let requestMobileNotification = "Notification.requestMobile"
         static let findInPageNotification = "Notification.findInPage"
-        static let autocompleteTipTitle = "Autocomplete URLs for the sites you use most:"
-        static let autocompleteTipDescription = "Long-press any URL in the address bar"
         static let sitesNotWorkingTipTitle = "Site acting strange?"
         static let sitesNotWorkingTipDescription = "Try turning off Tracking Protection"
         static let biometricTipTitle = String(format: "Lock %@ even when a site is open:", AppInfo.productName)

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -509,7 +509,8 @@ struct UIConstants {
         static let siriFavoriteTipDescription = "Add Siri shortcut"
         static let siriEraseTipTitle = String(format: "“Siri, erase my %@ session.”", AppInfo.productName)
         static let siriEraseTipDescription = "Add Siri shortcut"
-        static let shareTrackersTipTitle = "%@ trackers blocked so far"
+        static let shareTrackersTipTitle = String(format: "You browse. %@ blocks.", AppInfo.productName)
+        static let shareTrackersTipDescription = "%@ trackers blocked so far"
         static let sumoTopicWhatsNew = "whats-new-focus-ios-8"
         static let klarSumoTopicWhatsNew = "whats-new-firefox-klar-ios-version-8"
         static let sumoTopicSearchSuggestion = "search-suggestions-focus-ios"


### PR DESCRIPTION
This patch updates `TipManager.shouldShowTips()` to check for `en` instead of `en-US`.