### PR TITLE
Fixes #2253 - Include new locales: co an en-GB

### DIFF
--- a/shipping_locales.txt
+++ b/shipping_locales.txt
@@ -8,12 +8,14 @@ bn
 br
 bs
 ca
+co
 cs
 cy
 da
 de
 dsb
 el
+en-GB
 en-US
 eo
 es-AR


### PR DESCRIPTION
This patch is a followup for #2254 and also adds `co` and `en-GB` to `shipping_locales.txt`.
