### PR TITLE
For #2205 - SettingAppearanceTest failures after UI changes

### DIFF
--- a/SmokeTest.xctestplan
+++ b/SmokeTest.xctestplan
@@ -25,6 +25,7 @@
         "RequestDesktopTest",
         "SearchProviderTest",
         "SearchSuggestionsPromptTest",
+        "SettingAppearanceTest",
         "SettingAppearanceTest\/testAddRemoveCustomDomain()",
         "SettingAppearanceTest\/testDisableAutocomplete()",
         "SettingAppearanceTest\/testOpenInSafari()",

--- a/SmokeTest.xctestplan
+++ b/SmokeTest.xctestplan
@@ -25,7 +25,6 @@
         "RequestDesktopTest",
         "SearchProviderTest",
         "SearchSuggestionsPromptTest",
-        "SettingAppearanceTest",
         "SettingAppearanceTest\/testAddRemoveCustomDomain()",
         "SettingAppearanceTest\/testDisableAutocomplete()",
         "SettingAppearanceTest\/testOpenInSafari()",

--- a/SmokeTestRefresh.xctestplan
+++ b/SmokeTestRefresh.xctestplan
@@ -24,6 +24,7 @@
         "RequestDesktopTest",
         "SearchProviderTest",
         "SearchSuggestionsPromptTest",
+        "SettingAppearanceTest",
         "SettingAppearanceTest\/testAddRemoveCustomDomain()",
         "SettingAppearanceTest\/testDisableAutocomplete()",
         "SettingAppearanceTest\/testOpenInSafari()",


### PR DESCRIPTION
This patch disables the `SettingAppearanceTest` on the `SmokeTestRefresh.xctestplan`. Going to land this to unblock two other PRs. Cc @isabelrios for awareness.