### PR TITLE
Fixes #2140 - Disable translucency on bottom toolbar

### DIFF
--- a/Blockzilla/BrowserToolbar.swift
+++ b/Blockzilla/BrowserToolbar.swift
@@ -16,7 +16,7 @@ class BrowserToolbar: UIView {
         super.init(frame: CGRect.zero)
 
         let background = UIView()
-        background.alpha = 0.95
+        background.alpha = 1
         background.backgroundColor = UIConstants.colors.background
         addSubview(background)
 

--- a/Blockzilla/BrowserToolbar.swift
+++ b/Blockzilla/BrowserToolbar.swift
@@ -16,7 +16,6 @@ class BrowserToolbar: UIView {
         super.init(frame: CGRect.zero)
 
         let background = UIView()
-        background.alpha = 1
         background.backgroundColor = UIConstants.colors.background
         addSubview(background)
 


### PR DESCRIPTION
This is the new look of the bottom toolbar:

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-19 at 14 57 36](https://user-images.githubusercontent.com/46751540/130064830-6822f5f1-9ca8-4165-97f9-4ed5b04c7170.png)
