### PR TITLE
Fixes #2145 - On the search results interface, the top toolbar, address box and search results have different backgrounds

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -873,7 +873,7 @@ extension BrowserViewController: URLBarDelegate {
                     if userInputText == trimmedText {
                         let suggestions = suggestions ?? [trimmedText]
                         DispatchQueue.main.async {
-                            self.overlayView.setGradientToSearchButtons()
+                            self.overlayView.setColorstToSearchButtons()
                             self.overlayView.setSearchQuery(suggestions: suggestions, hideFindInPage: isOnHomeView || text.isEmpty, hideAddToComplete: true)
                         }
                     }

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -172,7 +172,7 @@ class OverlayView: UIView {
             }
         }
         
-        findInPageButton.backgroundColor = iPadView ? .searchSuggestionIPad : UIConstants.colors.background
+        findInPageButton.backgroundColor = iPadView ? .searchSuggestionIPad : .foundation
         
         remakeConstraintsForFindInPage()
         
@@ -193,7 +193,7 @@ class OverlayView: UIView {
             topBorder.backgroundColor =  UIConstants.Photon.Grey90.withAlphaComponent(0.4)
             
         }
-        setGradientToSearchButtons()
+        setColorstToSearchButtons()
     }
 
     private func makeSearchSuggestionButton(atIndex i: Int) {
@@ -229,14 +229,9 @@ class OverlayView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func setGradientToSearchButtons() {
+    func setColorstToSearchButtons() {
         for button in searchButtonGroup {
-            if isIpadView {
-                button.removeGradient()
-                button.backgroundColor = .searchSuggestionIPad
-            } else {
-                button.applyGradient(colors: [.searchGradientFirst, .searchGradientSecond, .searchGradientThird, .searchGradientFourth])
-            }
+            button.backgroundColor = isIpadView ? .searchSuggestionIPad : .foundation
         }
     }
 

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -645,7 +645,6 @@ class URLBar: UIView {
             }
 
             self.urlBarBorderView.backgroundColor = borderColor
-            self.urlBarBackgroundView.backgroundColor = backgroundColor
         }, completion: { finished in
             if finished {
                 self.displayClearButton(shouldDisplay: self.isEditing)

--- a/Blockzilla/URLBarContainer.swift
+++ b/Blockzilla/URLBarContainer.swift
@@ -12,7 +12,7 @@ class URLBarContainer: UIView {
     init() {
         super.init(frame: CGRect.zero)
 
-        backgroundEditing.backgroundColor = .secondayButton
+        backgroundEditing.backgroundColor = .foundation
         addSubview(backgroundEditing)
 
         backgroundDark.backgroundColor = UIConstants.colors.background
@@ -20,7 +20,7 @@ class URLBarContainer: UIView {
         backgroundDark.alpha = 0
         addSubview(backgroundDark)
 
-        backgroundBright.backgroundColor = .secondayButton
+        backgroundBright.backgroundColor = .foundation
         backgroundBright.isHidden = true
         backgroundBright.alpha = 0
         addSubview(backgroundBright)


### PR DESCRIPTION
This PR added the required colors for top toolbar, address box and search results view. This is how the search results interface looks now:
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-23 at 16 59 19](https://user-images.githubusercontent.com/46751540/130460850-81b6daed-fba1-4130-b79d-bc39a0e13fb2.png)
