### PR TITLE
Fixes #2253 - Include new locales: co an en-GB

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -928,6 +928,20 @@
 		F84AFE721DE77FE6005C4DD1 /* LaunchScreen.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = LaunchScreen.png; sourceTree = "<group>"; };
 		F84AFE731DE77FE6005C4DD1 /* LaunchScreen@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "LaunchScreen@2x.png"; sourceTree = "<group>"; };
 		F84AFE741DE77FE6005C4DD1 /* LaunchScreen@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "LaunchScreen@3x.png"; sourceTree = "<group>"; };
+		F8820C7126E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Intro.strings"; sourceTree = "<group>"; };
+		F8820C7226E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Intents.strings"; sourceTree = "<group>"; };
+		F8820C7326E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		F8820C7426E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		F8820C7526E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		F8820C7626E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		F8820C7726E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		F8820C7826E19B4D006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/Intro.strings; sourceTree = "<group>"; };
+		F8820C7926E19B4D006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/Intents.strings; sourceTree = "<group>"; };
+		F8820C7A26E19B4D006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F8820C7B26E19B4D006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F8820C7C26E19B4E006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F8820C7D26E19B4E006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F8820C7E26E19B4E006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F8CE542D26C169B3000A5F9C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/Intro.strings; sourceTree = "<group>"; };
 		F8CE542E26C169B3000A5F9C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/Intents.strings; sourceTree = "<group>"; };
 		F8CE542F26C169B4000A5F9C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1662,6 +1676,8 @@
 				"gu-IN",
 				lv,
 				lt,
+				"en-GB",
+				co,
 			);
 			mainGroup = E4BF2DCA1BACE8CA00DA9D68;
 			packageReferences = (
@@ -2118,6 +2134,8 @@
 				16ABCD7021406DAF00CABBF4 /* gu-IN */,
 				F8CE542E26C169B3000A5F9C /* lv */,
 				F8CE543526C169D8000A5F9C /* lt */,
+				F8820C7226E19B1E006AB3B8 /* en-GB */,
+				F8820C7926E19B4D006AB3B8 /* co */,
 			);
 			name = Intents.strings;
 			sourceTree = "<group>";
@@ -2200,6 +2218,8 @@
 				16938C1021012A0300DCD489 /* gu-IN */,
 				F8CE542D26C169B3000A5F9C /* lv */,
 				F8CE543426C169D8000A5F9C /* lt */,
+				F8820C7126E19B1E006AB3B8 /* en-GB */,
+				F8820C7826E19B4D006AB3B8 /* co */,
 			);
 			name = Intro.strings;
 			sourceTree = "<group>";
@@ -2282,6 +2302,8 @@
 				16938C0F21012A0200DCD489 /* gu-IN */,
 				F8CE543026C169B4000A5F9C /* lv */,
 				F8CE543726C169D8000A5F9C /* lt */,
+				F8820C7426E19B1E006AB3B8 /* en-GB */,
+				F8820C7B26E19B4D006AB3B8 /* co */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -2364,6 +2386,8 @@
 				16938C0E21012A0200DCD489 /* gu-IN */,
 				F8CE542F26C169B4000A5F9C /* lv */,
 				F8CE543626C169D8000A5F9C /* lt */,
+				F8820C7326E19B1E006AB3B8 /* en-GB */,
+				F8820C7A26E19B4D006AB3B8 /* co */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -2433,6 +2457,8 @@
 				A89766D31F57DCA8008183C5 /* es-AR */,
 				F8CE543226C169B4000A5F9C /* lv */,
 				F8CE543926C169D8000A5F9C /* lt */,
+				F8820C7626E19B1E006AB3B8 /* en-GB */,
+				F8820C7D26E19B4E006AB3B8 /* co */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -2502,6 +2528,8 @@
 				A89766D61F57DCA9008183C5 /* es-AR */,
 				F8CE543326C169B4000A5F9C /* lv */,
 				F8CE543A26C169D8000A5F9C /* lt */,
+				F8820C7726E19B1E006AB3B8 /* en-GB */,
+				F8820C7E26E19B4E006AB3B8 /* co */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -2584,6 +2612,8 @@
 				16938C1121012A0300DCD489 /* gu-IN */,
 				F8CE543126C169B4000A5F9C /* lv */,
 				F8CE543826C169D8000A5F9C /* lt */,
+				F8820C7526E19B1E006AB3B8 /* en-GB */,
+				F8820C7C26E19B4E006AB3B8 /* co */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";

--- a/Blockzilla/co.lproj/InfoPlist.strings
+++ b/Blockzilla/co.lproj/InfoPlist.strings
@@ -1,0 +1,18 @@
+/* (No Comment) */
+"NSCameraUsageDescription" = "This lets you take and upload photos.";
+
+/* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
+"NSLocationWhenInUseUsageDescription" = "Websites you visit may request your location.";
+
+/* (No Comment) */
+"NSMicrophoneUsageDescription" = "This lets you take and upload videos.";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
+
+/* This is the menu item that appears when you long press the Focus icon on the phone home screen. */
+"UIApplicationShortcutItemTitle.EraseAndOpen" = "Erase and Open";
+

--- a/Blockzilla/co.lproj/Intents.strings
+++ b/Blockzilla/co.lproj/Intents.strings
@@ -1,0 +1,3 @@
+/* Title of the Erase intent. */
+"Intents.Erase.Title" = "Erase";
+

--- a/Blockzilla/co.lproj/Intro.strings
+++ b/Blockzilla/co.lproj/Intro.strings
@@ -1,0 +1,24 @@
+/* Description for the 'History' panel in the First Run tour. */
+"Intro.Slides.History.Description" = "Clear your entire browsing session history, passwords, cookies anytime with a single tap.";
+
+/* Title for the third  panel 'History' in the First Run tour. */
+"Intro.Slides.History.Title" = "Your history is history";
+
+/* Button to go to the next card in Focus onboarding. */
+"Intro.Slides.Next.Button" = "Next";
+
+/* Description for the 'Favorite Search Engine' panel in the First Run tour. */
+"Intro.Slides.Search.Description" = "Searching for something different? Choose a different search engine.";
+
+/* Title for the second  panel 'Search' in the First Run tour. */
+"Intro.Slides.Search.Title" = "Your search, your way";
+
+/* Button to skip onboarding in Focus */
+"Intro.Slides.Skip.Button" = "Skip";
+
+/* Description for the 'Welcome' panel in the First Run tour. */
+"Intro.Slides.Welcome.Description" = "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.";
+
+/* Title for the first panel 'Welcome' in the First Run tour. */
+"Intro.Slides.Welcome.Title" = "Power up your privacy";
+

