### PR TITLE
Fixes #2168 - Include Hebrew in shipping_locales.txt

### DIFF
--- a/shipping_locales.txt
+++ b/shipping_locales.txt
@@ -27,6 +27,7 @@ fr
 ga-IE
 gd
 gu-IN
+he
 hsb
 hu
 hy-AM


### PR DESCRIPTION
Hebrew ("he") seems to be missing here, although we have it on Pontoon (https://pontoon.mozilla.org/he/focus-for-ios/). Adding it to list of shipping locales
CC @isabelrios and @st3fan as FYI

Needs Uplift to `refresh`.

## Commit Message
Fixes #2168 - Include Hebrew in shipping_locales.txt