### PR TITLE
Missing updates for XCUITest Full Test Plan

### DIFF
--- a/XCUITest/AsianLocaleTest.swift
+++ b/XCUITest/AsianLocaleTest.swift
@@ -20,14 +20,17 @@ class AsianLocaleTest: BaseTestCase {
 		// Enter 'mozilla' on the search field
 		search(searchWord: "모질라")
         app.buttons["URLBar.deleteButton"].tap()
+        dismissURLBarFocused()
         checkForHomeScreen()
 
 		search(searchWord: "モジラ")
         app.buttons["URLBar.deleteButton"].tap()
+        dismissURLBarFocused()
         checkForHomeScreen()
 
 		search(searchWord: "因特網")
         app.buttons["URLBar.deleteButton"].tap()
+        dismissURLBarFocused()
         checkForHomeScreen()
 	}
 

--- a/XCUITest/FindInPageTest.swift
+++ b/XCUITest/FindInPageTest.swift
@@ -15,7 +15,7 @@ class FindInPageTest: BaseTestCase {
         app.textFields["Search or enter address"].typeText("domain")
 
         // Try all functions of find in page bar
-        waitForHittable(app.buttons["FindInPageBar.button"])
+        waitForExistence(app.buttons["FindInPageBar.button"], timeout: 5)
         app.buttons["FindInPageBar.button"].tap()
 
         waitForHittable(app.buttons["FindInPage.find_previous"])
@@ -38,6 +38,7 @@ class FindInPageTest: BaseTestCase {
 
         waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
+        waitForExistence(app.tables.cells["icon_searchfor"])
         app.tables.cells["icon_searchfor"].tap()
 
         // Activate find in page activity item and search for a keyword

--- a/XCUITest/UserAgentTest.swift
+++ b/XCUITest/UserAgentTest.swift
@@ -8,7 +8,7 @@ class UserAgentTest: BaseTestCase {
 
     func testSignInWithGoogle() {
         loadWebPage("https://getpocket.com/")
-        let btn = app.links["Sign up with Google"]
+        let btn = app.links["Sign up with Google"].firstMatch
         waitForExistence(btn)
         btn.tap()
         waitForWebPageLoad()


### PR DESCRIPTION
I think I already fixed these tests for the Full Functional Test plan but it may be missing after the refresh merge into main. 

With these changes all tests will work on iPhone. On iPad we still have a few failures due to issue: #2324 