### PR TITLE
Fixes #2445 - Your rights section not matching color scheme

### DIFF
--- a/Blockzilla/LocalWebServer/style.css
+++ b/Blockzilla/LocalWebServer/style.css
@@ -1,6 +1,6 @@
 body, html {
-    background: #202340;
-    color: #E1E5EA;
+    background: #1C1C1E;
+    color: #FBFBFE;
     font: -apple-system-body;
     font-size: 14px;
     margin-left: 16px;
@@ -8,6 +8,6 @@ body, html {
 }
 
 a {
-    color: #0A9AF4;
+    color: #FF4AA2;
     text-decoration: none;
 }


### PR DESCRIPTION
Fixes #2445 - Your rights section not matching color scheme

![Simulator Screen Shot - iPhone 11 - 2021-09-27 at 10 30 54](https://user-images.githubusercontent.com/47420700/134863779-f8e6f6c1-dbc1-4033-b1a1-41b85cc1dcfe.png)

