### PR TITLE
Fixes #2495 - The URL long press context menu is not displayed after steps

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -739,6 +739,8 @@ class URLBar: UIView {
     @objc private func displayURLContextMenu(sender: UILongPressGestureRecognizer) {
         if sender.state == .began {
             delegate?.urlBarDidLongPress(self)
+            self.isUserInteractionEnabled = true
+            self.becomeFirstResponder()
             UIMenuController.shared.showMenu(from: self, rect: self.bounds)
         }
     }


### PR DESCRIPTION
Fixes #2495 - The URL long press context menu is not displayed after steps