--- a/Blockzilla/co.lproj/Localizable.strings
+++ b/Blockzilla/co.lproj/Localizable.strings
@@ -1,0 +1,561 @@
+/* Button on About screen */
+"About.learnMoreButton" = "Learn more";
+
+/* Label on About screen */
+"About.missionLabel" = "%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.";
+
+/* Label on About screen */
+"About.privateBullet1" = "Search and browse right in the app";
+
+/* Label on About screen */
+"About.privateBullet2" = "Block trackers (or update settings to allow trackers)";
+
+/* Label on About screen */
+"About.privateBullet3" = "Erase to delete cookies as well as search and browsing history";
+
+/* Label on About screen */
+"About.privateBulletHeader" = "Use it as a private browser:";
+
+/* Label for row in About screen */
+"About.rowHelp" = "Help";
+
+/* Link to Privacy Notice in the About screen */
+"About.rowPrivacy" = "Privacy Notice";
+
+/* Label for row in About screen */
+"About.rowRights" = "Your Rights";
+
+/* Label on About screen */
+"About.safariBullet1" = "Block trackers for improved privacy";
+
+/* Label on About screen */
+"About.safariBullet2" = "Block Web fonts to reduce page size";
+
+/* Label on About screen */
+"About.safariBulletHeader" = "Use it as a Safari extension:";
+
+/* (No Comment) */
+"About.screenTitle" = "About";
+
+/* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page. */
+"About.title" = "About %@";
+
+/* Label on About screen */
+"About.topLabel" = "%@ puts you in control.";
+
+/* Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page. */
+"actionSheet.openIn" = "Open in %@";
+
+/* %@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app. */
+"Authentication.reason" = "Authenticate to return to %@";
+
+/* Label for button to add a custom URL */
+"Autocomplete.addCustomUrl" = "Add Custom URL";
+
+/* Label for error state when entering an invalid URL */
+"Autocomplete.addCustomUrlError" = "Double-check the URL you entered.";
+
+/* A label displaying an example URL */
+"Autocomplete.addCustomUrlExample" = "Example: example.com";
+
+/* Label for the input to add a custom URL */
+"Autocomplete.addCustomUrlLabel" = "URL to add";
+
+/* Placeholder for the input field to add a custom URL */
+"Autocomplete.addCustomUrlPlaceholder" = "Paste or enter URL";
+
+/* Label for button to add a custom URL with the + prefix */
+"Autocomplete.addCustomUrlWithPlus" = "+ Add Custom URL";
+
+/* Description for adding and managing custom autocomplete URLs */
+"Autocomplete.customDescriptoin" = "Add and manage custom autocomplete URLs.";
+
+/* Label for button taking you to your custom Autocomplete URL list */
+"Autocomplete.customLabel" = "Custom URLs";
+
+/* Title for the default URL list section */
+"Autocomplete.customTitle" = "CUSTOM URL LIST";
+
+/* Label for toast alerting a custom URL has been added */
+"Autocomplete.customUrlAdded" = "New Custom URL added.";
+
+/* Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
+"Autocomplete.defaultDescriptoin" = "Enable to have %@ autocomplete over 450 popular URLs in the address bar.";
+
+/* Label for enabling or disabling autocomplete */
+"Autocomplete.defaultLabel" = "Autocomplete";
+
+/* Title for the default URL list section */
+"Autocomplete.defaultTitle" = "DEFAULT URL LIST";
+
+/* label describing URL Autocomplete as disabled */
+"Autocomplete.disabled" = "Disabled";
+
+/* Label for toast alerting that the custom URL being added is a duplicate */
+"Autocomplete.duplicateUrl" = "URL already exists";
+
+/* Label for button to add a custom URL */
+"Autocomplete.emptyState" = "No Custom URLs to display";
+
+/* label describing URL Autocomplete as enabled */
+"Autocomplete.enabled" = "Enabled";
+
+/* Label for button taking you to your custom Autocomplete URL list */
+"Autocomplete.manageSites" = "Manage Sites";
+
+/* Label for enabling or disabling autocomplete */
+"Autocomplete.mySites" = "My Sites";
+
+/* Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
+"Autocomplete.mySitesDesc" = "Enable to have %@ autocomplete your favorite URLs.";
+
+/* Label for enabling or disabling top sites */
+"Autocomplete.topSites" = "Top Sites";
+
+/* Create a new session after failing a biometric check */
+"BiometricPrompt.newSession" = "New Session";
+
+/* %@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app. */
+"BiometricPrompt.reason" = "Unlock %@ when re-opening in order to prevent unauthorized access.";
+
+/* Accessibility label for the back button */
+"Browser.backLabel" = "Back";
+
+/* Copy URL button in URL long press menu */
+"Browser.copyAddressLabel" = "Copy Address";
+
+/* Toast displayed after a URL has been copied to the clipboard */
+"browser.copyAddressToast" = "URL Copied To Clipboard";
+
+/* Copy URL button in URL long press menu */
+"Browser.copyMenuLabel" = "Copy";
+
+/* Custom URL button in URL long press menu */
+"Browser.customURLMenuLabel" = "Add Custom URL";
+
+/* Accessibility label for the forward button */
+"Browser.forwardLabel" = "Forward";
+
+/* Accessibility label for the reload button */
+"Browser.reloadLabel" = "Reload";
+
+/* Accessibility label for the settings button */
+"Browser.settingsLabel" = "Settings";
+
+/* Accessibility label for the share button */
+"Browser.shareLabel" = "Share";
+
+/* Accessibility label for the stop button */
+"Browser.stopLabel" = "Stop";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"browserShortcutDescription.selectLocationBar" = "Select Location Bar";
+
+/* Label on button to cancel edits */
+"Cancel" = "Cancel";
+
+/* Text for the context menu when a user has a link on their clipboard. */
+"contextMenu.clipboardLink" = "Link you copied: %@";
+
+/* Text for the context menu when a user wants to copy an image after long pressing it. */
+"contextMenu.copyImageTitle" = "Copy Image";
+
+/* Text for the context menu when a user wants to copy a link after long pressing it. */
+"contextMenu.copyLink" = "Copy Link";
+
+/* Text for the context menu when a user has a link on their clipboard. */
+"contextMenu.linkCopied" = "Link you copied: ";
+
+/* Text for the context menu when a user wants to save an image after long pressing it. */
+"contextMenu.saveImageTitle" = "Save Image";
+
+/* Text for the context menu when a user wants to share a link after long pressing it. */
+"contextMenu.shareLinkTitle" = "Share Link";
+
+/* Label on button to complete edits */
+"Done" = "Done";
+
+/* Label on button to allow edits */
+"Edit" = "Edit";
+
+/* Button label to reload the error page */
+"Error.tryAgainButton" = "Try again";
+
+/* Button label used for cancelling to open another app from Focus */
+"ExternalAppLink.cancelTitle" = "Cancel";
+
+/* Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar. */
+"ExternalAppLink.messageTitle" = "%@ wants to open another App";
+
+/* Button label for opening another app from Focus */
+"ExternalAppLink.openTitle" = "Open";
+
+/* Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open. */
+"externalAppLinkWithAppName.messageTitle" = "%1$@ wants to open %2$@";
+
+/* Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.callButton" = "Call";
+
+/* Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.cancelButton" = "Cancel";
+
+/* Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.emailButton" = "Email";
+
+/* Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.messageTitleWithPlaceholder" = "You are now leaving %@.";
+
+/* Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.openAppStoreButton" = "Open App Store";
+
+/* Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
+"ExternalLink.openAppStoreTitle" = "%@ wants to open the App Store.";
+
+/* Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.openMapsButton" = "Open Maps";
+
+/* Accessibility label for done button in Find in Page Toolbar. */
+"FindInPage.Done" = "Find in page done";
+
+/* Accessibility label for next result button in Find in Page Toolbar. */
+"FindInPage.NextResult" = "Find next in page";
+
+/* Accessibility label for previous result button in Find in Page Toolbar. */
+"FindInPage.PreviousResult" = "Find previous in page";
+
+/* Label on button to dismiss first run UI */
+"FirstRun.lastSlide.buttonLabel" = "OK, Got It!";
+
+/* Message label on the first run screen */
+"FirstRun.messageLabelDescription" = "Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.";
+
+/* Message label on the first run screen */
+"FirstRun.messageLabelTagline" = "Browse like no one’s watching.";
+
+/* Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681 */
+"Focus.handoffSyncing" = "Apple Handoff is syncing";
+
+/* First label for product description on the home screen */
+"Home.descriptionLabel1" = "Automatic private browsing.";
+
+/* Second label for product description on the home screen */
+"Home.descriptionLabel2" = "Browse. Erase. Repeat.";
+
+/* Button label used to close a menu that displays as a popup. */
+"Menu.Close" = "Close";
+
+/* Label in share alert to cancel the alert */
+"Open.Cancel" = "Cancel";
+
+/* Label in share alert to open the URL in Firefox */
+"Open.Firefox" = "Firefox (Private Browsing)";
+
+/* Label in share alert to open the full system share menu */
+"Open.More" = "More";
+
+/* Label in share alert to open the URL in Safari */
+"Open.Safari" = "Safari";
+
+/* Description for dialog used for requesting a user to enable access to Photos. */
+"photosPermission.description" = "This lets you save images to your Camera Roll";
+
+/* Title for button that takes the user to system settings */
+"photosPermission.openSettings" = "Open Settings";
+
+/* Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar */
+"photosPermission.title" = "“%@” Would Like to Access Your Photos";
+
+/* Label for button that requests the desktop version of the currently loaded website. */
+"Request Desktop Site" = "Request Desktop Site";
+
+/* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
+"Safari.instructionsContentBlockers" = "Tap Safari, then select Content Blockers";
+
+/* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
+"Safari.instructionsEnable" = "Enable %@";
+
+/* Error label when the blocker is not enabled, shown in the intro and main app when disabled */
+"Safari.instructionsNotEnabled" = "%@ is not enabled.";
+
+/* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
+"Safari.instructionsOpen" = "Open Settings App";
+
+/* Save button label */
+"Save" = "Save";
+
+/* Label for error state when entering an invalid search engine URL. %s is a search term in a URL. */
+"SearchEngine.addEngineError" = "That didn't work. Try replacing the search term with this: %s.";
+
+/* Label for disable option on search suggestions prompt */
+"SearchSuggestions.promptDisable" = "No";
+
+/* Label for enable option on search suggestions prompt */
+"SearchSuggestions.promptEnable" = "Yes";
+
+/* %@ is the name of the app (Focus / Klar). Label for search suggestions prompt message */
+"SearchSuggestions.promptMessage" = "To get suggestions, %@ needs to send what you type in the address bar to the search engine.";
+
+/* Title for search suggestions prompt */
+"SearchSuggestions.promptTitle" = "Show Search Suggestions?";
+
+/* Title for the URL Autocomplete row */
+"Settings.autocompleteSection" = "URL Autocomplete";
+
+/* Alert message shown when toggling the Content blocker */
+"Settings.blockOtherMessage" = "Blocking other content trackers may break some videos and Web pages.";
+
+/* Button label for declining Content blocker alert */
+"Settings.blockOtherNo" = "No, Thanks";
+
+/* Button label for accepting Content blocker alert */
+"Settings.blockOtherYes" = "I Understand";
+
+/* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
+"Settings.detailTextSearchSuggestion" = "%@ will send what you type in the address bar to your search engine.";
+
+/* Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar) */
+"Settings.detailTextSendUsageData" = "Mozilla strives to collect only what we need to provide and improve %@ for everyone.";
+
+/* Subtitle for Send Anonymous Usage Data toggle on main screen */
+"Settings.learnMore" = "Learn more.";
+
+/* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store. */
+"Settings.rate" = "Rate %@";
+
+/* Label for Safari integration section */
+"Settings.safariTitle" = "SAFARI INTEGRATION";
+
+/* Title for settings screen */
+"Settings.screenTitle" = "Settings";
+
+/* Text for button to add another search engine in settings */
+"Settings.Search.AddSearchEngineButton" = "Add Another Search Engine";
+
+/* Text for button to add another search engine in settings with the + prefix */
+"Settings.Search.AddSearchEngineButtonWithPlus" = "+ Add Another Search Engine";
+
+/* Title on add search engine settings screen */
+"Settings.Search.AddSearchEngineTitle" = "Add Search Engine";
+
+/* Header for rows of installed search engines */
+"Settings.Search.InstalledSearchEngines" = "INSTALLED SEARCH ENGINES";
+
+/* Label for input field for the name of the search engine to be added */
+"Settings.Search.NameToDisplay" = "Name to display";
+
+/* Toast displayed after adding a search engine */
+"Settings.Search.NewSearchEngineAdded" = "New Search Engine Added.";
+
+/* Label for button to bring deleted default engines back */
+"Settings.Search.RestoreEngine" = "Restore Default Search Engines";
+
+/* Placeholder text for input of new search engine name */
+"Settings.Search.SearchEngineName" = "Search engine name";
+
+/* Label for input of search engine template */
+"Settings.Search.SearchTemplate" = "Search string to use";
+
+/* Text displayed as an example of the template to add a search engine. */
+"settings.Search.SearchTemplateExample" = "Example: searchengineexample.com/search/?q=%s";
+
+/* Placeholder text for input of new search engine template */
+"Settings.Search.SearchTemplatePlaceholder" = "Paste or enter search string. If necessary, replace search term with: %s.";
+
+/* Label for the search engine in the search screen */
+"Settings.searchLabel" = "Search Engine";
+
+/* Label for the Search Suggestions toggle row */
+"Settings.searchSuggestions" = "Get Search Suggestions";
+
+/* Title for the search selection screen */
+"Settings.searchTitle2" = "SEARCH";
+
+/* Label for Safari integration section */
+"Settings.sectionIntegration" = "INTEGRATION";
+
+/* Section label for Mozilla toggles */
+"Settings.sectionMozilla" = "MOZILLA";
+
+/* Section label for performance toggles */
+"Settings.sectionPerformance" = "PERFORMANCE";
+
+/* Section label for privacy toggles */
+"Settings.sectionPrivacy" = "PRIVACY";
+
+/* Header label for security toggles displayed in the settings menu */
+"Settings.sectionSecurity" = "SECURITY";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockAds" = "Advertising";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockAnalytics" = "Analytics";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockFonts" = "Block Web fonts";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockOther" = "Content";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockSocial" = "Social";
+
+/* Label for toggle on settings screen */
+"Settings.toggleFaceID" = "Use Face ID to unlock app";
+
+/* %@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu. */
+"Settings.toggleFaceIDDescription" = "Face ID can unlock %@ if a URL is already open in the app";
+
+/* Show home screen tips toggle label on settings screen */
+"Settings.toggleHomeScreenTips" = "Show home screen tips";
+
+/* Label subtitle for toggle on main screen */
+"Settings.toggleOtherSubtitle" = "May break some videos and Web pages";
+
+/* Safari toggle label on settings screen */
+"Settings.toggleSafari" = "Safari";
+
+/* Label for Send Usage Data toggle on main screen */
+"Settings.toggleSendUsageData" = "Send usage data";
+
+/* Label for toggle on settings screen */
+"Settings.toggleTouchID" = "Use Touch ID to unlock app";
+
+/* %@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu. */
+"Settings.toggleTouchIDDescription" = "Touch ID can unlock %@ if a URL is already open in the app";
+
+/* URL for the learn more of the send usage data toggle */
+"Settings.usageData" = "usage-data";
+
+/* Title for What's new screen */
+"Settings.whatsNewTitle" = "What’s New";
+
+/* Title for settings section to enable different Siri Shortcuts. */
+"Settinsg.siriShortcutsTitle" = "SIRI SHORTCUTS";
+
+/* Text for a share button */
+"share" = "Share";
+
+/* Text for the share menu when a user wants to copy a URL. */
+"shareMenu.copyAddress" = "Copy Address";
+
+/* Text for the share menu option when a user wants to open the find in page menu */
+"ShareMenu.FindInPage" = "Find in Page";
+
+/* Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string. */
+"ShareMenu.GetFirefox" = "Get the Firefox App";
+
+/* Text for the share menu option when a user wants to open a page in Focus. */
+"ShareMenu.OpenInFocus" = "Open in %@";
+
+/* Title for the share menu where users can take actions for the current website they are on. */
+"ShareMenu.PageActions" = "Page Actions";
+
+/* Text for the share menu option when a user wants to reload the site as a desktop */
+"ShareMenu.RequestDesktop" = "Request Desktop Site";
+
+/* Text for the share menu option when a user wants to reload the site as a mobile device */
+"ShareMenu.RequestMobile" = "Request Mobile Site";
+
+/* Text for the share menu option when a user wants to open the current website in the Chrome app. */
+"ShareMenu.ShareOpenChrome" = "Open in Chrome";
+
+/* Text for the share menu option when a user wants to open the current website in the Firefox app. */
+"ShareMenu.ShareOpenFirefox" = "Open in Firefox";
+
+/* Text for the share menu option when a user wants to open the current website in the Safari app. */
+"ShareMenu.ShareOpenSafari" = "Open in Safari";
+
+/* Text for the share menu option when a user wants to share the current website they are on through another app. */
+"ShareMenu.SharePage" = "Share Page With...";
+
+/* Button to add a favorite URL to Siri. */
+"Siri.add" = "Add";
+
+/* Button to add a specified shortcut option to Siri. */
+"Siri.addTo" = "Add to Siri";
+
+/* Label for button to edit the Siri phrase or delete the Siri functionality. */
+"Siri.editOpenUrl" = "Re-Record or Delete Shortcut";
+
+/* Title of option in settings to set up Siri to erase */
+"Siri.erase" = "Erase";
+
+/* Title of option in settings to set up Siri to erase and then open the app. */
+"Siri.eraseAndOpen" = "Erase & Open";
+
+/* Title for screen to add a favorite URL to Siri. */
+"Siri.favoriteUrl" = "Open Favorite Site";
+
+/* Title of option in settings to set up Siri to open a specified URL in Focus/Klar. */
+"Siri.openURL" = "Open Favorite Site";
+
+/* Label for input to set a favorite URL to be opened by Siri. */
+"Siri.urlToOpen" = "URL to open";
+
+/* %@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app. */
+"touchId.reason" = "Use Touch ID to return to %@";
+
+/* Label for ad trackers. */
+"trackingProtection.adTrackersLabel" = "Ad trackers";
+
+/* label for analytic trackers. */
+"trackingProtection.analyticTrackerLabel" = "Analytic trackers";
+
+/* label for content trackers. */
+"trackingProtection.contentTrackerLabel" = "Content trackers";
+
+/* text showing the tracking protection is disabled. */
+"trackingProtection.disabledLabel" = "Tracking Protection off";
+
+/* Title for the tracking settings page to change what trackers are blocked. */
+"trackingProtection.label" = "Tracking Protection";
+
+/* Description/subtitle for the tracking protection label. */
+"trackingProtection.labelDescription" = "Turning this off may fix some site problems";
+
+/* Text for the button to learn more about Tracking Protection. */
+"trackingProtection.learnMore" = "Learn More";
+
+/* label for social trackers. */
+"trackingProtection.socialTrackerLabel" = "Social trackers";
+
+/* Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar */
+"trackingProtection.toggleDescription1" = "Disable until you close %@ or tap ERASE.";
+
+/* Text for the toggle that temporarily disables tracking protection. */
+"trackingProtection.toggleLabel2" = "Enhanced Tracking Protection";
+
+/* General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar */
+"trackingProtection.trackerDescriptionLabel2" = "Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.";
+
+/* Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete. */
+"URL.addToAutocompleteLabel" = "Add link to autocomplete";
+
+/* Label for cancel button shown when entering a URL or search */
+"URL.cancelLabel" = "Cancel";
+
+/* Text for the URL context menu when a user long presses on the URL bar with clipboard contents. */
+"URL.contextMenu" = "Paste & Go";
+
+/* Erase button in the URL bar */
+"URL.eraseButtonLabel" = "ERASE";
+
+/* Message shown after pressing the Erase button */
+"URL.eraseMessageLabel" = "Browsing history cleared";
+
+/* Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page. */
+"URL.findOnPageLabel" = "Find in page: %@";
+
+/* Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents. */
+"URL.paste" = "Paste";
+
+/* Placeholder text shown in the URL bar before the user navigates to a page */
+"URL.placeholderText" = "Search or enter address";
+
+/* Label displayed for search button when typing in the URL bar */
+"URL.searchLabel" = "Search for %@";
+
+/* Text for the URL bar showing the number of trackers blocked on a webpage. */
+"URL.trackersBlockedLabel" = "Trackers blocked";
+

