### PR TITLE
Fixes #2375 - Tips pagination hidden below keyboard

### DIFF
--- a/Blockzilla/HomeViewController.swift
+++ b/Blockzilla/HomeViewController.swift
@@ -59,7 +59,6 @@ class HomeViewController: UIViewController {
         tipView.snp.makeConstraints { make in
             make.bottom.equalTo(toolbar.snp.top).offset(-UIConstants.layout.tipViewBottomOffset)
             make.leading.trailing.equalToSuperview()
-            make.centerX.equalToSuperview()
             make.height.equalTo(UIConstants.layout.tipViewHeight)
         }
 
@@ -95,18 +94,36 @@ class HomeViewController: UIViewController {
 
     @objc private func rotated() {
         if UIApplication.shared.orientation?.isLandscape == true {
-            hideTextLogo()
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                // On iPad in landscape we only show the tips.
+                hideTextLogo()
+                showTips()
+            } else {
+                // On iPhone in landscape we show neither.
+                hideTextLogo()
+                hideTips()
+            }
         } else {
+            // In portrait on any form factor we show both.
             showTextLogo()
+            showTips()
         }
     }
-
+    
     private func hideTextLogo() {
         textLogo.isHidden = true
     }
 
     private func showTextLogo() {
         textLogo.isHidden = false
+    }
+
+    private func hideTips() {
+        tipsViewController.view.isHidden = true
+    }
+
+    private func showTips() {
+        tipsViewController.view.isHidden = false
     }
 
     func showTextTip(_ tip: TipManager.Tip) {
@@ -128,21 +145,20 @@ class HomeViewController: UIViewController {
     }
     
     func updateUI(urlBarIsActive: Bool) {
-        tipsViewController.showPageController(urlBarIsActive)
         toolbar.isHidden = urlBarIsActive
-        
+
         tipView.snp.remakeConstraints { make in
             make.leading.trailing.equalToSuperview()
             make.centerX.equalToSuperview()
             make.height.equalTo(UIConstants.layout.tipViewHeight)
-            
+
             if urlBarIsActive {
                 make.bottom.equalToSuperview()
             } else {
                 make.bottom.equalTo(toolbar.snp.top).offset(-UIConstants.layout.tipViewBottomOffset)
             }
         }
-        
+
         if UIScreen.main.bounds.height ==  UIConstants.layout.iPhoneSEHeight {
             textLogo.snp.updateConstraints{ make in
                 make.top.equalTo(self.view.snp.centerY).offset(urlBarIsActive ?  UIConstants.layout.textLogoOffsetSmallDevice : UIConstants.layout.textLogoOffset)

--- a/Blockzilla/Pro Tips/TipsPageViewController.swift
+++ b/Blockzilla/Pro Tips/TipsPageViewController.swift
@@ -58,10 +58,6 @@ class TipsPageViewController: UIViewController {
         }
         
     }
-    
-    func showPageController(_ urlBarIsActive: Bool) {
-        (pageController.view.subviews.first { $0 is UIPageControl } as? UIPageControl)?.isHidden = urlBarIsActive
-    }
 }
 
 extension TipsPageViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {


### PR DESCRIPTION
This change brings back the pager dots under the pro tips. We were hiding these in landscape to make more vertical space. However, this did not fully solve the problem for really small devices. 

After talking to @brampitoyo we decided to simplify landscape more and simply do not show anything right now on iPhone landscape.

I've tested this on iPhone and iPad.

This patch works best if #2381 has landed.

I've put some orientation and form factor specific code:

```swift
    @objc private func rotated() {
        if UIApplication.shared.orientation?.isLandscape == true {
            if UIDevice.current.userInterfaceIdiom == .pad {
                // On iPad in landscape we only show the tips.
                hideTextLogo()
                showTips()
            } else {
                // On iPhone in landscape we show neither.
                hideTextLogo()
                hideTips()
            }
        } else {
            // In portrait on any form factor we show both.
            showTextLogo()
            showTips()
        }
    }
```

But what we should ultimately do is actually look at the available space and then dynamically decide what to show. There is at least one situation where we would then do a better job: iPad in landscape with hardware keyboard. In which case there definitely would be enough space for both tips and logo.