### PR TITLE
Fixes #2051 - Remove unused LSApplicationQueriesSchemes from Info.plist

### DIFF
--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -37,13 +37,6 @@
 	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>org-appextension-feature-password-management</string>
-		<string>googlechromes</string>
-		<string>googlechrome</string>
-		<string>firefox</string>
-	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -37,6 +37,12 @@
 	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlechromes</string>
+		<string>googlechrome</string>
+		<string>firefox</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Closes #2051 .

## Commit Message
Fixes #2051 - Remove unused LSApplicationQueriesSchemes from Info.plist