### PR TITLE
Fixes #2226 - The URL bar is not properly dismissed when dismissing the keyboard via keyboard button

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1675,7 +1675,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
         }
     }
 
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) { }
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            urlBar.dismiss()
+        }
+    }
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) { }
 }
 


### PR DESCRIPTION
Added changes that ensure that URL Bar will be dismissed properly after pressing dismiss keyboard button on iPad.