### PR TITLE
Fixes #2352 - The Restore Default Search Engines button does not work

### DIFF
--- a/Blockzilla/SearchEngineManager.swift
+++ b/Blockzilla/SearchEngineManager.swift
@@ -48,11 +48,11 @@ class SearchEngineManager {
     }
 
     func hasDisabledDefaultEngine() -> Bool {
-        return getDisabledDefaultEngineNames().count > 0
+        return readCustomEngines().count > 0
     }
 
     func restoreDisabledDefaultEngines() {
-        prefs.removeObject(forKey: SearchEngineManager.prefKeyDisabledEngines)
+        prefs.removeObject(forKey: SearchEngineManager.prefKeyCustomEngines)
         loadEngines()
     }
 

--- a/Blockzilla/SearchSettingsViewController.swift
+++ b/Blockzilla/SearchSettingsViewController.swift
@@ -203,6 +203,10 @@ class SearchSettingsViewController: UIViewController, UITableViewDelegate, UITab
         let engine = engines[indexPath.row]
         return engine != searchEngineManager.activeEngine
     }
+    
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        return indexPath.section == 1 ? .none : .delete
+    }
 
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {


### PR DESCRIPTION
Fixes #2352 - The Restore Default Search Engines button does not work

![Simulator Screen Shot - iPhone 11 - 2021-09-20 at 15 25 47](https://user-images.githubusercontent.com/47420700/134001951-dcce4415-e83c-4685-b93d-f528d9036c1b.png)