--- a/Blockzilla/en-GB.lproj/InfoPlist.strings
+++ b/Blockzilla/en-GB.lproj/InfoPlist.strings
@@ -1,0 +1,18 @@
+/* (No Comment) */
+"NSCameraUsageDescription" = "This lets you take and upload photos.";
+
+/* (No Comment) */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* (No Comment) */
+"NSLocationWhenInUseUsageDescription" = "Websites you visit may request your location.";
+
+/* (No Comment) */
+"NSMicrophoneUsageDescription" = "This lets you take and upload videos.";
+
+/* (No Comment) */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
+
+/* This is the menu item that appears when you long press the Focus icon on the phone home screen. */
+"UIApplicationShortcutItemTitle.EraseAndOpen" = "Erase and Open";
+

--- a/Blockzilla/en-GB.lproj/Intents.strings
+++ b/Blockzilla/en-GB.lproj/Intents.strings
@@ -1,0 +1,3 @@
+/* Title of the Erase intent. */
+"Intents.Erase.Title" = "Erase";
+

--- a/Blockzilla/en-GB.lproj/Intro.strings
+++ b/Blockzilla/en-GB.lproj/Intro.strings
@@ -1,0 +1,24 @@
+/* Description for the 'History' panel in the First Run tour. */
+"Intro.Slides.History.Description" = "Clear your entire browsing session history, passwords, cookies anytime with a single tap.";
+
+/* Title for the third  panel 'History' in the First Run tour. */
+"Intro.Slides.History.Title" = "Your history is history";
+
+/* Button to go to the next card in Focus onboarding. */
+"Intro.Slides.Next.Button" = "Next";
+
+/* Description for the 'Favorite Search Engine' panel in the First Run tour. */
+"Intro.Slides.Search.Description" = "Searching for something different? Choose a different search engine.";
+
+/* Title for the second  panel 'Search' in the First Run tour. */
+"Intro.Slides.Search.Title" = "Your search, your way";
+
+/* Button to skip onboarding in Focus */
+"Intro.Slides.Skip.Button" = "Skip";
+
+/* Description for the 'Welcome' panel in the First Run tour. */
+"Intro.Slides.Welcome.Description" = "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.";
+
+/* Title for the first panel 'Welcome' in the First Run tour. */
+"Intro.Slides.Welcome.Title" = "Power up your privacy";
+

