### PR TITLE
Fixes #2223 - Incorrect icon will be displayed for the search suggestion after manually typing the full URL

### DIFF
--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -294,14 +294,9 @@ class OverlayView: UIView {
         button.setAttributedTitle(attributedString, for: .normal)
     }
 
-    private func setURLicon(phrase: String, button: InsetButton) {
-        if phrase.isUrl {
-            button.setImage(#imageLiteral(resourceName: "icon_link"), for: .normal)
-            button.setImage(#imageLiteral(resourceName: "icon_link"), for: .highlighted)
-        } else {
+    private func setURLicon(button: InsetButton) {
             button.setImage(#imageLiteral(resourceName: "icon_searchfor"), for: .normal)
             button.setImage(#imageLiteral(resourceName: "icon_searchfor"), for: .highlighted)
-        }
     }
 
     func setSearchQuery(suggestions: [String], hideFindInPage: Bool, hideAddToComplete: Bool) {
@@ -344,7 +339,7 @@ class OverlayView: UIView {
                     button: self.searchButtonGroup[index],
                     localizedStringFormat: Settings.getToggle(.enableSearchSuggestions) ? "" : UIConstants.strings.searchButton
                 )
-                self.setURLicon(phrase: self.searchSuggestions[index], button: self.searchButtonGroup[index])
+                self.setURLicon(button: self.searchButtonGroup[index])
             }
         }
     }


### PR DESCRIPTION
This PR solves issue #2223. Now the correct icon will be displayed, as in the following screenshot:

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-09 at 11 57 49](https://user-images.githubusercontent.com/46751540/132656539-183f9db2-c93d-4592-bfd8-c37fba4313d9.png)
