### PR TITLE
Fixes #2535 - On Home screen, wrong icon is displayed after tracking protection is toggled off

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -57,7 +57,7 @@ class BrowserViewController: UIViewController {
 
     private var trackingProtectionStatus: TrackingProtectionStatus = .on(TPPageStats()) {
         didSet {
-            urlBar.updateTrackingProtectionBadge(trackingStatus: trackingProtectionStatus, secureConnection: self.webViewController.connectionIsSecure)
+            urlBar.updateTrackingProtectionBadge(trackingStatus: trackingProtectionStatus, shouldDisplayShieldIcon:  urlBar.inBrowsingMode ? self.webViewController.connectionIsSecure : true )
         }
     }
 

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -793,9 +793,9 @@ class URLBar: UIView {
         self.layoutIfNeeded()
     }
 
-    func updateTrackingProtectionBadge(trackingStatus: TrackingProtectionStatus, secureConnection: Bool) {
-        shieldIcon.updateState(trackingStatus: trackingStatus, secureConnection: secureConnection)
-        collapsedTrackingProtectionBadge.updateState(trackingStatus: trackingStatus, secureConnection: secureConnection)
+    func updateTrackingProtectionBadge(trackingStatus: TrackingProtectionStatus, shouldDisplayShieldIcon: Bool) {
+        shieldIcon.updateState(trackingStatus: trackingStatus, shouldDisplayShieldIcon: shouldDisplayShieldIcon)
+        collapsedTrackingProtectionBadge.updateState(trackingStatus: trackingStatus, shouldDisplayShieldIcon: shouldDisplayShieldIcon)
     }
 }
 
@@ -968,8 +968,8 @@ class TrackingProtectionBadge: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func updateState(trackingStatus: TrackingProtectionStatus, secureConnection: Bool) {
-        guard secureConnection else {
+    func updateState(trackingStatus: TrackingProtectionStatus, shouldDisplayShieldIcon: Bool) {
+        guard shouldDisplayShieldIcon else {
             trackingProtectionOn.alpha = 0
             trackingProtectionOff.alpha = 0
             connectionNotSecure.alpha = 1
@@ -1014,8 +1014,8 @@ class CollapsedTrackingProtectionBadge: TrackingProtectionBadge {
         }
     }
 
-    override func updateState(trackingStatus: TrackingProtectionStatus, secureConnection: Bool) {
-        guard secureConnection else {
+    override func updateState(trackingStatus: TrackingProtectionStatus, shouldDisplayShieldIcon: Bool) {
+        guard shouldDisplayShieldIcon else {
             trackingProtectionOn.alpha = 0
             trackingProtectionOff.alpha = 0
             connectionNotSecure.alpha = 1


### PR DESCRIPTION
Fixes #2535 - On Home screen, wrong icon is displayed after tracking protection is toggled off

Now on home screen will appear only the shield icon (on or off depending on tracking protection state)