### PR TITLE
Fixes #2340 - Include the build number in the About screen

### DIFF
--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -197,7 +197,7 @@ private class AboutHeaderView: UIView {
 
     private lazy var versionNumber: UILabel = {
         let label = SmartLabel()
-        label.text = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        label.text = "\(AppInfo.shortVersion) (\(AppInfo.buildNumber)) / \(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
         label.font = UIConstants.fonts.aboutText
         label.textColor = UIConstants.colors.defaultFont.withAlphaComponent(0.5)
         return label


### PR DESCRIPTION
This patch includes the app version and the iOS version in the About screen. This will make it easier to ask people "what version of Focus are you running".

<img width="449" alt="Screen Shot 2021-09-13 at 6 00 08 PM" src="https://user-images.githubusercontent.com/28052/133162175-1b70ab63-a19a-43d7-a195-e17f1257f97b.png">
