### PR TITLE
Fixes #1993 - Move Nimbus settings into Info.plist at CI build time

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		F85F7A292655AD5800395515 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A282655AD5800395515 /* SnapKit */; };
 		F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2A2655AD5800395515 /* Fuzi */; };
 		F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2E2655AD5800395515 /* Telemetry */; };
+		F88A4DF9270B455900100530 /* NimbusExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88A4DF8270B455900100530 /* NimbusExtensions.swift */; };
 		F8DE0EC826CC887800A31419 /* SupportUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DE0EC726CC887800A31419 /* SupportUtilsTest.swift */; };
 		F8DE0EC926CC88B200A31419 /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB131DC939FF00DA5651 /* SupportUtils.swift */; };
 		F8DE0ECA26CC88FF00A31419 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35C11461E04AADA005FFFEF /* AppConfig.swift */; };
@@ -946,6 +947,7 @@
 		F8820C7C26E19B4E006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F8820C7D26E19B4E006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F8820C7E26E19B4E006AB3B8 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F88A4DF8270B455900100530 /* NimbusExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusExtensions.swift; sourceTree = "<group>"; };
 		F8CE542D26C169B3000A5F9C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/Intro.strings; sourceTree = "<group>"; };
 		F8CE542E26C169B3000A5F9C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/Intents.strings; sourceTree = "<group>"; };
 		F8CE542F26C169B4000A5F9C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1327,6 +1329,7 @@
 				D364DC251DC4163700562991 /* BrowserToolset.swift */,
 				D3E2C8E91D9F0E6200DEBE3D /* BrowserViewController.swift */,
 				D3E2C96C1DA3077400DEBE3D /* CharacterSetExtensions.swift */,
+				F88A4DF8270B455900100530 /* NimbusExtensions.swift */,
 				D35A0E011E26C94F00297884 /* ClosedRangeExtensions.swift */,
 				D5ABA3D71FCC846800D5C060 /* AddCustomDomainViewController.swift */,
 				C8415DB226E9FA38008BAAA2 /* UIApplication+Orientation.swift */,
@@ -1954,6 +1957,7 @@
 				31421EB12176492A0015F48B /* TitleActivityItemProvider.swift in Sources */,
 				E4BF2E111BAD8AC500DA9D68 /* Settings.swift in Sources */,
 				C8A9FE0A26E7A63F00A9C72B /* UserDefault.swift in Sources */,
+				F88A4DF9270B455900100530 /* NimbusExtensions.swift in Sources */,
 				D3E54FDE1DF0E0D7003E1AFF /* UIImageExtensions.swift in Sources */,
 				16D716A5211503CD000C8A66 /* PageActionSheetItems.swift in Sources */,
 				D597608C1F9FEFB300A2D212 /* TrackingProtection.swift in Sources */,

--- a/Blockzilla/NimbusExtensions.swift
+++ b/Blockzilla/NimbusExtensions.swift
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Nimbus
+
+let NimbusServerURLKey = "NimbusServerURL"
+let NimbusAppNameKey = "NimbusAppName"
+let NimbusAppChannelKey = "NimbusAppChannel"
+
+extension NimbusServerSettings {
+    /// Create a `NimbusServerSettings` instance by looking up the server URL from the `Info.plist`.
+    /// - Returns: <#description#>
+    static func createFromInfoDictionary() -> NimbusServerSettings? {
+        guard let serverURLString = Bundle.main.object(forInfoDictionaryKey: NimbusServerURLKey) as? String, let serverURL = URL(string: serverURLString) else {
+            return nil
+        }
+        return NimbusServerSettings(url: serverURL)
+    }
+}
+
+extension NimbusAppSettings {
+    /// <#Description#>
+    /// - Returns: <#description#>
+    static func createFromInfoDictionary() -> NimbusAppSettings? {
+        guard let appName = Bundle.main.object(forInfoDictionaryKey: NimbusAppNameKey) as? String, let channel = Bundle.main.object(forInfoDictionaryKey: NimbusAppChannelKey) as? String else {
+            return nil
+        }
+        return NimbusAppSettings(appName: appName, channel: channel)
+    }
+}

--- a/Blockzilla/NimbusExtensions.swift
+++ b/Blockzilla/NimbusExtensions.swift
@@ -9,8 +9,9 @@ let NimbusAppNameKey = "NimbusAppName"
 let NimbusAppChannelKey = "NimbusAppChannel"
 
 extension NimbusServerSettings {
-    /// Create a `NimbusServerSettings` instance by looking up the server URL from the `Info.plist`.
-    /// - Returns: <#description#>
+    /// Create a `NimbusServerSettings` struct by looking up the server URL in the `Info.plist`. If the value is missing
+    /// from the `Info.plist`, or if it failes to parse as a valid URL, then `nil` is returned.
+    /// - Returns: NimbusServerSettings
     static func createFromInfoDictionary() -> NimbusServerSettings? {
         guard let serverURLString = Bundle.main.object(forInfoDictionaryKey: NimbusServerURLKey) as? String, let serverURL = URL(string: serverURLString) else {
             return nil
@@ -20,8 +21,9 @@ extension NimbusServerSettings {
 }
 
 extension NimbusAppSettings {
-    /// <#Description#>
-    /// - Returns: <#description#>
+    /// Create a `NimbusAsppSettings` struct by looking up the application name and channel in the `Info.plist`. If the values are missing
+    /// from the `Info.plist` or if they fail to parse, then `nil` is returned.
+    /// - Returns: NimbusAppSettings
     static func createFromInfoDictionary() -> NimbusAppSettings? {
         guard let appName = Bundle.main.object(forInfoDictionaryKey: NimbusAppNameKey) as? String, let channel = Bundle.main.object(forInfoDictionaryKey: NimbusAppChannelKey) as? String else {
             return nil

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -60,6 +60,18 @@ workflows:
         stack: osx-xcode-13.0.x
     before_run: []
 
+  configure-nimbus:
+    steps:
+    - script@1:
+        title: Set Nimbus Options
+        input:
+        - content: |-
+            #!/usr/bin/env bash
+            set -x
+            /usr/libexec/PlistBuddy -c "Add :NimbusServerURL string $NIMBUS_SERVER_URL" Blockzilla/Info.plist
+            /usr/libexec/PlistBuddy -c "Add :NimbusAppName string $NIMBUS_APP_NAME" Blockzilla/Info.plist
+            /usr/libexec/PlistBuddy -c "Add :NimbusAppChannel string $NIMBUS_APP_CHANNEL" Blockzilla/Info.plist
+
 
   set-default-browser-entitlement:
     steps:
@@ -109,6 +121,7 @@ workflows:
       - clone-and-build-dependencies
       - set-project-version
       - set-default-browser-entitlement
+      - configure-nimbus
 
 
   runParallelTests:


### PR DESCRIPTION
This patch moves Nimbus settings into `Info.plist`, which is configured in CI.

Note that none of those settings are secret - our goal is not to hide them but instead to make sure a checkout of the project does not contain these values. So that forks and derivative works don't use the Mozilla specific services or experimentation in this case.

I also refactored the code in general a bit.