### PR TITLE
Fixes #2302 - Inset grouped table row in Settings and Tracking Protection have top and bottom horizontal rulers

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -294,7 +294,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         tableView.delegate = self
         tableView.backgroundColor = .primaryBackground
         tableView.layoutMargins = UIEdgeInsets.zero
-        tableView.separatorColor = .searchSeparator.withAlphaComponent(0.65)
+        tableView.separatorStyle = .none
         tableView.allowsSelection = true
         tableView.estimatedRowHeight = 44
 
@@ -465,6 +465,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         cell.textLabel?.setupShrinkage()
         cell.detailTextLabel?.setupShrinkage()
 
+        
+        cell.addSeparator(tableView: tableView, indexPath: indexPath, leadingOffset: UIConstants.layout.cellSeparatorLeadingOffset)
+        
         return cell
     }
     

--- a/Blockzilla/TrackingProtectionViewController.swift
+++ b/Blockzilla/TrackingProtectionViewController.swift
@@ -60,7 +60,7 @@ class TrackingProtectionViewController: UIViewController, UITableViewDataSource,
         tableView.delegate = self
         tableView.dataSource = self
         tableView.backgroundColor = .primaryBackground
-        tableView.separatorColor = .searchSeparator.withAlphaComponent(0.65)
+        tableView.separatorStyle = .none
         tableView.tableFooterView = UIView()
         view.addSubview(tableView)
 
@@ -175,7 +175,9 @@ class TrackingProtectionViewController: UIViewController, UITableViewDataSource,
         case 1:
             return trackingProtectionCell()
         case 2:
-            return trackingProtectionEnabled ? trackersCell(index: indexPath.row) : settingsCell()
+            let cell = trackingProtectionEnabled ? trackersCell(index: indexPath.row) : settingsCell()
+            cell.addSeparator(tableView: tableView, indexPath: indexPath, leadingOffset: UIConstants.layout.cellSeparatorLeadingOffset)
+            return cell
         case 3:
             return settingsCell()
         default:

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -167,6 +167,7 @@ struct UIConstants {
     struct layout {
         static let browserToolbarDisabledOpacity: CGFloat = 0.4
         static let browserToolbarHeight: CGFloat = 44
+        static let cellSeparatorLeadingOffset: CGFloat = 14
         static let deleteAnimationDuration: TimeInterval = 0.25
         static let alphaToZeroDeleteAnimationDuration: TimeInterval = deleteAnimationDuration * (2 / 3)
         static let displayKeyboardDeleteAnimationDuration: TimeInterval = deleteAnimationDuration * (1 / 3)

--- a/Blockzilla/UITableViewCellExtensions.swift
+++ b/Blockzilla/UITableViewCellExtensions.swift
@@ -29,7 +29,7 @@ extension UITableViewCell {
         self.layer.mask = maskLayer
     }
     
-    func addSeparator(tableView: UITableView, indexPath: IndexPath) {
+    func addSeparator(tableView: UITableView, indexPath: IndexPath, leadingOffset: CGFloat = 0) {
         if indexPath.row != tableView.numberOfRows(inSection: indexPath.section) - 1 {
             let separator = UIView()
             separator.backgroundColor = .searchSeparator.withAlphaComponent(0.65)
@@ -37,7 +37,8 @@ extension UITableViewCell {
             self.addSubview(separator)
             separator.snp.makeConstraints { make in
                 make.height.equalTo(0.5)
-                make.leading.trailing.bottom.equalToSuperview()
+                make.leading.equalToSuperview().offset(leadingOffset)
+                make.trailing.bottom.equalToSuperview()
             }
         }
     }


### PR DESCRIPTION
Added separators only between cells, as is the screenshots:

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-15 at 13 25 59](https://user-images.githubusercontent.com/46751540/133417224-c643c46d-efea-4a53-86f1-164a39a6818b.png)

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-15 at 13 26 06](https://user-images.githubusercontent.com/46751540/133417174-adeda46c-9df3-43bd-82cb-6c8f5f73703f.png)
