### PR TITLE
Fixes #2415 - Sharing text on Focus is not working

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -176,7 +176,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
                 if let fixedUrl = URIFixup.getURL(entry: text) {
                     browserViewController.submit(url: fixedUrl)
                 } else {
-                    browserViewController.openOverlay(text: text)
+                    browserViewController.submit(text: text)
                 }
             } else {
                 queuedString = text
@@ -296,7 +296,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
                 browserViewController.dismissActionSheet()
                 browserViewController.submit(url: fixedUrl)
             } else {
-                browserViewController.openOverlay(text: text)
+                browserViewController.ensureBrowsingMode()
+                browserViewController.deactivateUrlBarOnHomeView()
+                browserViewController.dismissSettings()
+                browserViewController.dismissActionSheet()
+                browserViewController.submit(text: text)
             }
 
             queuedString = nil

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -289,17 +289,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
         } else if let text = queuedString {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.openedFromExtension, object: TelemetryEventObject.app)
 
+            browserViewController.ensureBrowsingMode()
+            browserViewController.deactivateUrlBarOnHomeView()
+            browserViewController.dismissSettings()
+            browserViewController.dismissActionSheet()
+
             if let fixedUrl = URIFixup.getURL(entry: text) {
-                browserViewController.ensureBrowsingMode()
-                browserViewController.deactivateUrlBarOnHomeView()
-                browserViewController.dismissSettings()
-                browserViewController.dismissActionSheet()
                 browserViewController.submit(url: fixedUrl)
             } else {
-                browserViewController.ensureBrowsingMode()
-                browserViewController.deactivateUrlBarOnHomeView()
-                browserViewController.dismissSettings()
-                browserViewController.dismissActionSheet()
                 browserViewController.submit(text: text)
             }
 

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -170,10 +170,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
         } else if host == "open-text" || isHttpScheme {
             let text = unescape(string: query["text"]) ?? ""
 
+            // If we are active then we can ask the BVC to open the new tab right away.
+            // Otherwise, we remember the URL and we open it in applicationDidBecomeActive.
             if application.applicationState == .active {
-                // If we are active then we can ask the BVC to open the new tab right away.
-                // Otherwise, we remember the URL and we open it in applicationDidBecomeActive.
-                browserViewController.openOverylay(text: text)
+                if let fixedUrl = URIFixup.getURL(entry: text) {
+                    browserViewController.submit(url: fixedUrl)
+                } else {
+                    browserViewController.openOverlay(text: text)
+                }
             } else {
                 queuedString = text
             }
@@ -285,7 +289,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
         } else if let text = queuedString {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.openedFromExtension, object: TelemetryEventObject.app)
 
-            browserViewController.openOverylay(text: text)
+            if let fixedUrl = URIFixup.getURL(entry: text) {
+                browserViewController.ensureBrowsingMode()
+                browserViewController.deactivateUrlBarOnHomeView()
+                browserViewController.dismissSettings()
+                browserViewController.dismissActionSheet()
+                browserViewController.submit(url: fixedUrl)
+            } else {
+                browserViewController.openOverlay(text: text)
+            }
+
             queuedString = nil
         }
 

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -398,7 +398,7 @@ class BrowserViewController: UIViewController {
         if !(homeViewController != nil || overlayView.isHidden) {
             return
         }
-        
+
         urlBar.activateTextField()
     }
 
@@ -725,11 +725,13 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    func openOverylay(text: String) {
+    func openOverlay(text: String) {
+        ensureBrowsingMode()
+        showToolbars()
         urlBar.activateTextField()
-        urlBar.fillUrlBar(text: text)
+        urlBar.fillUrlBarWithString(text: text)
     }
-
+    
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -739,13 +739,6 @@ class BrowserViewController: UIViewController {
             userActivity = SiriShortcuts().getActivity(for: .openURL)
         }
     }
-
-    func openOverlay(text: String) {
-        ensureBrowsingMode()
-        showToolbars()
-        urlBar.activateTextField()
-        urlBar.fillUrlBarWithString(text: text)
-    }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -691,6 +691,21 @@ class BrowserViewController: UIViewController {
 
         shouldEnsureBrowsingMode = false
     }
+    
+    func submit(text: String) {
+        var url = URIFixup.getURL(entry: text)
+        if url == nil {
+            Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
+            Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            url = searchEngineManager.activeEngine.urlForQuery(text)
+        } else {
+            Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)
+        }
+        
+        if let url = url {
+            submit(url: url)
+        }
+    }
 
     func submit(url: URL) {
         // If this is the first navigation, show the browser and the toolbar.

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -567,11 +567,6 @@ class URLBar: UIView {
         urlText.text = text
     }
 
-    func fillUrlBarWithString(text: String) {
-        urlText.text = text
-        delegate?.urlBar(self, didEnterText: text)
-    }
-
     private func updateUrlIcons() {
         let visible = !isEditing && url != nil
         let duration = UIConstants.layout.urlBarTransitionAnimationDuration / 2

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -567,6 +567,11 @@ class URLBar: UIView {
         urlText.text = text
     }
 
+    func fillUrlBarWithString(text: String) {
+        urlText.text = text
+        delegate?.urlBar(self, didEnterText: text)
+    }
+
     private func updateUrlIcons() {
         let visible = !isEditing && url != nil
         let duration = UIConstants.layout.urlBarTransitionAnimationDuration / 2

--- a/OpenInFocus/ActionViewController.swift
+++ b/OpenInFocus/ActionViewController.swift
@@ -77,14 +77,8 @@ class ActionViewController: SLComposeServiceViewController {
         } else if let textProvider = textProvider {
             textProvider.processText { (textItem, error) in
                 guard let text = textItem as? String else { self.cancel(); return }
-
-                if let url = NSURL(string: text) {
-                    guard let focusUrl = url.encodedUrl.flatMap(self.focusUrl) else { self.cancel(); return }
-                    self.handleUrl(focusUrl)
-                } else {
-                    guard let focusUrl = self.textUrl(text: text) else { self.cancel(); return }
-                    self.handleUrl(focusUrl)
-                }
+                guard let focusUrl = self.textUrl(text: text) else { self.cancel(); return }
+                self.handleUrl(focusUrl)
             }
         } else {
             // If no item was processed. Cancel the share action to prevent the


### PR DESCRIPTION
This patch is similar to https://github.com/mozilla-mobile/focus-ios/pull/1972 which was partially undone when we merged `refresh` into `main`.

Tests - Share Text:

 - when Focus has not been started yet: searches for the text with your default search engine
 - when Focus has been started: searches for the text with your default search engine
 - when Focus has been started and has loaded a web page: searches for the text with your default search engine

Tests - Share URL:

 - when Focus has not been started yet: opens the page
 - when Focus has been started: opens the page
 - when Focus has been started and has loaded a web page: opens the page

This is a bit different than the original patch, which only loaded the text in the location field and let you hit Go manually. I  changed it to how Firefox iOS handles this.
