### PR TITLE
Fixes #1766 - Enable Glean Debug Tools

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -190,6 +190,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
             } else {
                 queuedString = text
             }
+        } else if host == "glean" {
+            Glean.shared.handleCustomUrl(url: url)
         }
 
         return true


### PR DESCRIPTION
This patch allows Focus to be opened with `firefox-focus://glean` URLs. This will then allow us to trigger debug mode with for example `firefox-focus://glean?debugViewTag=MyTestTag`.

The easiest way to trigger this is by creating an iOS Shortcut that looks like this:

<img width="549" alt="Screen Shot 2021-09-02 at 12 02 24 PM" src="https://user-images.githubusercontent.com/28052/131881031-30351e5a-9f00-4c1c-9fb9-4811bd44a53f.png">

This shortcut can then be added to your device home screen for easy access.

One note: If testing telemetry that is created during app startup, it is important to open the above test URL while the app is not open. So kill the app first, and then open it up with the above link. When it gets moved to the background, it should send telemetry in debug mode.