### PR TITLE
For #2424 - Bitrise: update to gen2 machines

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -171,7 +171,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: standard
+        machine_type_id: g2.4core
 
 
   runFocus:
@@ -407,7 +407,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.5.x
-        machine_type_id: standard
+        machine_type_id: g2.4core
   L10nBuild:
     steps:
     - activate-ssh-key@4:


### PR DESCRIPTION
Fixes #2424 by updating all workflows that were still using gen1 machines to gen2