### PR TITLE
Fixes #2357 - Do not activate the URL bar when the app is foregrounded with a website loaded

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -386,7 +386,27 @@ class BrowserViewController: UIViewController {
     public func activateUrlBarOnHomeView() {
         // If the Settings view is not displayed AND
         // If the home view is not displayed, nor the overlayView hidden do not activate the text field:
-        guard !(self.presentedViewController?.children.first is SettingsViewController) && (homeViewController != nil || !overlayView.isHidden) else { return }
+        
+        // Do not activate if the settings are presented
+        if self.presentedViewController?.children.first is SettingsViewController {
+            return
+        }
+        
+        // Do not activate if the home view is displayed
+        if homeViewController != nil {
+            return
+        }
+        
+        // Do not activate if the overlay view is shown
+        if !overlayView.isHidden {
+            return
+        }
+        
+        // Do not activate if we are in browsing mode
+        if urlBar.inBrowsingMode {
+            return
+        }
+        
         urlBar.activateTextField()
     }
 

--- a/XCUITest/PastenGoTest.swift
+++ b/XCUITest/PastenGoTest.swift
@@ -62,6 +62,7 @@ class PastenGoTest: BaseTestCase {
         // Tap url bar to show context menu
         let searchOrEnterAddressTextField = app.textFields["URLBar.urlText"]
         searchOrEnterAddressTextField.tap()
+        searchOrEnterAddressTextField.tap()
         waitForExistence(app.menuItems["Paste"], timeout: 10)
         XCTAssertTrue(app.menuItems["Paste & Go"].isEnabled)
 

--- a/XCUITest/SettingAppearanceTest.swift
+++ b/XCUITest/SettingAppearanceTest.swift
@@ -11,10 +11,8 @@ class SettingAppearanceTest: BaseTestCase {
     // Smoketest
     // Check for the basic appearance of the Settings Menu
     func testCheckSetting() {
-        dismissURLBarFocused()
-
         // Navigate to Settings
-        waitForExistence(app.buttons["Settings"])
+        waitForExistence(app.buttons["Settings"], timeout: 5)
         app.buttons["Settings"].tap()
 
         let settingsButton = app.cells["Settings"]
@@ -223,9 +221,8 @@ class SettingAppearanceTest: BaseTestCase {
 
     // Smoktest
     func testSafariIntegration() {
-        dismissURLBarFocused()
         // Navigate to Settings
-        waitForExistence(app.buttons["Settings"])
+        waitForExistence(app.buttons["Settings"], timeout: 5)
         app.buttons["Settings"].tap()
 
         let settingsButton = app.cells["Settings"]

--- a/XCUITest/WebsiteAccessTest.swift
+++ b/XCUITest/WebsiteAccessTest.swift
@@ -8,7 +8,6 @@ class WebsiteAccessTests: BaseTestCase {
     // Smoketest
     func testVisitWebsite() {
         // Check initial page
-        dismissURLBarFocused()
         checkForHomeScreen()
 
         // Enter 'mozilla' on the search field


### PR DESCRIPTION
I split up the logic into separate statements because I think that reads a lot easier than a long boolean expression. I am however not 100% sure that this is the correct fix.

It does solve the problem and it seems that this code path through `browserViewController.activateUrlBarOnHomeView` is triggered through `browserViewController.toggleSplashView` which is triggered in the `UIApplication.didBecomeActiveNotification` notification handler. (Which is setup in `BrowserViewController.setupBiometrics`).