### PR TITLE
Fixes #2377 - Request mobile site icon is squashed

### DIFF
--- a/Blockzilla/PhotonActionSheet.swift
+++ b/Blockzilla/PhotonActionSheet.swift
@@ -14,7 +14,7 @@ struct PhotonActionSheetUX {
     static let BorderColor = UIConstants.Photon.Grey30
     static let CornerRadius: CGFloat = 10
     static let SiteImageViewSize = 52
-    static let IconSize = CGSize(width: 24, height: 24)
+    static let IconSize: CGFloat = 24
     static let SiteHeaderName  = "PhotonActionSheetSiteHeaderView"
     static let TitleHeaderName = "PhotonActionSheetTitleHeaderView"
     static let CloseButtonHeight: CGFloat  = 56

--- a/Blockzilla/PhotonActionSheetCell.swift
+++ b/Blockzilla/PhotonActionSheetCell.swift
@@ -17,7 +17,7 @@ struct PhotonActionSheetCellUX {
     static let CellSideOffset = 20
     static let TitleLabelOffset = 10
     static let CellTopBottomOffset = 12
-    static let StatusIconSize = 24
+    static let StatusIconSize: CGFloat = 24
     static let SelectedOverlayColor = UIColor(rgb: 0x5D5F79)
     static let CornerRadius: CGFloat = 3
 }
@@ -140,7 +140,7 @@ class PhotonActionSheetCell: UITableViewCell {
         selectionStyle = .none
         
         if let iconName = action.iconString, let image = UIImage(named: iconName) {
-            statusIcon.image = image.createScaled(size: PhotonActionSheetUX.IconSize)
+            statusIcon.image = image.createScaled(targetSize: PhotonActionSheetUX.IconSize)
             if statusIcon.superview == nil {
                 if action.iconAlignment == .right {
                     stackView.addArrangedSubview(statusIcon)

--- a/Blockzilla/SearchSettingsViewController.swift
+++ b/Blockzilla/SearchSettingsViewController.swift
@@ -120,7 +120,7 @@ class SearchSettingsViewController: UIViewController, UITableViewDelegate, UITab
             let cell = UITableViewCell(style: .default, reuseIdentifier: engine.image == nil ? "empty-image-cell" : nil)
             cell.textLabel?.text = engine.name
             cell.textLabel?.textColor = UIConstants.colors.settingsTextLabel
-            cell.imageView?.image = engine.image?.createScaled(size: CGSize(width: 24, height: 24))
+            cell.imageView?.image = engine.image?.createScaled(targetSize: 24)
             cell.selectedBackgroundView = getBackgroundView()
             cell.backgroundColor = .secondaryBackground
             cell.accessibilityIdentifier = engine.name

--- a/Blockzilla/UIImageExtensions.swift
+++ b/Blockzilla/UIImageExtensions.swift
@@ -5,11 +5,25 @@
 import UIKit
 
 extension UIImage {
-    public func createScaled(size: CGSize) -> UIImage {
-        let imageRenderer = UIGraphicsImageRenderer(size: size)
-        return imageRenderer.image(actions: { (context) in
-            draw(in: CGRect(origin: .zero, size: size))
-        })
+    public func createScaled(targetSize: CGFloat) -> UIImage {
+        let widthRatio  = targetSize  / self.size.width
+        let heightRatio = targetSize / self.size.height
+
+        let newSize: CGSize
+        if widthRatio > heightRatio {
+            newSize = CGSize(width: self.size.width * heightRatio, height: self.size.height * heightRatio)
+        } else {
+            newSize = CGSize(width: self.size.width * widthRatio,  height: self.size.height * widthRatio)
+        }
+        
+        let rect = CGRect(
+            origin: CGPoint(x: (targetSize - newSize.width) / 2.0, y: (targetSize - newSize.height) / 2.0),
+            size: CGSize(width: newSize.width, height: newSize.height)
+        )
+        
+        return UIGraphicsImageRenderer(size: CGSize(width: targetSize, height: targetSize)).image { context in
+            self.draw(in: rect)
+        }
     }
     
     func alpha(_ value: CGFloat) -> UIImage {


### PR DESCRIPTION
This patch makes `UIImage.createScaled()` aware of image aspect ratios. It previously assumed that all images are square and the `request_mobile_site_activity` image is not - it is taller than wider and as a result it was _stretched_ to fill the (24x24) destination image.

To remove some ambiguity I also changed the `destinationSize` that `createScaled()` takes from `CGPoint` to a `CGFloat` to make it clear that this renders to square images.

The code to preserve the aspect ratio is not really exciting but I wish we did not need this. I went this route because I think it more compatible with the vector (PDF) assets that we've been using. Which probably are not always square.

Ultimately what should be done is just let `UIImage` and `UIImageView` deal with scaling. I don't really understand why this `UIImage.createScaled()` extension was added back in 2019 because iOS is really great at rendering images and we could literally just create an `UIImageView` with size 24x24 and set `contentMode` to `.scaleAspectFill ` to get the same results.

Screenshot attached - @brampitoyo or @lime124 can you take a peek and see if this is good?

<img width="478" alt="Screen Shot 2021-09-18 at 8 43 41 PM" src="https://user-images.githubusercontent.com/28052/133912004-a3dd6537-8220-4408-96ed-0cd2b92f6fcf.png">
