### PR TITLE
Fixes #2333 - Tracking protection menu in lanscape - some strings does not respect the safe area

### DIFF
--- a/Blockzilla/AddSearchEngineViewController.swift
+++ b/Blockzilla/AddSearchEngineViewController.swift
@@ -22,6 +22,7 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
     private var nameInput = UITextField()
     private var templateInput = UITextView()
     private var templatePlaceholderLabel = UITextView()
+    private var container = UIView()
 
     init(delegate: AddSearchEngineDelegate, searchEngineManager: SearchEngineManager) {
         self.delegate = delegate
@@ -45,8 +46,6 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
 
     private func setupUI() {
         view.backgroundColor = .primaryBackground
-
-        let container = UIView()
         view.addSubview(container)
 
         let nameLabel = SmartLabel()
@@ -117,8 +116,7 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
         container.addSubview(exampleLabel)
 
         container.snp.makeConstraints { (make) in
-            make.width.equalToSuperview()
-            make.height.equalToSuperview()
+            make.leading.trailing.height.equalToSuperview()
         }
 
         nameLabel.snp.makeConstraints { (make) in
@@ -161,6 +159,29 @@ class AddSearchEngineViewController: UIViewController, UITextViewDelegate {
             make.leading.equalToSuperview().offset(leftMargin)
             make.trailing.equalToSuperview().offset(-leftMargin)
         }
+    }
+    
+    override func viewSafeAreaInsetsDidChange() {
+        updateContainerConstraints()
+    }
+    
+    private func updateContainerConstraints() {
+        container.snp.updateConstraints { make in
+            switch (UIDevice.current.userInterfaceIdiom, UIDevice.current.orientation) {
+            case (.phone, .landscapeLeft):
+                make.leading.equalTo(view).offset(self.view.safeAreaInsets.left)
+                make.trailing.equalTo(view)
+            case (.phone, .landscapeRight):
+                make.leading.equalTo(view)
+                make.trailing.equalTo(view).inset(self.view.safeAreaInsets.right)
+            default:
+                make.leading.trailing.equalTo(view)
+            }
+            
+        }
+    }
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        updateContainerConstraints()
     }
 
     @objc func learnMoreTapped() {

--- a/Blockzilla/TrackingProtectionViewController.swift
+++ b/Blockzilla/TrackingProtectionViewController.swift
@@ -78,6 +78,25 @@ class TrackingProtectionViewController: UIViewController, UITableViewDataSource,
             toggle.isOn = Settings.getToggle(blockerToggle.setting)
         }
     }
+    
+    override func viewWillLayoutSubviews() {
+        updateHorizontalConstraintsForTableView()
+    }
+    
+    private func updateHorizontalConstraintsForTableView() {
+        tableView.snp.updateConstraints { make in
+            switch (UIDevice.current.userInterfaceIdiom, UIDevice.current.orientation) {
+            case (.phone, .landscapeLeft):
+                make.leading.equalTo(view).offset(view.safeAreaInsets.left)
+                make.trailing.equalTo(view).inset(UIConstants.layout.trackingProtectionTableInset)
+            case (.phone, .landscapeRight):
+                make.leading.equalTo(view).inset(UIConstants.layout.trackingProtectionTableInset)
+                make.trailing.equalTo(view).inset(view.safeAreaInsets.right)
+            default:
+                make.leading.trailing.equalTo(view).inset(UIConstants.layout.trackingProtectionTableInset)
+            }
+        }
+    }
 
     @objc private func doneTapped() {
         self.dismiss(animated: true, completion: nil)
@@ -94,7 +113,9 @@ class TrackingProtectionViewController: UIViewController, UITableViewDataSource,
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        tableView.reloadData()
+        DispatchQueue.main.async { [weak self] in
+            self?.tableView.reloadData()
+        }
     }
     
     private func showSettings() {


### PR DESCRIPTION
Solved landscape safe area issues for Tracking protection and add Search engine screens.

<img width="1060" alt="Screen Shot 2021-09-24 at 11 58 49 AM" src="https://user-images.githubusercontent.com/46751540/134648031-b66a7851-08b9-4332-8ad2-2672f9e65655.png">

<img width="1060" alt="Screen Shot 2021-09-24 at 11 58 34 AM" src="https://user-images.githubusercontent.com/46751540/134648038-c79a6e98-ca95-416e-badb-96339e20358d.png">


