### PR TITLE
Fixes #2545 - Reset Nimbus when data sharing options are changed

### DIFF
--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -658,6 +658,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             Telemetry.default.configuration.isCollectionEnabled = sender.isOn
             Telemetry.default.configuration.isUploadEnabled = sender.isOn
             Glean.shared.setUploadEnabled(sender.isOn)
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                appDelegate.nimbusApi?.resetTelemetryIdentifiers()
+            }
         } else if toggle.setting == .biometricLogin {
             TipManager.biometricTip = false
         }


### PR DESCRIPTION
This patch calls `resetTelemetryIdentifiers()` when the _Send Anonymous Usage Data_ setting is toggled. We don't have a fancy `Experiments` wrapper yet like Firefox has. So we just get to nimbus through the `AppDelegate` now. 