### PR TITLE
Fixes #2192 prevent crash when delete a swipe typed url with completion.

### DIFF
--- a/Blockzilla/AutocompleteTextField.swift
+++ b/Blockzilla/AutocompleteTextField.swift
@@ -46,6 +46,15 @@ open class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         lastReplacement = string
+
+        // Fixes: https://github.com/mozilla-mobile/focus-ios/issues/2192
+        // When swipe-typing + completionRange is present, and deletion causes
+        // incorrect internal text value. So we call deleteDackward() here.
+        if let completionRange = completionRange, string.isEmpty,
+           NSIntersectionRange(range, completionRange).length > 0 {
+            self.deleteBackward()
+            return false
+        }
         return true
     }
 
@@ -135,7 +144,9 @@ open class AutocompleteTextField: UITextField, UITextFieldDelegate {
         // Prevents the hard crash when you select all and start a new query
         guard let count = text?.count, count > 1 else { return }
 
-        text = (text as NSString?)?.replacingCharacters(in: completionRange, with: "")
+        if count >= completionRange.location + completionRange.length {
+            text = (text as NSString?)?.replacingCharacters(in: completionRange, with: "")
+        }
     }
 
     private func setCompletion(_ completion: String) {


### PR DESCRIPTION
This PR fixes #2192 .

The cause is found though some internal operations within iOS remain unclear.

When swipe typing a word with URL completion, the internal `UITextField.text` become something unexpected. The crash happens inside `removeCompletion()` that tries to replace this unexpected string content.

Example:

* swipe type word "yahoo" 
* then we got `yahoo[.com/]`
  * at this moment completion range is loc5, length5
* when user tap "backspace"
* `public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool` is called first
  * The deletion range is loc9, length1. If this value is correct the result value should be `yahoo.com`
  * if returning "true" in `shouldChange` function (as before this fix), the internal text becomes `yahoo.` which doesn't follow the parameters passed in `shouldChange` function. true reason of string value change is unknown yet.
* after `shouldChange` function, `deleteBackward` and `removeCompletion` have incorrect data that causes crash.

A detection of invalid length is added in `removeCompletion`. Furthermore, a detection of deletion within completion range is also added inside `shouldChange` function.