### PR TITLE
Fixes #2313 - String import skips es-ES, lt, lv

### DIFF
--- a/tools/Localizations/Sources/Localizations/ExportTask.swift
+++ b/tools/Localizations/Sources/Localizations/ExportTask.swift
@@ -50,8 +50,6 @@ struct ExportTask {
         "nn" : "nn-NO",
         "sv" : "sv-SE",
         "fil" : "tl",
-        "tzm" : "zgh",
-        "sat-Olck" : "sat",
     ]
     
     private var EXPORT_BASE_PATH: String {

--- a/tools/Localizations/Sources/Localizations/ImportTask.swift
+++ b/tools/Localizations/Sources/Localizations/ImportTask.swift
@@ -33,14 +33,11 @@ struct ImportTask {
 
     // Pontoon has slightly different keys than Xcode for a handful of locales.
     private let LOCALE_MAPPING = [
-        "es-ES": "es",
         "ga-IE": "ga",
         "nb-NO": "nb",
         "nn-NO": "nn",
         "sv-SE": "sv",
         "tl"   : "fil",
-        "zgh"  : "tzm",
-        "sat"  : "sat-Olck"
     ]
 
     // We don't want to expose these to our localization team
@@ -53,7 +50,6 @@ struct ImportTask {
     // Locales that we do not want to import
     private let EXCLUDED_LOCALES: Set<String> = [
         "en-US", // This is our base language and the source of truth is in the app, not Pontoon
-        "es-ES", "lt", "lv" // These are only excluded because they are new and we don't know yet what to do with them
     ]
 
     // InfoPlist.strings requre these keys to have content or the application will crash


### PR DESCRIPTION
This patch fixes the string import tool and removes `es-ES`, `lt` and `lv` from `EXCLUDED_LOCALES`. These were previously in there because they were not supposed to ship yet.

Since we would like to import all available locales, `EXCLUDED_LOCALES` should really only contain `en-US` since the source of truth for that locale is in the application itself.

Cc @Delphine 