### PR TITLE
Fixes  #2229 -  Incorrect shortcuts bar layout when using splitscreen in portrait view

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -759,6 +759,10 @@ class BrowserViewController: UIViewController {
         
         urlBar.updateConstraints()
         browserToolbar.updateConstraints()
+        
+        shortcutsContainer.spacing = size.width < UIConstants.layout.smallestSplitViewMaxWidthLimit ?
+                                        UIConstants.layout.shortcutsContainerSpacingSmallestSplitView :
+                                        (isIPadRegularDimensions ? UIConstants.layout.shortcutsContainerSpacingIPad : UIConstants.layout.shortcutsContainerSpacing)
 
         coordinator.animate(alongsideTransition: { _ in
             self.urlBar.shouldShowToolset = self.showsToolsetInURLBar

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -298,9 +298,11 @@ struct UIConstants {
         static let shortcutsContainerOffsetIPad: CGFloat = 36
         static let shortcutsContainerSpacing: CGFloat = 28
         static let shortcutsContainerSpacingIPad: CGFloat = 40
+        static let shortcutsContainerSpacingSmallestSplitView: CGFloat = 20
         static let shortcutsBackgroundHeight: CGFloat = 140
         static let shortcutsBackgroundHeightIPad: CGFloat = 176
         static let shortcutsBackgroundWidthIPad: CGFloat = 676
+        static let smallestSplitViewMaxWidthLimit: CGFloat = UIScreen.main.bounds.width * 0.45
     }
 
     struct strings {


### PR DESCRIPTION
Fixes the shortcuts bar layout for the smallest view when the iPad is in split screen mode.

![Simulator Screen Shot - iPad mini 4 - 2021-09-08 at 12 57 55](https://user-images.githubusercontent.com/46751540/132488951-06ece7d4-a766-4f82-85cd-e22f8a9a03fd.png)
