### PR TITLE
Fixes #2362 - Toolset is hidden

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -757,7 +757,7 @@ class BrowserViewController: UIViewController {
                 self.hideToolbars()
             }
 
-            self.browserToolbar.animateHidden(self.homeViewController != nil || self.showsToolsetInURLBar, duration: coordinator.transitionDuration, completion: {
+            self.browserToolbar.animateHidden(!self.urlBar.inBrowsingMode || self.showsToolsetInURLBar, duration: coordinator.transitionDuration, completion: {
                 self.updateViewConstraints()
             })
         })


### PR DESCRIPTION
Updated the condition `self.homeViewController != nil` because it is no longer valid  (before home was of type UIView, not UIViewController).