### PR TITLE
Fixes #2414 - Labels in settings which require two lines are cut off

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -329,7 +329,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        tableView.reloadData()
+        DispatchQueue.main.async { [weak self] in
+            self?.tableView.reloadData()
+        }
     }
 
     @objc private func applicationDidBecomeActive() {


### PR DESCRIPTION
Fixes #2414 - Labels in settings which require two lines are cut off
Also fixes the rounded corners of sections issue (after transitioning from landscape the corners were not rounded). 

This is how the screen looks after transitioning back to portrait:

![Simulator Screen Shot - iPhone 12 - 2021-09-22 at 17 51 47](https://user-images.githubusercontent.com/46751540/134367565-57623079-d0fd-4b76-9def-4b05e63c08ff.png)


