### PR TITLE
Fixes #2507 - toggling tracking protection (only) from settings not working

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -553,6 +553,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         case .privacy:
             if indexPath.row == 0 {
                 let trackingProtectionVC = TrackingProtectionViewController()
+                trackingProtectionVC.delegate = presentingViewController as? BrowserViewController
                 navigationController?.pushViewController(trackingProtectionVC, animated: true)
             }
         case .search:


### PR DESCRIPTION
Fixes #2507 - toggling tracking protection (only) from settings not working