### PR TITLE
Fixes #2266 - Do not generate Documentation/metrics.md anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ export-locales-env
 # Glean
 .venv/
 Blockzilla/Generated
+Documentation/metrics.md
+

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,3 @@ export-locales-env
 # Glean
 .venv/
 Blockzilla/Generated
-Documentation/metrics.md
-

--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -1840,7 +1840,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "bash $PWD/bin/sdk_generator.sh -m $SRCROOT/Documentation\n";
+			shellScript = "bash $PWD/bin/sdk_generator.sh\n";
 		};
 		F84AFE711DE77ACC005C4DD1 /* Run Script (Copy Wordmark) */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Documentation/metrics.md
+++ b/Documentation/metrics.md
@@ -1,0 +1,6 @@
+# Metrics definitions have moved
+
+Metrics definitions for FOcus for iOS have moved to the [Glean Dictionary](https://dictionary.telemetry.mozilla.org/apps/focus_ios).
+
+This file is kept only for historical reference.
+


### PR DESCRIPTION
Do not generate `Documentation/metrics.md` anymore. Instead I put in a link to the [Glean Dictionary](https://dictionary.telemetry.mozilla.org/apps/focus_ios) instead, which is the source of truth for telemetry documentation.

I hope to never see this show up when making patches 😁 