### PR TITLE
Fixes #2255 - Determine the list of locales for screenshots at runtime

### DIFF
--- a/screenshots.sh
+++ b/screenshots.sh
@@ -8,9 +8,6 @@ function get_abs_path {
     echo "$( cd "$(dirname "$file_path")" >/dev/null 2>&1 ; pwd -P )"
 }
 
-CURRENT_DIR="$(get_abs_path $0)"
-PROJECT_DIR="$(get_abs_path $CURRENT_DIR/../../../..)"
-
 mkdir -p screenshots
 
 if [ "$1" = '--test-without-building' ]; then
@@ -18,12 +15,20 @@ if [ "$1" = '--test-without-building' ]; then
     shift
 fi
 
-# Note that fil is tl in the l10n repo
-LANGUAGES="af,an,ar,ast,az,bn,br,bs,ca,cs,cy,da,de,dsb,el,en,eo,es-AR,es-CL,es-ES,es-MX,eu,fa,fi,fil,fr,ga,gd,he,hi-IN,hsb,hu,hy-AM,ia,id,is,it,ja,ka,kab,kk,kn,ko,lo,ms,my,nb,ne-NP,nl,nn,pl,pt-BR,pt-PT,ro,ru,ses,sk,sl,sq,sv,ta,te,th,tr,uk,ur,uz,vi,zh-CN,zh-TW"
-
 if [ $# -eq 1 ]; then
   LANGUAGES=$1
+else
+  for PATH in Blockzilla/*.lproj; do
+    FILE="${PATH##*/}"
+    if [ -n "$LANGUAGES" ]; then
+      LANGUAGES="$LANGUAGES "
+    fi
+    LANGUAGES="$LANGUAGES${FILE%.lproj}"
+  done
 fi
+
+echo "$LANGUAGES"
+exit 0
 
 DEVICE="iPhone 11"
 


### PR DESCRIPTION
This patch removes the hard-coded list of locales from `screenshots.sh` and instead looks at the available `Blockzilla/.lproj` bundles to build a list of available languages. We assume that if the language is in the project, we want to screenshot it.