### PR TITLE
Fixes #2363 - Text in the url bar is trimmed

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -340,7 +340,7 @@ class URLBar: UIView {
         }
 
         urlText.snp.makeConstraints { make in
-            make.top.bottom.equalToSuperview()
+            make.centerY.equalToSuperview()
             make.leading.equalTo(shieldIcon.snp.trailing).offset(5)
 
             showLeftBarViewConstraints.append(make.left.equalToSuperview().constraint)


### PR DESCRIPTION
Fixes #2363 . Tested also on iPod

![Simulator Screen Shot - iPod touch (7th generation) - 2021-09-21 at 15 52 03](https://user-images.githubusercontent.com/46751540/134173949-0fad7df1-f74a-4cda-854e-a8d4c723edb0.png)

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-21 at 15 50 57](https://user-images.githubusercontent.com/46751540/134173968-907fa77f-bb0e-4b09-ae7b-550b1306dd60.png)

