### PR TITLE
Fixes #2440 - Transparent navigation bar on iOS 15

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -51,6 +51,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
 
         setupTelemetry()
         TPStatsBlocklistChecker.shared.startup()
+        
+        // Fix transparent navigation bar issue in iOS 15
+        if #available(iOS 15, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.primaryText]
+            appearance.backgroundColor = .primaryBackground
+            appearance.shadowColor = .clear
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        }
 
         // Count number of app launches for requesting a review
         let currentLaunchCount = UserDefaults.standard.integer(forKey: UIConstants.strings.userDefaultsLaunchCountKey)


### PR DESCRIPTION
Fixes #2440 - Transparent navigation bar on iOS 15

![Simulator Screen Shot - iPhone 11 - 2021-09-23 at 17 28 33](https://user-images.githubusercontent.com/47420700/134526206-465818a2-3725-43a2-9cc5-eb2e34e5f82a.png)

