### PR TITLE
Fixes #2278 - The "X" button is displayed in the URL bar but not text is typed.

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -672,7 +672,9 @@ class URLBar: UIView {
             self.urlBarBorderView.backgroundColor = borderColor
         }, completion: { finished in
             if finished {
-                self.displayClearButton(shouldDisplay: self.isEditing)
+                if let isEmpty = self.urlText.text?.isEmpty {
+                    self.displayClearButton(shouldDisplay: !isEmpty)
+                }
             }
         })
     }


### PR DESCRIPTION
Fixes #2278 - The "X" button is displayed in the URL bar but not text is typed.

![Simulator Screen Shot - iPhone 11 - 2021-09-15 at 14 25 05](https://user-images.githubusercontent.com/47420700/133424879-9bacd137-0b76-41e5-ae8f-f043d2fcb5bd.png)
