### PR TITLE
Fix  #2337 Dismiss url bar focused button (<) is missing the very first time the app is launched in non English locales

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -46,12 +46,16 @@ class URLBar: UIView {
     let progressBar = GradientProgressBar(progressViewStyle: .bar)
     var inBrowsingMode: Bool = false {
         didSet {
-            updateBarState()
+            DispatchQueue.main.async {
+                self.updateBarState()
+            }
         }
     }
     private(set) var isEditing = false {
         didSet {
-            updateBarState()
+            DispatchQueue.main.async {
+                self.updateBarState()
+            }
         }
     }
     var shouldPresent = false


### PR DESCRIPTION
Fix  #2337 

Possible concurrency issue that cause button to stay hidden.
It was reproducible by fresh installing the app and skipping the onboarding.
 
<img src="https://user-images.githubusercontent.com/26011662/133453629-3de7e32b-5c69-41a8-8990-6b22f5a98faf.PNG" width="400">