### PR TITLE
For #2205 - Disable testCheckSetting()

### DIFF
--- a/SmokeTestRefresh.xctestplan
+++ b/SmokeTestRefresh.xctestplan
@@ -27,7 +27,7 @@
         "SettingAppearanceTest\/testAddRemoveCustomDomain()",
         "SettingAppearanceTest\/testDisableAutocomplete()",
         "SettingAppearanceTest\/testOpenInSafari()",
-        "SettingAppearanceTest\/testCheckSettings()",
+        "SettingAppearanceTest\/testCheckSetting()",
         "TrackingProtectionMenu\/testInactiveProtectionSidebar()",
         "TrackingProtectionSettings",
         "UserAgentTest",


### PR DESCRIPTION
Another patch to disable `testCheckSetting()`.

I did the previous by directly editing the `SmokeTestRefresh.xctestplan` and disabled `testCheckSettings()` - but that was not the right name of the test :-/
