### PR TITLE
Fixes #2376 - Pro tip touch target area is too small

### DIFF
--- a/Blockzilla/Pro Tips/TipViewController.swift
+++ b/Blockzilla/Pro Tips/TipViewController.swift
@@ -10,6 +10,7 @@ class TipViewController: UIViewController {
         let label = SmartLabel()
         label.textColor = UIConstants.colors.defaultFont
         label.font = UIConstants.fonts.shareTrackerStatsLabel
+        label.textAlignment = .center
         label.numberOfLines = 0
         label.minimumScaleFactor = UIConstants.layout.homeViewLabelMinimumScale
         return label
@@ -40,28 +41,27 @@ class TipViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+                
         view.addSubview(tipTitleLabel)
         view.addSubview(tipDescriptionLabel)
         
         tipTitleLabel.text = tip.title
-        tipTitleLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapTip)))
-        tipTitleLabel.isUserInteractionEnabled = true
-
         tipDescriptionLabel.text = tip.description
-        tipDescriptionLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapTip)))
-        tipDescriptionLabel.isUserInteractionEnabled = true
-
-        tipDescriptionLabel.snp.makeConstraints { make in
-            make.leading.equalTo(view).offset(UIConstants.layout.tipDescriptionMargin)
-            make.trailing.equalTo(view).inset(UIConstants.layout.tipDescriptionMargin)
-            make.bottom.equalToSuperview()
-        }
 
         tipTitleLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.bottom.equalTo(tipDescriptionLabel.snp.top)
+            make.leading.equalToSuperview()
+            make.trailing.equalToSuperview()
+            make.bottom.equalTo(self.view.snp.centerY)
         }
+
+        tipDescriptionLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview()
+            make.trailing.equalToSuperview()
+            make.top.equalTo(self.view.snp.centerY)
+        }
+
+        self.view.isUserInteractionEnabled = true
+        self.view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapTip)))
     }
     
     @objc private func tapTip() {

--- a/Blockzilla/Pro Tips/TipViewController.swift
+++ b/Blockzilla/Pro Tips/TipViewController.swift
@@ -44,13 +44,14 @@ class TipViewController: UIViewController {
         view.addSubview(tipTitleLabel)
         view.addSubview(tipDescriptionLabel)
         
-        tipDescriptionLabel.isUserInteractionEnabled = true
-        let tap = UITapGestureRecognizer(target: self, action: #selector(tapTip))
-        tipDescriptionLabel.addGestureRecognizer(tap)
-
         tipTitleLabel.text = tip.title
+        tipTitleLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapTip)))
+        tipTitleLabel.isUserInteractionEnabled = true
+
         tipDescriptionLabel.text = tip.description
-        
+        tipDescriptionLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapTip)))
+        tipDescriptionLabel.isUserInteractionEnabled = true
+
         tipDescriptionLabel.snp.makeConstraints { make in
             make.leading.equalTo(view).offset(UIConstants.layout.tipDescriptionMargin)
             make.trailing.equalTo(view).inset(UIConstants.layout.tipDescriptionMargin)


### PR DESCRIPTION
@brampitoyo @lime124 I changed the layout a bit and the grey area (only for debugging) is now the full tappable area. 

<img width="468" alt="Screen Shot 2021-09-16 at 3 31 44 PM" src="https://user-images.githubusercontent.com/28052/133674551-6d5f7e34-da4b-4290-87bb-5b16c0131a77.png">

As a result this also adds more margin between the text and the paging control. Previously the highligted control was firm against the bottom line of text:

<img width="504" alt="Screen Shot 2021-09-16 at 3 33 59 PM" src="https://user-images.githubusercontent.com/28052/133674795-79e2ebab-08b0-4a04-b4f3-9444916873eb.png">

Without the selected page control:

<img width="456" alt="Screen Shot 2021-09-16 at 3 57 56 PM" src="https://user-images.githubusercontent.com/28052/133677805-053fb3c8-d981-47ce-b778-a6e7c89d781d.png">

There is a bug where the pager control is obscured by the keyboard when it is up - that will be fixed in a separate issue.