### PR TITLE
Fixes #2413 - Continuous haptic feedback when long pressing on shortcut

### DIFF
--- a/Blockzilla/ShortcutView.swift
+++ b/Blockzilla/ShortcutView.swift
@@ -82,12 +82,14 @@ class ShortcutView: UIView {
         }
     }
     
-    @objc private func didLongPress() {
-        let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
-        feedbackGenerator.prepare()
-        if let shortcut = self.shortcut {
-            CHHapticEngine.capabilitiesForHardware().supportsHaptics ? feedbackGenerator.impactOccurred() : AudioServicesPlaySystemSound(1519)
-            delegate?.shortcutLongPressed(shortcut: shortcut, shortcutView: self)
+    @objc private func didLongPress(sender: UILongPressGestureRecognizer) {
+        if sender.state == .began {
+            let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+            feedbackGenerator.prepare()
+            if let shortcut = self.shortcut {
+                CHHapticEngine.capabilitiesForHardware().supportsHaptics ? feedbackGenerator.impactOccurred() : AudioServicesPlaySystemSound(1519)
+                delegate?.shortcutLongPressed(shortcut: shortcut, shortcutView: self)
+            }
         }
     }
 }


### PR DESCRIPTION
The UILongPressGestureRecognizer is continuous, which means the action method is also called when you move or lift your finger. I simply added a filter for `.began`.