### PR TITLE
Updates rust-components-swift to 0.0.6

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -5360,7 +5360,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.4;
+				minimumVersion = 0.0.6;
 			};
 		};
 		F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {


### PR DESCRIPTION
Updates rust-components-swift to 0.0.6, which includes a glean update (42.0.1) that needs to be tested


cc: @badboy and @travis79 