### PR TITLE
Fixes #2295 - Bottom toolbar does not use new background colour

### DIFF
--- a/Blockzilla/BrowserToolbar.swift
+++ b/Blockzilla/BrowserToolbar.swift
@@ -9,28 +9,25 @@ class BrowserToolbar: UIView {
     let toolset = BrowserToolset()
     private let backgroundLoading = GradientBackgroundView()
     private let backgroundDark = UIView()
-    private let backgroundBright = GradientBackgroundView(alpha: 0.2, background: UIConstants.colors.background)
+    private let backgroundBright = UIView()
     private let stackView = UIStackView()
 
     init() {
         super.init(frame: CGRect.zero)
 
         let background = UIView()
-        background.backgroundColor = UIConstants.colors.background
+        background.backgroundColor = .foundation
         addSubview(background)
 
         addSubview(backgroundLoading)
         addSubview(backgroundDark)
 
-        backgroundDark.backgroundColor = UIConstants.colors.background
+        backgroundDark.backgroundColor = .foundation
+        backgroundBright.backgroundColor = .foundation
 
         backgroundBright.isHidden = true
         backgroundBright.alpha = 0
         background.addSubview(backgroundBright)
-
-        let borderView = UIView()
-        borderView.backgroundColor = UIConstants.Photon.Grey70
-        addSubview(borderView)
 
         stackView.distribution = .fillEqually
 
@@ -40,11 +37,6 @@ class BrowserToolbar: UIView {
         stackView.addArrangedSubview(toolset.contextMenuButton)
         addSubview(stackView)
 
-        borderView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalTo(self)
-            make.height.equalTo(1)
-        }
-
         stackView.snp.makeConstraints { make in
             make.top.right.left.equalTo(self)
             make.height.equalTo(UIConstants.layout.browserToolbarHeight)
@@ -52,8 +44,7 @@ class BrowserToolbar: UIView {
         }
 
         background.snp.makeConstraints { make in
-            make.top.equalTo(borderView.snp.bottom)
-            make.leading.trailing.bottom.equalTo(self)
+            make.top.leading.trailing.bottom.equalTo(self)
         }
 
         backgroundDark.snp.makeConstraints { make in


### PR DESCRIPTION
Fixes #2295 - Bottom toolbar does not use new background colour

![Simulator Screen Shot - iPhone 11 - 2021-09-22 at 12 11 14](https://user-images.githubusercontent.com/47420700/134316239-07d23663-f26a-4aef-8a9a-b90abdcd4aa0.png)


