### PR TITLE
Fixes #2384 - On iPad with smaller app width the toolbar or hamburger menu is missing

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -766,6 +766,8 @@ class BrowserViewController: UIViewController {
         urlBar.updateConstraints()
         browserToolbar.updateConstraints()
         
+        homeViewController.toolbar.isIPadRegularDimensions = isIPadRegularDimensions
+        
         shortcutsContainer.spacing = size.width < UIConstants.layout.smallestSplitViewMaxWidthLimit ?
                                         UIConstants.layout.shortcutsContainerSpacingSmallestSplitView :
                                         (isIPadRegularDimensions ? UIConstants.layout.shortcutsContainerSpacingIPad : UIConstants.layout.shortcutsContainerSpacing)

--- a/Blockzilla/HomeViewToolbar.swift
+++ b/Blockzilla/HomeViewToolbar.swift
@@ -7,6 +7,18 @@ import UIKit
 class HomeViewToolbar: UIView {
     let toolset = BrowserToolset()
     private let stackView = UIStackView()
+    
+    var isIPadRegularDimensions: Bool = false {
+        didSet {
+            guard UIDevice.current.userInterfaceIdiom == .pad else { return }
+            
+            if isIPadRegularDimensions {
+                toolset.contextMenuButton.removeFromSuperview()
+            } else {
+                stackView.addArrangedSubview(toolset.contextMenuButton)
+            }
+        }
+    }
 
     init() {
         super.init(frame: CGRect.zero)


### PR DESCRIPTION
Now the menu button position updates on every transition (from/to splitView) on iPad.