### PR TITLE
Fixes #2369 - Suggestions overlap append button

### DIFF
--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -166,7 +166,7 @@ class OverlayView: UIView {
             }
             
             self.arrowButtons[i - 1].snp.remakeConstraints { make in
-                make.height.width.equalTo(30)
+                make.height.width.equalTo(UIConstants.layout.searchSuggestionsArrowButtonWidth)
                 make.trailing.equalTo(searchButtonGroup[i].snp.trailing).inset(12)
                 make.centerY.equalTo(searchButtonGroup[i])
             }
@@ -247,9 +247,9 @@ class OverlayView: UIView {
         let padding = UIConstants.layout.searchButtonInset
         button.imageEdgeInsets = UIEdgeInsets(top: padding, left: padding, bottom: padding, right: padding)
         if UIView.userInterfaceLayoutDirection(for: button.semanticContentAttribute) == .rightToLeft {
-            button.titleEdgeInsets = UIEdgeInsets(top: padding, left: padding, bottom: padding, right: padding * 2)
+            button.titleEdgeInsets = UIEdgeInsets(top: padding, left: padding + UIConstants.layout.searchSuggestionsArrowButtonWidth, bottom: padding, right: padding * 2)
         } else {
-            button.titleEdgeInsets = UIEdgeInsets(top: padding, left: padding * 2, bottom: padding, right: padding)
+            button.titleEdgeInsets = UIEdgeInsets(top: padding, left: padding * 2, bottom: padding, right: UIConstants.layout.searchSuggestionsArrowButtonWidth + padding)
         }
     }
 

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -308,6 +308,7 @@ struct UIConstants {
         static let shortcutsBackgroundWidthIPad: CGFloat = 676
         static let smallestSplitViewMaxWidthLimit: CGFloat = UIScreen.main.bounds.width * 0.45
         static let iPhoneSEHeight: CGFloat = 568
+        static let searchSuggestionsArrowButtonWidth: CGFloat = 30
     }
 
     struct strings {


### PR DESCRIPTION
This patch adds padding to avoid the button text to overlap with the arrow icon. Tested on iPhone in portrait and landscape with RTL and LTR locale. Also tested on iPad.

<img width="549" alt="Screen Shot 2021-09-18 at 10 58 47 AM" src="https://user-images.githubusercontent.com/28052/133893198-b5970fdb-55cd-43b8-8d73-d3e59c816e09.png">

<img width="742" alt="Screen Shot 2021-09-18 at 11 05 22 AM" src="https://user-images.githubusercontent.com/28052/133893344-42bf61be-416a-4fcc-8b08-774e89a69520.png">
