### PR TITLE
Fixes #2347 Find in page option not shown when typing on the url bar once a site is loaded

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -938,7 +938,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBar(_ urlBar: URLBar, didEnterText text: String) {
         let trimmedText = text.trimmingCharacters(in: .whitespaces)
-        let isOnHomeView = homeViewController != nil
+        let isOnHomeView = !urlBar.inBrowsingMode
         let shouldShowShortcuts = trimmedText.isEmpty && shortcutManager.numberOfShortcuts != 0
         shortcutsContainer.isHidden = !shouldShowShortcuts
         shortcutsBackground.isHidden = isOnHomeView ? true : !shouldShowShortcuts


### PR DESCRIPTION
Fixes #2347 
|   |  |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/26011662/133243778-5e084716-f204-4feb-8c56-7dcf430a849d.png)  | ![image](https://user-images.githubusercontent.com/26011662/133243813-376e767b-be7e-4689-8492-8332ba4cce35.png) |
