### PR TITLE
Fixes #2272 - Menu items layout is broken in landscape

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -327,6 +327,10 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             shouldScrollToSiri = false
         }
     }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        tableView.reloadData()
+    }
 
     @objc private func applicationDidBecomeActive() {
         // On iOS 9, we detect the blocker status by loading an invisible SafariViewController


### PR DESCRIPTION
Fixes #2272 - Menu items layout is broken in landscape

![Simulator Screen Shot - iPhone 11 - 2021-09-15 at 15 49 21](https://user-images.githubusercontent.com/47420700/133436347-69e9b4ce-9d14-4788-8042-b64f115eb0f9.png)
