### PR TITLE
Fixes #2513 - Create a tool to more easily change the app version

### DIFF
--- a/tools/set-version.sh
+++ b/tools/set-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]; then
+  echo "usage: set-version.sh <version-number>"
+  exit 1
+fi
+
+
+for plist in Blockzilla/Info.plist ContentBlocker/Info.plist FocusIntentExtension/Info.plist OpenInFocus/Info.plist; do
+  current=`/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$plist"`
+  echo "Changing CFBundleShortVersionString in $plist from $current to $1"
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $1" "$plist"
+done
+
+


### PR DESCRIPTION
This introduces `tools/set-version.sh` which can be used like this:

```
$ tools/set-version.sh 38.2
Changing CFBundleShortVersionString in Blockzilla/Info.plist from 9000 to 38.2
Changing CFBundleShortVersionString in ContentBlocker/Info.plist from 9000 to 38.2
Changing CFBundleShortVersionString in FocusIntentExtension/Info.plist from 9000 to 38.2
Changing CFBundleShortVersionString in OpenInFocus/Info.plist from 9000 to 38.2
```
