### PR TITLE
Fixes #2212 Incorrect shortcuts bar layout on smallest horizontal size class

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -102,6 +102,26 @@ class BrowserViewController: UIViewController {
         NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
     }
 
+    fileprivate func addShortcutsBackgroundConstraints() {
+        shortcutsBackground.backgroundColor = isIPadRegularDimensions ? .primaryBackground.withAlphaComponent(0.85) : .foundation
+        shortcutsBackground.layer.cornerRadius = isIPadRegularDimensions ? 10 : 0
+        
+        if isIPadRegularDimensions {
+            shortcutsBackground.snp.makeConstraints { make in
+                make.top.equalTo(urlBarContainer.snp.bottom)
+                make.width.equalTo(UIConstants.layout.shortcutsBackgroundWidthIPad)
+                make.height.equalTo(UIConstants.layout.shortcutsBackgroundHeightIPad)
+                make.centerX.equalTo(urlBarContainer)
+            }
+        } else {
+            shortcutsBackground.snp.makeConstraints { make in
+                make.top.equalTo(urlBarContainer.snp.bottom)
+                make.left.right.equalToSuperview()
+                make.height.equalTo(UIConstants.layout.shortcutsBackgroundHeight)
+            }
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -142,6 +162,12 @@ class BrowserViewController: UIViewController {
         browserToolbar.delegate = self
         browserToolbar.translatesAutoresizingMaskIntoConstraints = false
         mainContainerView.addSubview(browserToolbar)
+        
+        mainContainerView.addSubview(shortcutsBackground)
+        shortcutsBackground.isHidden = true
+        addShortcutsBackgroundConstraints()
+        setupShortcuts()
+        mainContainerView.addSubview(shortcutsContainer)
 
         overlayView.isHidden = true
         overlayView.alpha = 0
@@ -149,13 +175,6 @@ class BrowserViewController: UIViewController {
         overlayView.backgroundColor = isIPadRegularDimensions ? .clear : .scrim.withAlphaComponent(0.48)
         overlayView.setSearchSuggestionsPromptViewDelegate(delegate: self)
         mainContainerView.addSubview(overlayView)
-        
-        shortcutsBackground.backgroundColor = isIPadRegularDimensions ? .primaryBackground.withAlphaComponent(0.85) : .foundation
-        shortcutsBackground.layer.cornerRadius = isIPadRegularDimensions ? 10 : 0
-        shortcutsBackground.isHidden = true
-        mainContainerView.addSubview(shortcutsBackground)
-        
-        setupShortcuts()
 
         background.snp.makeConstraints { make in
             make.edges.equalTo(mainContainerView)
@@ -195,34 +214,20 @@ class BrowserViewController: UIViewController {
             make.leading.trailing.bottom.equalTo(mainContainerView)
         }
         
-        if isIPadRegularDimensions {
-            shortcutsBackground.snp.makeConstraints { make in
-                make.top.equalTo(urlBarContainer.snp.bottom)
-                make.width.equalTo(UIConstants.layout.shortcutsBackgroundWidthIPad)
-                make.height.equalTo(UIConstants.layout.shortcutsBackgroundHeightIPad)
-                make.centerX.equalTo(urlBarContainer)
-            }
-        } else {
-            shortcutsBackground.snp.makeConstraints { make in
-                make.top.equalTo(urlBarContainer.snp.bottom)
-                make.left.right.equalToSuperview()
-                make.height.equalTo(UIConstants.layout.shortcutsBackgroundHeight)
-            }
-        }
-        
         shortcutsContainer.snp.makeConstraints { make in
             make.top.equalTo(urlBarContainer.snp.bottom).offset(isIPadRegularDimensions ? UIConstants.layout.shortcutsContainerOffsetIPad : UIConstants.layout.shortcutsContainerOffset)
             make.width.equalTo(isIPadRegularDimensions ?
                                 UIConstants.layout.shortcutsContainerWidthIPad :
-                                UIConstants.layout.shortcutsContainerWidth)
+                                UIConstants.layout.shortcutsContainerWidth).priority(.medium)
             make.height.equalTo(isIPadRegularDimensions ?
                                     UIConstants.layout.shortcutViewHeightIPad :
                                     UIConstants.layout.shortcutViewHeight)
             make.centerX.equalToSuperview()
+            make.leading.greaterThanOrEqualTo(mainContainerView).inset(8)
+            make.trailing.lessThanOrEqualTo(mainContainerView).inset(-8)
+
         }
         
-        
-
         view.addSubview(alertStackView)
         alertStackView.axis = .vertical
         alertStackView.alignment = .center
@@ -358,7 +363,6 @@ class BrowserViewController: UIViewController {
             UIConstants.layout.shortcutsContainerSpacing
         
         addShortcuts()
-        mainContainerView.addSubview(shortcutsContainer)
     }
     
     @objc func orientationChanged() {
@@ -766,6 +770,12 @@ class BrowserViewController: UIViewController {
                 self.updateViewConstraints()
             })
         })
+        
+        shortcutsContainer.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        addShortcuts()
+        
+        shortcutsBackground.snp.removeConstraints()
+        addShortcutsBackgroundConstraints()
     }
 
     private func presentImageActionSheet(title: String, link: String?, saveAction: @escaping () -> Void, copyAction: @escaping () -> Void) {


### PR DESCRIPTION
Fix iPad layout in split view by defaulting to iPhone layout.
| iPad  | Split view |
| ------------- | ------------- |
| <img width="1052" alt="Screenshot 2021-08-31 at 16 02 59" src="https://user-images.githubusercontent.com/26011662/131507725-1f791bf2-a348-4a17-bb31-61ce75546d89.png">  | <img width="1052" alt="Screenshot 2021-08-31 at 16 02 44" src="https://user-images.githubusercontent.com/26011662/131507784-6c31bc26-a3ed-4850-88f9-d913e5eca4ec.png"> |
| <img width="1052" alt="Screenshot 2021-08-31 at 16 02 35" src="https://user-images.githubusercontent.com/26011662/131507858-f862b078-7b89-432f-8d6f-50c24f82d512.png"> | <img width="1052" alt="Screenshot 2021-08-31 at 16 02 15" src="https://user-images.githubusercontent.com/26011662/131507914-68fbe4d1-0a9b-4204-aacb-9947800deebb.png">  |

## Commit Message
Fixes #2212 Incorrect shortcuts bar layout on smallest horizontal size class

