### PR TITLE
Fixes #2508 - Update the shavar lists to 93.0

### DIFF
--- a/checkout.sh
+++ b/checkout.sh
@@ -4,8 +4,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -x
+
 git clone https://github.com/mozilla-services/shavar-prod-lists.git || exit 1
 
-(cd shavar-prod-lists && git checkout -q 93.0)
+# Grab the las known (pinned) commit on the 93.0 branch
+(cd shavar-prod-lists && git checkout -q 352f772269f13e70893d0d112d26aed1f079ce6e)
 
 (cd content-blocker-lib-ios/ContentBlockerGen && swift run)

--- a/checkout.sh
+++ b/checkout.sh
@@ -6,7 +6,6 @@
 
 git clone https://github.com/mozilla-services/shavar-prod-lists.git || exit 1
 
-# This revision is taken from the original Cartfile.resolved
-(cd shavar-prod-lists && git checkout -q 3910527004252af3aa9dd701566a2cb3b78e5c3a)
+(cd shavar-prod-lists && git checkout -q 93.0)
 
 (cd content-blocker-lib-ios/ContentBlockerGen && swift run)


### PR DESCRIPTION
This patch takes the lists from the 93.0 branch from https://github.com/mozilla-services/shavar-prod-lists 