### PR TITLE
Fixes #2285 - Update deletion-request ping

### DIFF
--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -2,20 +2,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 legacy.ids:
-   client_id:
-      type: uuid
-      lifetime: user
-      description: |
-        The client id from legacy telemetry.
-      send_in_pings:
-         - deletion-request
-      bugs:
-         - https://github.com/mozilla-mobile/firefox-ios/issues/7019
-      data_reviews:
-         - https://github.com/mozilla-mobile/focus-ios/pull/1741#issuecomment-705853690
-      notification_emails:
-         - firefox-ios@mozilla.com
-      expires: never
+  client_id:
+    type: uuid
+    lifetime: user
+    description: |
+      The client id from legacy telemetry.
+    send_in_pings:
+      - deletion-request
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/1740
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-ios/pull/1741#issuecomment-705853690
+    notification_emails:
+      - firefox-focus@mozilla.com
+      - sarentz@mozilla.com
+    expires: never


### PR DESCRIPTION
This patch updates the email addresses and issue links in the deletion ping.

@travis79 You mentioned these inconsistencies in a review for another metric. Does this need a new data review? Or can we just land this?