### PR TITLE
Fixes #2300 - On the New Tab Page, if the clear 'x' symbol is selected, shortcut tile appears with a solid colour background

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -949,7 +949,7 @@ extension BrowserViewController: URLBarDelegate {
         let isOnHomeView = homeView != nil
         let shouldShowShortcuts = trimmedText.isEmpty && shortcutManager.numberOfShortcuts != 0
         shortcutsContainer.isHidden = !shouldShowShortcuts
-        shortcutsBackground.isHidden = !shouldShowShortcuts
+        shortcutsBackground.isHidden = isOnHomeView ? true : !shouldShowShortcuts
         
         if Settings.getToggle(.enableSearchSuggestions) && !trimmedText.isEmpty {
             searchSuggestionsDebouncer.renewInterval()


### PR DESCRIPTION
The background for shortcuts view is now hidden on home page also after the clear button is tapped.