### PR TITLE
Fixes #2263 - AllowsLinkPreview does not work

### DIFF
--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -145,7 +145,7 @@ class WebViewController: UIViewController, WebController {
         browserView = WKWebView(frame: .zero, configuration: wvConfig)
 
         browserView.allowsBackForwardNavigationGestures = true
-        browserView.allowsLinkPreview = false
+        browserView.allowsLinkPreview = true
         browserView.scrollView.clipsToBounds = false
         browserView.scrollView.delegate = self
         browserView.navigationDelegate = self


### PR DESCRIPTION
This patch sets `allowsLinkPreview`. We fixed this previously with #1701  but it seems that code is not actually working or used?