### PR TITLE
Fixes #2224 - Shortcuts overlap the Focus logo on some device

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1039,6 +1039,7 @@ extension BrowserViewController: URLBarDelegate {
         let shouldShowShortcuts = shortcutManager.numberOfShortcuts != 0
         shortcutsContainer.isHidden = !shouldShowShortcuts
         shortcutsBackground.isHidden = !shouldShowShortcuts || !urlBar.inBrowsingMode
+        homeViewController.updateUI(urlBarIsActive: true)
         UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration, animations: {
             self.urlBarContainer.alpha = 1
             self.updateFindInPageVisibility(visible: false)
@@ -1049,7 +1050,7 @@ extension BrowserViewController: URLBarDelegate {
     func urlBarDidDeactivate(_ urlBar: URLBar) {
         shortcutsContainer.isHidden = false
         shortcutsBackground.isHidden = true
-        
+        homeViewController.updateUI(urlBarIsActive: false)
         UIView.animate(withDuration: UIConstants.layout.urlBarTransitionAnimationDuration) {
             self.urlBarContainer.alpha = 0
             self.view.layoutIfNeeded()

--- a/Blockzilla/HomeViewController.swift
+++ b/Blockzilla/HomeViewController.swift
@@ -57,7 +57,7 @@ class HomeViewController: UIViewController {
         }
 
         tipView.snp.makeConstraints { make in
-            make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.tipViewBottomOffset)
+            make.bottom.equalTo(toolbar.snp.top).offset(-UIConstants.layout.tipViewBottomOffset)
             make.leading.trailing.equalToSuperview()
             make.centerX.equalToSuperview()
             make.height.equalTo(UIConstants.layout.tipViewHeight)
@@ -139,7 +139,7 @@ class HomeViewController: UIViewController {
             if urlBarIsActive {
                 make.bottom.equalToSuperview()
             } else {
-                make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.tipViewBottomOffset)
+                make.bottom.equalTo(toolbar.snp.top).offset(-UIConstants.layout.tipViewBottomOffset)
             }
         }
         

--- a/Blockzilla/HomeViewController.swift
+++ b/Blockzilla/HomeViewController.swift
@@ -57,10 +57,10 @@ class HomeViewController: UIViewController {
         }
 
         tipView.snp.makeConstraints { make in
-            make.bottom.equalTo(toolbar.snp.top).offset(-6)
+            make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.tipViewBottomOffset)
             make.leading.trailing.equalToSuperview()
             make.centerX.equalToSuperview()
-            make.height.equalTo(75)
+            make.height.equalTo(UIConstants.layout.tipViewHeight)
         }
 
         toolbar.snp.makeConstraints { make in
@@ -126,6 +126,30 @@ class HomeViewController: UIViewController {
             break
         }
     }
+    
+    func updateUI(urlBarIsActive: Bool) {
+        tipsViewController.showPageController(urlBarIsActive)
+        toolbar.isHidden = urlBarIsActive
+        
+        tipView.snp.remakeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.height.equalTo(UIConstants.layout.tipViewHeight)
+            
+            if urlBarIsActive {
+                make.bottom.equalToSuperview()
+            } else {
+                make.bottom.equalTo(toolbar.snp.top).offset(UIConstants.layout.tipViewBottomOffset)
+            }
+        }
+        
+        if UIScreen.main.bounds.height ==  UIConstants.layout.iPhoneSEHeight {
+            textLogo.snp.updateConstraints{ make in
+                make.top.equalTo(self.view.snp.centerY).offset(urlBarIsActive ?  UIConstants.layout.textLogoOffsetSmallDevice : UIConstants.layout.textLogoOffset)
+            }
+        }
+    }
+
 
     private func didTap(tip: TipManager.Tip) {
         delegate?.didTapTip(tip)

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -222,7 +222,7 @@ struct UIConstants {
         static let textLogoMargin: CGFloat = 44
         static let tipDescriptionMargin: CGFloat = 12
         static let tipViewHeight: CGFloat = 75
-        static let tipViewBottomOffset: CGFloat = -6
+        static let tipViewBottomOffset: CGFloat = 6
         static let urlBarButtonImageSize: CGFloat = 20
         static let urlBarButtonTargetSize: CGFloat = 40
         static let settingsTextPadding: CGFloat = 10

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -218,7 +218,11 @@ struct UIConstants {
         static let urlBarToolsetOffset: CGFloat = 60
         static let urlBarIPadToolsetOffset: CGFloat = 110
         static let textLogoOffset: CGFloat = -10 - browserToolbarHeight / 2
+        static let textLogoOffsetSmallDevice: CGFloat = 10 - browserToolbarHeight / 4
         static let textLogoMargin: CGFloat = 44
+        static let tipDescriptionMargin: CGFloat = 12
+        static let tipViewHeight: CGFloat = 75
+        static let tipViewBottomOffset: CGFloat = -6
         static let urlBarButtonImageSize: CGFloat = 20
         static let urlBarButtonTargetSize: CGFloat = 40
         static let settingsTextPadding: CGFloat = 10
@@ -302,6 +306,7 @@ struct UIConstants {
         static let shortcutsBackgroundHeightIPad: CGFloat = 176
         static let shortcutsBackgroundWidthIPad: CGFloat = 676
         static let smallestSplitViewMaxWidthLimit: CGFloat = UIScreen.main.bounds.width * 0.45
+        static let iPhoneSEHeight: CGFloat = 568
     }
 
     struct strings {

--- a/TipViewController.swift
+++ b/TipViewController.swift
@@ -15,6 +15,7 @@ class TipViewController: UIViewController {
         let label = SmartLabel()
         label.textColor = .accent
         label.font = UIConstants.fonts.shareTrackerStatsLabel
+        label.textAlignment = .center
         label.numberOfLines = 0
         label.minimumScaleFactor = UIConstants.layout.homeViewLabelMinimumScale
         return label
@@ -45,7 +46,6 @@ class TipViewController: UIViewController {
 
         tipTitleLabel.text = tip.title
         tipDescriptionLabel.text = tip.description
-        tipDescriptionLabel.textAlignment = .center
         
         tipDescriptionLabel.snp.makeConstraints { make in
             make.leading.equalTo(view).offset(UIConstants.layout.tipDescriptionMargin)

--- a/TipViewController.swift
+++ b/TipViewController.swift
@@ -45,9 +45,11 @@ class TipViewController: UIViewController {
 
         tipTitleLabel.text = tip.title
         tipDescriptionLabel.text = tip.description
+        tipDescriptionLabel.textAlignment = .center
         
         tipDescriptionLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
+            make.leading.equalTo(view).offset(UIConstants.layout.tipDescriptionMargin)
+            make.trailing.equalTo(view).inset(UIConstants.layout.tipDescriptionMargin)
             make.bottom.equalToSuperview()
         }
 

--- a/TipsPageViewController.swift
+++ b/TipsPageViewController.swift
@@ -54,6 +54,10 @@ class TipsPageViewController: UIViewController {
         }
         
     }
+    
+    func showPageController(_ urlBarIsActive: Bool) {
+        (pageController.view.subviews.first { $0 is UIPageControl } as? UIPageControl)?.isHidden = urlBarIsActive
+    }
 }
 
 extension TipsPageViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {

--- a/XCUITest/WebsiteAccessTest.swift
+++ b/XCUITest/WebsiteAccessTest.swift
@@ -8,6 +8,7 @@ class WebsiteAccessTests: BaseTestCase {
     // Smoketest
     func testVisitWebsite() {
         // Check initial page
+        dismissURLBarFocused()
         checkForHomeScreen()
 
         // Enter 'mozilla' on the search field
@@ -30,6 +31,7 @@ class WebsiteAccessTests: BaseTestCase {
         app.buttons["URLBar.deleteButton"].firstMatch.tap()
 
         // Check it is on the initial page
+        dismissURLBarFocused()
         checkForHomeScreen()
     }
 


### PR DESCRIPTION
- Solved the Focus logo overlap issue
- Added side margins of 16px to pro tips label, as specified by UX
- The Main Application Menu (꠵) and pro tips carousel (• • • •) now will be hidden when the keyboard is up

| iPhone SE | iPhone 12 Pro Max |
| ------------- | ------------- |
| ![Simulator Screen Shot - SE 1 - 2021-09-14 at 13 21 25](https://user-images.githubusercontent.com/46751540/133243535-2c02618c-bcd3-4658-865f-ca4d2cb3fa27.png)  | ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-14 at 13 33 31](https://user-images.githubusercontent.com/46751540/133243713-9c75df0d-5329-4b9f-bcdd-bee82cbfe99c.png)|
| ![Simulator Screen Shot - SE 1 - 2021-09-14 at 13 21 29](https://user-images.githubusercontent.com/46751540/133243587-b078bdce-764e-459d-8e1f-76b5eedbdb89.png) | ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-14 at 13 33 36](https://user-images.githubusercontent.com/46751540/133243746-0e9df8e9-b72f-4a5b-bfe8-14b0d6b351a8.png) |