--- a/Blockzilla/en-GB.lproj/Localizable.strings
+++ b/Blockzilla/en-GB.lproj/Localizable.strings
@@ -1,0 +1,561 @@
+/* Button on About screen */
+"About.learnMoreButton" = "Learn more";
+
+/* Label on About screen */
+"About.missionLabel" = "%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.";
+
+/* Label on About screen */
+"About.privateBullet1" = "Search and browse right in the app";
+
+/* Label on About screen */
+"About.privateBullet2" = "Block trackers (or update settings to allow trackers)";
+
+/* Label on About screen */
+"About.privateBullet3" = "Erase to delete cookies as well as search and browsing history";
+
+/* Label on About screen */
+"About.privateBulletHeader" = "Use it as a private browser:";
+
+/* Label for row in About screen */
+"About.rowHelp" = "Help";
+
+/* Link to Privacy Notice in the About screen */
+"About.rowPrivacy" = "Privacy Notice";
+
+/* Label for row in About screen */
+"About.rowRights" = "Your Rights";
+
+/* Label on About screen */
+"About.safariBullet1" = "Block trackers for improved privacy";
+
+/* Label on About screen */
+"About.safariBullet2" = "Block Web fonts to reduce page size";
+
+/* Label on About screen */
+"About.safariBulletHeader" = "Use it as a Safari extension:";
+
+/* (No Comment) */
+"About.screenTitle" = "About";
+
+/* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page. */
+"About.title" = "About %@";
+
+/* Label on About screen */
+"About.topLabel" = "%@ puts you in control.";
+
+/* Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page. */
+"actionSheet.openIn" = "Open in %@";
+
+/* %@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app. */
+"Authentication.reason" = "Authenticate to return to %@";
+
+/* Label for button to add a custom URL */
+"Autocomplete.addCustomUrl" = "Add Custom URL";
+
+/* Label for error state when entering an invalid URL */
+"Autocomplete.addCustomUrlError" = "Double-check the URL you entered.";
+
+/* A label displaying an example URL */
+"Autocomplete.addCustomUrlExample" = "Example: example.com";
+
+/* Label for the input to add a custom URL */
+"Autocomplete.addCustomUrlLabel" = "URL to add";
+
+/* Placeholder for the input field to add a custom URL */
+"Autocomplete.addCustomUrlPlaceholder" = "Paste or enter URL";
+
+/* Label for button to add a custom URL with the + prefix */
+"Autocomplete.addCustomUrlWithPlus" = "+ Add Custom URL";
+
+/* Description for adding and managing custom autocomplete URLs */
+"Autocomplete.customDescriptoin" = "Add and manage custom autocomplete URLs.";
+
+/* Label for button taking you to your custom Autocomplete URL list */
+"Autocomplete.customLabel" = "Custom URLs";
+
+/* Title for the default URL list section */
+"Autocomplete.customTitle" = "CUSTOM URL LIST";
+
+/* Label for toast alerting a custom URL has been added */
+"Autocomplete.customUrlAdded" = "New Custom URL added.";
+
+/* Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
+"Autocomplete.defaultDescriptoin" = "Enable to have %@ autocomplete over 450 popular URLs in the address bar.";
+
+/* Label for enabling or disabling autocomplete */
+"Autocomplete.defaultLabel" = "Autocomplete";
+
+/* Title for the default URL list section */
+"Autocomplete.defaultTitle" = "DEFAULT URL LIST";
+
+/* label describing URL Autocomplete as disabled */
+"Autocomplete.disabled" = "Disabled";
+
+/* Label for toast alerting that the custom URL being added is a duplicate */
+"Autocomplete.duplicateUrl" = "URL already exists";
+
+/* Label for button to add a custom URL */
+"Autocomplete.emptyState" = "No Custom URLs to display";
+
+/* label describing URL Autocomplete as enabled */
+"Autocomplete.enabled" = "Enabled";
+
+/* Label for button taking you to your custom Autocomplete URL list */
+"Autocomplete.manageSites" = "Manage Sites";
+
+/* Label for enabling or disabling autocomplete */
+"Autocomplete.mySites" = "My Sites";
+
+/* Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
+"Autocomplete.mySitesDesc" = "Enable to have %@ autocomplete your favorite URLs.";
+
+/* Label for enabling or disabling top sites */
+"Autocomplete.topSites" = "Top Sites";
+
+/* Create a new session after failing a biometric check */
+"BiometricPrompt.newSession" = "New Session";
+
+/* %@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app. */
+"BiometricPrompt.reason" = "Unlock %@ when re-opening in order to prevent unauthorized access.";
+
+/* Accessibility label for the back button */
+"Browser.backLabel" = "Back";
+
+/* Copy URL button in URL long press menu */
+"Browser.copyAddressLabel" = "Copy Address";
+
+/* Toast displayed after a URL has been copied to the clipboard */
+"browser.copyAddressToast" = "URL Copied To Clipboard";
+
+/* Copy URL button in URL long press menu */
+"Browser.copyMenuLabel" = "Copy";
+
+/* Custom URL button in URL long press menu */
+"Browser.customURLMenuLabel" = "Add Custom URL";
+
+/* Accessibility label for the forward button */
+"Browser.forwardLabel" = "Forward";
+
+/* Accessibility label for the reload button */
+"Browser.reloadLabel" = "Reload";
+
+/* Accessibility label for the settings button */
+"Browser.settingsLabel" = "Settings";
+
+/* Accessibility label for the share button */
+"Browser.shareLabel" = "Share";
+
+/* Accessibility label for the stop button */
+"Browser.stopLabel" = "Stop";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"browserShortcutDescription.selectLocationBar" = "Select Location Bar";
+
+/* Label on button to cancel edits */
+"Cancel" = "Cancel";
+
+/* Text for the context menu when a user has a link on their clipboard. */
+"contextMenu.clipboardLink" = "Link you copied: %@";
+
+/* Text for the context menu when a user wants to copy an image after long pressing it. */
+"contextMenu.copyImageTitle" = "Copy Image";
+
+/* Text for the context menu when a user wants to copy a link after long pressing it. */
+"contextMenu.copyLink" = "Copy Link";
+
+/* Text for the context menu when a user has a link on their clipboard. */
+"contextMenu.linkCopied" = "Link you copied: ";
+
+/* Text for the context menu when a user wants to save an image after long pressing it. */
+"contextMenu.saveImageTitle" = "Save Image";
+
+/* Text for the context menu when a user wants to share a link after long pressing it. */
+"contextMenu.shareLinkTitle" = "Share Link";
+
+/* Label on button to complete edits */
+"Done" = "Done";
+
+/* Label on button to allow edits */
+"Edit" = "Edit";
+
+/* Button label to reload the error page */
+"Error.tryAgainButton" = "Try again";
+
+/* Button label used for cancelling to open another app from Focus */
+"ExternalAppLink.cancelTitle" = "Cancel";
+
+/* Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar. */
+"ExternalAppLink.messageTitle" = "%@ wants to open another App";
+
+/* Button label for opening another app from Focus */
+"ExternalAppLink.openTitle" = "Open";
+
+/* Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open. */
+"externalAppLinkWithAppName.messageTitle" = "%1$@ wants to open %2$@";
+
+/* Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.callButton" = "Call";
+
+/* Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.cancelButton" = "Cancel";
+
+/* Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.emailButton" = "Email";
+
+/* Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.messageTitleWithPlaceholder" = "You are now leaving %@.";
+
+/* Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.openAppStoreButton" = "Open App Store";
+
+/* Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
+"ExternalLink.openAppStoreTitle" = "%@ wants to open the App Store.";
+
+/* Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
+"ExternalLink.openMapsButton" = "Open Maps";
+
+/* Accessibility label for done button in Find in Page Toolbar. */
+"FindInPage.Done" = "Find in page done";
+
+/* Accessibility label for next result button in Find in Page Toolbar. */
+"FindInPage.NextResult" = "Find next in page";
+
+/* Accessibility label for previous result button in Find in Page Toolbar. */
+"FindInPage.PreviousResult" = "Find previous in page";
+
+/* Label on button to dismiss first run UI */
+"FirstRun.lastSlide.buttonLabel" = "OK, Got It!";
+
+/* Message label on the first run screen */
+"FirstRun.messageLabelDescription" = "Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.";
+
+/* Message label on the first run screen */
+"FirstRun.messageLabelTagline" = "Browse like no one’s watching.";
+
+/* Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681 */
+"Focus.handoffSyncing" = "Apple Handoff is syncing";
+
+/* First label for product description on the home screen */
+"Home.descriptionLabel1" = "Automatic private browsing.";
+
+/* Second label for product description on the home screen */
+"Home.descriptionLabel2" = "Browse. Erase. Repeat.";
+
+/* Button label used to close a menu that displays as a popup. */
+"Menu.Close" = "Close";
+
+/* Label in share alert to cancel the alert */
+"Open.Cancel" = "Cancel";
+
+/* Label in share alert to open the URL in Firefox */
+"Open.Firefox" = "Firefox (Private Browsing)";
+
+/* Label in share alert to open the full system share menu */
+"Open.More" = "More";
+
+/* Label in share alert to open the URL in Safari */
+"Open.Safari" = "Safari";
+
+/* Description for dialog used for requesting a user to enable access to Photos. */
+"photosPermission.description" = "This lets you save images to your Camera Roll";
+
+/* Title for button that takes the user to system settings */
+"photosPermission.openSettings" = "Open Settings";
+
+/* Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar */
+"photosPermission.title" = "“%@” Would Like to Access Your Photos";
+
+/* Label for button that requests the desktop version of the currently loaded website. */
+"Request Desktop Site" = "Request Desktop Site";
+
+/* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
+"Safari.instructionsContentBlockers" = "Tap Safari, then select Content Blockers";
+
+/* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
+"Safari.instructionsEnable" = "Enable %@";
+
+/* Error label when the blocker is not enabled, shown in the intro and main app when disabled */
+"Safari.instructionsNotEnabled" = "%@ is not enabled.";
+
+/* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
+"Safari.instructionsOpen" = "Open Settings App";
+
+/* Save button label */
+"Save" = "Save";
+
+/* Label for error state when entering an invalid search engine URL. %s is a search term in a URL. */
+"SearchEngine.addEngineError" = "That didn't work. Try replacing the search term with this: %s.";
+
+/* Label for disable option on search suggestions prompt */
+"SearchSuggestions.promptDisable" = "No";
+
+/* Label for enable option on search suggestions prompt */
+"SearchSuggestions.promptEnable" = "Yes";
+
+/* %@ is the name of the app (Focus / Klar). Label for search suggestions prompt message */
+"SearchSuggestions.promptMessage" = "To get suggestions, %@ needs to send what you type in the address bar to the search engine.";
+
+/* Title for search suggestions prompt */
+"SearchSuggestions.promptTitle" = "Show Search Suggestions?";
+
+/* Title for the URL Autocomplete row */
+"Settings.autocompleteSection" = "URL Autocomplete";
+
+/* Alert message shown when toggling the Content blocker */
+"Settings.blockOtherMessage" = "Blocking other content trackers may break some videos and Web pages.";
+
+/* Button label for declining Content blocker alert */
+"Settings.blockOtherNo" = "No, Thanks";
+
+/* Button label for accepting Content blocker alert */
+"Settings.blockOtherYes" = "I Understand";
+
+/* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
+"Settings.detailTextSearchSuggestion" = "%@ will send what you type in the address bar to your search engine.";
+
+/* Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar) */
+"Settings.detailTextSendUsageData" = "Mozilla strives to collect only what we need to provide and improve %@ for everyone.";
+
+/* Subtitle for Send Anonymous Usage Data toggle on main screen */
+"Settings.learnMore" = "Learn more.";
+
+/* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store. */
+"Settings.rate" = "Rate %@";
+
+/* Label for Safari integration section */
+"Settings.safariTitle" = "SAFARI INTEGRATION";
+
+/* Title for settings screen */
+"Settings.screenTitle" = "Settings";
+
+/* Text for button to add another search engine in settings */
+"Settings.Search.AddSearchEngineButton" = "Add Another Search Engine";
+
+/* Text for button to add another search engine in settings with the + prefix */
+"Settings.Search.AddSearchEngineButtonWithPlus" = "+ Add Another Search Engine";
+
+/* Title on add search engine settings screen */
+"Settings.Search.AddSearchEngineTitle" = "Add Search Engine";
+
+/* Header for rows of installed search engines */
+"Settings.Search.InstalledSearchEngines" = "INSTALLED SEARCH ENGINES";
+
+/* Label for input field for the name of the search engine to be added */
+"Settings.Search.NameToDisplay" = "Name to display";
+
+/* Toast displayed after adding a search engine */
+"Settings.Search.NewSearchEngineAdded" = "New Search Engine Added.";
+
+/* Label for button to bring deleted default engines back */
+"Settings.Search.RestoreEngine" = "Restore Default Search Engines";
+
+/* Placeholder text for input of new search engine name */
+"Settings.Search.SearchEngineName" = "Search engine name";
+
+/* Label for input of search engine template */
+"Settings.Search.SearchTemplate" = "Search string to use";
+
+/* Text displayed as an example of the template to add a search engine. */
+"settings.Search.SearchTemplateExample" = "Example: searchengineexample.com/search/?q=%s";
+
+/* Placeholder text for input of new search engine template */
+"Settings.Search.SearchTemplatePlaceholder" = "Paste or enter search string. If necessary, replace search term with: %s.";
+
+/* Label for the search engine in the search screen */
+"Settings.searchLabel" = "Search Engine";
+
+/* Label for the Search Suggestions toggle row */
+"Settings.searchSuggestions" = "Get Search Suggestions";
+
+/* Title for the search selection screen */
+"Settings.searchTitle2" = "SEARCH";
+
+/* Label for Safari integration section */
+"Settings.sectionIntegration" = "INTEGRATION";
+
+/* Section label for Mozilla toggles */
+"Settings.sectionMozilla" = "MOZILLA";
+
+/* Section label for performance toggles */
+"Settings.sectionPerformance" = "PERFORMANCE";
+
+/* Section label for privacy toggles */
+"Settings.sectionPrivacy" = "PRIVACY";
+
+/* Header label for security toggles displayed in the settings menu */
+"Settings.sectionSecurity" = "SECURITY";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockAds" = "Advertising";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockAnalytics" = "Analytics";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockFonts" = "Block Web fonts";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockOther" = "Content";
+
+/* Label for toggle on main screen */
+"Settings.toggleBlockSocial" = "Social";
+
+/* Label for toggle on settings screen */
+"Settings.toggleFaceID" = "Use Face ID to unlock app";
+
+/* %@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu. */
+"Settings.toggleFaceIDDescription" = "Face ID can unlock %@ if a URL is already open in the app";
+
+/* Show home screen tips toggle label on settings screen */
+"Settings.toggleHomeScreenTips" = "Show home screen tips";
+
+/* Label subtitle for toggle on main screen */
+"Settings.toggleOtherSubtitle" = "May break some videos and Web pages";
+
+/* Safari toggle label on settings screen */
+"Settings.toggleSafari" = "Safari";
+
+/* Label for Send Usage Data toggle on main screen */
+"Settings.toggleSendUsageData" = "Send usage data";
+
+/* Label for toggle on settings screen */
+"Settings.toggleTouchID" = "Use Touch ID to unlock app";
+
+/* %@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu. */
+"Settings.toggleTouchIDDescription" = "Touch ID can unlock %@ if a URL is already open in the app";
+
+/* URL for the learn more of the send usage data toggle */
+"Settings.usageData" = "usage-data";
+
+/* Title for What's new screen */
+"Settings.whatsNewTitle" = "What’s New";
+
+/* Title for settings section to enable different Siri Shortcuts. */
+"Settinsg.siriShortcutsTitle" = "SIRI SHORTCUTS";
+
+/* Text for a share button */
+"share" = "Share";
+
+/* Text for the share menu when a user wants to copy a URL. */
+"shareMenu.copyAddress" = "Copy Address";
+
+/* Text for the share menu option when a user wants to open the find in page menu */
+"ShareMenu.FindInPage" = "Find in Page";
+
+/* Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string. */
+"ShareMenu.GetFirefox" = "Get the Firefox App";
+
+/* Text for the share menu option when a user wants to open a page in Focus. */
+"ShareMenu.OpenInFocus" = "Open in %@";
+
+/* Title for the share menu where users can take actions for the current website they are on. */
+"ShareMenu.PageActions" = "Page Actions";
+
+/* Text for the share menu option when a user wants to reload the site as a desktop */
+"ShareMenu.RequestDesktop" = "Request Desktop Site";
+
+/* Text for the share menu option when a user wants to reload the site as a mobile device */
+"ShareMenu.RequestMobile" = "Request Mobile Site";
+
+/* Text for the share menu option when a user wants to open the current website in the Chrome app. */
+"ShareMenu.ShareOpenChrome" = "Open in Chrome";
+
+/* Text for the share menu option when a user wants to open the current website in the Firefox app. */
+"ShareMenu.ShareOpenFirefox" = "Open in Firefox";
+
+/* Text for the share menu option when a user wants to open the current website in the Safari app. */
+"ShareMenu.ShareOpenSafari" = "Open in Safari";
+
+/* Text for the share menu option when a user wants to share the current website they are on through another app. */
+"ShareMenu.SharePage" = "Share Page With...";
+
+/* Button to add a favorite URL to Siri. */
+"Siri.add" = "Add";
+
+/* Button to add a specified shortcut option to Siri. */
+"Siri.addTo" = "Add to Siri";
+
+/* Label for button to edit the Siri phrase or delete the Siri functionality. */
+"Siri.editOpenUrl" = "Re-Record or Delete Shortcut";
+
+/* Title of option in settings to set up Siri to erase */
+"Siri.erase" = "Erase";
+
+/* Title of option in settings to set up Siri to erase and then open the app. */
+"Siri.eraseAndOpen" = "Erase & Open";
+
+/* Title for screen to add a favorite URL to Siri. */
+"Siri.favoriteUrl" = "Open Favorite Site";
+
+/* Title of option in settings to set up Siri to open a specified URL in Focus/Klar. */
+"Siri.openURL" = "Open Favorite Site";
+
+/* Label for input to set a favorite URL to be opened by Siri. */
+"Siri.urlToOpen" = "URL to open";
+
+/* %@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app. */
+"touchId.reason" = "Use Touch ID to return to %@";
+
+/* Label for ad trackers. */
+"trackingProtection.adTrackersLabel" = "Ad trackers";
+
+/* label for analytic trackers. */
+"trackingProtection.analyticTrackerLabel" = "Analytic trackers";
+
+/* label for content trackers. */
+"trackingProtection.contentTrackerLabel" = "Content trackers";
+
+/* text showing the tracking protection is disabled. */
+"trackingProtection.disabledLabel" = "Tracking Protection off";
+
+/* Title for the tracking settings page to change what trackers are blocked. */
+"trackingProtection.label" = "Tracking Protection";
+
+/* Description/subtitle for the tracking protection label. */
+"trackingProtection.labelDescription" = "Turning this off may fix some site problems";
+
+/* Text for the button to learn more about Tracking Protection. */
+"trackingProtection.learnMore" = "Learn More";
+
+/* label for social trackers. */
+"trackingProtection.socialTrackerLabel" = "Social trackers";
+
+/* Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar */
+"trackingProtection.toggleDescription1" = "Disable until you close %@ or tap ERASE.";
+
+/* Text for the toggle that temporarily disables tracking protection. */
+"trackingProtection.toggleLabel2" = "Enhanced Tracking Protection";
+
+/* General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar */
+"trackingProtection.trackerDescriptionLabel2" = "Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.";
+
+/* Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete. */
+"URL.addToAutocompleteLabel" = "Add link to autocomplete";
+
+/* Label for cancel button shown when entering a URL or search */
+"URL.cancelLabel" = "Cancel";
+
+/* Text for the URL context menu when a user long presses on the URL bar with clipboard contents. */
+"URL.contextMenu" = "Paste & Go";
+
+/* Erase button in the URL bar */
+"URL.eraseButtonLabel" = "ERASE";
+
+/* Message shown after pressing the Erase button */
+"URL.eraseMessageLabel" = "Browsing history cleared";
+
+/* Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page. */
+"URL.findOnPageLabel" = "Find in page: %@";
+
+/* Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents. */
+"URL.paste" = "Paste";
+
+/* Placeholder text shown in the URL bar before the user navigates to a page */
+"URL.placeholderText" = "Search or enter address";
+
+/* Label displayed for search button when typing in the URL bar */
+"URL.searchLabel" = "Search for %@";
+
+/* Text for the URL bar showing the number of trackers blocked on a webpage. */
+"URL.trackersBlockedLabel" = "Trackers blocked";
+

