### PR TITLE
Fixes #2322 - Add a space after appending a search suggestion

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1427,7 +1427,7 @@ extension BrowserViewController: OverlayViewDelegate {
     }
     
     func overlayView(_ overlayView: OverlayView, didTapArrowText text: String) {
-        urlBar.fillUrlBar(text: text)
+        urlBar.fillUrlBar(text: text + " ")
         searchSuggestClient.getSuggestions(text) { [weak self] suggestions, error in
             if error == nil, let suggestions = suggestions {
                 self?.overlayView.setSearchQuery(suggestions: suggestions, hideFindInPage: true, hideAddToComplete: true)


### PR DESCRIPTION
I really liked this suggestion from #2322 and it is also what Safari does, so here is a tiny patch that simply adds a space after the text we put in the url bar so that you can easily add more text to a search.

Simple example use case:

 - Type `cheese`
 - Tap `cheesecake` suggestion
 - Tap `cheesecake factory` suggestion
 - Type to append `toronto` and hit Go
 