### PR TITLE
Fixes #2221 Refresh button not displayed after hiding and revealing the URL bar

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -770,7 +770,6 @@ class URLBar: UIView {
         collapsedUrlAndLockWrapper.alpha = collapseAlpha
         toolset.backButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.forwardButton.alpha = shouldShowToolset ? expandAlpha : 0
-        toolset.stopReloadButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.deleteButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.contextMenuButton.alpha = shouldShowToolset ? expandAlpha : 0
 


### PR DESCRIPTION
<img width="400" alt="Screenshot 2021-09-02 at 16 19 40" src="https://user-images.githubusercontent.com/26011662/132850543-f1e3a3ac-92c9-4f1d-908a-b38c4b83ccd5.PNG">

## Commit message
Fixes #2221 Refresh button not displayed after hiding and revealing the URL bar