### PR TITLE
Fixes #2401 - Keyboard does not open and home screen tips are cut off

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -385,7 +385,7 @@ class BrowserViewController: UIViewController {
     // These functions are used to handle displaying and hiding the keyboard after the splash view is animated
     public func activateUrlBarOnHomeView() {
         // Do not activate if we are showing a web page
-        if !webViewContainer.isHidden {
+        if urlBar.inBrowsingMode {
             return
         }
 

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -384,26 +384,18 @@ class BrowserViewController: UIViewController {
 
     // These functions are used to handle displaying and hiding the keyboard after the splash view is animated
     public func activateUrlBarOnHomeView() {
-        // If the Settings view is not displayed AND
-        // If the home view is not displayed, nor the overlayView hidden do not activate the text field:
-        
+        // Do not activate if we are showing a web page
+        if !webViewContainer.isHidden {
+            return
+        }
+
         // Do not activate if the settings are presented
         if self.presentedViewController?.children.first is SettingsViewController {
             return
         }
-        
-        // Do not activate if the home view is displayed
-        if homeViewController != nil {
-            return
-        }
-        
-        // Do not activate if the overlay view is shown
-        if !overlayView.isHidden {
-            return
-        }
-        
-        // Do not activate if we are in browsing mode
-        if urlBar.inBrowsingMode {
+
+        // Do not activate if the home view is not displayed, nor the overlayView hidden
+        if !(homeViewController != nil || overlayView.isHidden) {
             return
         }
         

--- a/XCUITest/PastenGoTest.swift
+++ b/XCUITest/PastenGoTest.swift
@@ -62,7 +62,6 @@ class PastenGoTest: BaseTestCase {
         // Tap url bar to show context menu
         let searchOrEnterAddressTextField = app.textFields["URLBar.urlText"]
         searchOrEnterAddressTextField.tap()
-        searchOrEnterAddressTextField.tap()
         waitForExistence(app.menuItems["Paste"], timeout: 10)
         XCTAssertTrue(app.menuItems["Paste & Go"].isEnabled)
 

--- a/XCUITest/SettingAppearanceTest.swift
+++ b/XCUITest/SettingAppearanceTest.swift
@@ -11,6 +11,8 @@ class SettingAppearanceTest: BaseTestCase {
     // Smoketest
     // Check for the basic appearance of the Settings Menu
     func testCheckSetting() {
+        dismissURLBarFocused()
+        
         // Navigate to Settings
         waitForExistence(app.buttons["Settings"], timeout: 5)
         app.buttons["Settings"].tap()
@@ -219,8 +221,10 @@ class SettingAppearanceTest: BaseTestCase {
         XCTAssertFalse(app.tables.cells["mozilla.org"].exists)
     }
 
-    // Smoktest
+    // Smoketest
     func testSafariIntegration() {
+        dismissURLBarFocused()
+        
         // Navigate to Settings
         waitForExistence(app.buttons["Settings"], timeout: 5)
         app.buttons["Settings"].tap()

--- a/XCUITest/WebsiteAccessTest.swift
+++ b/XCUITest/WebsiteAccessTest.swift
@@ -7,6 +7,8 @@ import XCTest
 class WebsiteAccessTests: BaseTestCase {
     // Smoketest
     func testVisitWebsite() {
+        dismissURLBarFocused()
+        
         // Check initial page
         checkForHomeScreen()
 


### PR DESCRIPTION
This patch fixes a regression from #2380 where the logic from the guard statement was not correctly turned into individual checks. As a result the keyboard did not always open correctly at the right time and the pro tips were also compressed a bit vertically.

Test cases listed in #2401 
