### PR TITLE
Fixes #2244 - Update Glean to v40

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -5192,7 +5192,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift/";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 39.0.2;
+				minimumVersion = 40.1.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mozilla/glean-swift/",
         "state": {
           "branch": null,
-          "revision": "e6c2d31b128be4fc59cdaf684acfbb419454866a",
-          "version": "39.0.2"
+          "revision": "a1c35bc7b52a6ffd36829897cb9e9bac4f5b4f65",
+          "version": "40.1.1"
         }
       },
       {

--- a/bin/sdk_generator.sh
+++ b/bin/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=1.28.6
+GLEAN_PARSER_VERSION=3.6.0
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034
@@ -139,6 +139,9 @@ fi
 VENVDIR="${SOURCE_ROOT}/.venv"
 
 [ -x "${VENVDIR}/bin/python" ] || python3 -m venv "${VENVDIR}"
+# We need at least pip 20.3 for Big Sur support, see https://pip.pypa.io/en/stable/news/#id48
+# Latest pip is 21.0.1
+"${VENVDIR}"/bin/pip install "pip>=20.3"
 "${VENVDIR}"/bin/pip install --upgrade glean_parser==$GLEAN_PARSER_VERSION
 
 # Run the glinter


### PR DESCRIPTION
This patch updates Glean to `40.1.1` and the sdk_generator to `3.6.0`.

Taken from @badboy 's patch against the #2235 work, thank you very much 👍🏻 