--- a/ContentBlocker/co.lproj/InfoPlist.strings
+++ b/ContentBlocker/co.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* No Strings */
+

--- a/ContentBlocker/en-GB.lproj/InfoPlist.strings
+++ b/ContentBlocker/en-GB.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* No Strings */
+

--- a/ScreenshotTests/co.lproj/InfoPlist.strings
+++ b/ScreenshotTests/co.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/* (No Commment) */
+"CFBundleName" = "$(PRODUCT_NAME)";
+
+/* (No Commment) */
+"CFBundleShortVersionString" = "1.0";
+

--- a/ScreenshotTests/en-GB.lproj/InfoPlist.strings
+++ b/ScreenshotTests/en-GB.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/* (No Commment) */
+"CFBundleName" = "$(PRODUCT_NAME)";
+
+/* (No Commment) */
+"CFBundleShortVersionString" = "1.0";
+

--- a/XCUITest/co.lproj/InfoPlist.strings
+++ b/XCUITest/co.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/* (No Commment) */
+"CFBundleName" = "$(PRODUCT_NAME)";
+
+/* (No Commment) */
+"CFBundleShortVersionString" = "1.0";
+

--- a/XCUITest/en-GB.lproj/InfoPlist.strings
+++ b/XCUITest/en-GB.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/* (No Commment) */
+"CFBundleName" = "$(PRODUCT_NAME)";
+
+/* (No Commment) */
+"CFBundleShortVersionString" = "1.0";
+


### PR DESCRIPTION
This patch adds Corsican and English (Great Britain) to the app. In a followup we will import the strings for these new locales, this patch just updates the project file and adds the base strings files.

@isabelrios we should probably land this before we do another round of screenshots