### PR TITLE
Fixes #2327 - Different font sizes in same tab menu - non English locales

### DIFF
--- a/Blockzilla/PhotonActionSheetCell.swift
+++ b/Blockzilla/PhotonActionSheetCell.swift
@@ -127,9 +127,7 @@ class PhotonActionSheetCell: UITableViewCell {
         titleLabel.text = action.title
         titleLabel.textColor = self.tintColor
         titleLabel.textColor = action.accessory == .Text ? titleLabel.textColor.withAlphaComponent(0.6) : titleLabel.textColor
-        titleLabel.numberOfLines = 1
-        titleLabel.adjustsFontSizeToFitWidth = true
-        titleLabel.minimumScaleFactor = 0.5
+        titleLabel.numberOfLines = 0
         
         subtitleLabel.text = action.text
         subtitleLabel.textColor = self.tintColor


### PR DESCRIPTION
Fixes #2327 - Different font sizes in same tab menu - non English locales

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-29 at 12 13 59](https://user-images.githubusercontent.com/46751540/135259517-350553e4-d020-464f-aedc-0b26d35cbb74.png)


