### PR TITLE
Fixes #2575 - Action cells don't have selectable state

### DIFF
--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -71,11 +71,7 @@ class AboutViewController: UIViewController, UITableViewDataSource, UITableViewD
         }
 
         cell.backgroundColor = .secondarySystemGroupedBackground
-
-        let cellBG = UIView()
-        cellBG.backgroundColor = .secondarySystemGroupedBackground
-        cell.selectedBackgroundView = cellBG
-
+        cell.selectionStyle = .gray
         cell.textLabel?.textColor = .primaryText
         cell.layoutMargins = UIEdgeInsets.zero
     }

--- a/Blockzilla/AutocompleteCustomUrlViewController.swift
+++ b/Blockzilla/AutocompleteCustomUrlViewController.swift
@@ -101,10 +101,7 @@ extension AutocompleteCustomUrlViewController: UITableViewDataSource {
             cell.textLabel?.text = UIConstants.strings.autocompleteAddCustomUrlWithPlus
             cell.accessoryType = .disclosureIndicator
             cell.accessibilityIdentifier = "addCustomDomainCell"
-
-            let backgroundColorView = UIView()
-
-            cell.selectedBackgroundView = backgroundColorView
+            cell.selectionStyle = .gray
             addDomainCell = cell
         } else {
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "domainCell")

--- a/Blockzilla/SearchSettingsViewController.swift
+++ b/Blockzilla/SearchSettingsViewController.swift
@@ -87,7 +87,7 @@ class SearchSettingsViewController: UIViewController, UITableViewDelegate, UITab
             cell.textLabel?.text = UIConstants.strings.AddSearchEngineButton
             cell.textLabel?.textColor = .primaryText
             cell.accessibilityIdentifier = "addSearchEngine"
-            cell.selectedBackgroundView = getBackgroundView()
+            cell.selectionStyle = .gray
             return cell
         } else if indexPath.section == 1 && indexPath.row == 0 {
             let cell = UITableViewCell(style: .default, reuseIdentifier: "restoreDefaultEngines")
@@ -96,11 +96,10 @@ class SearchSettingsViewController: UIViewController, UITableViewDelegate, UITab
             cell.textLabel?.numberOfLines = 0
             cell.textLabel?.lineBreakMode = .byWordWrapping
             cell.accessibilityIdentifier = "restoreDefaults"
-            cell.selectedBackgroundView = getBackgroundView()
 
             if searchEngineManager.hasDisabledDefaultEngine() {
                 cell.textLabel?.textColor = .primaryText
-                cell.selectionStyle = .default
+                cell.selectionStyle = .gray
                 cell.isUserInteractionEnabled = true
             } else {
                 cell.textLabel?.textColor = UIConstants.colors.settingsDisabled
@@ -115,7 +114,7 @@ class SearchSettingsViewController: UIViewController, UITableViewDelegate, UITab
             cell.textLabel?.text = engine.name
             cell.textLabel?.textColor = .primaryText
             cell.imageView?.image = engine.image?.createScaled(size: CGSize(width: 24, height: 24))
-            cell.selectedBackgroundView = getBackgroundView()
+            cell.selectionStyle = .gray
             cell.accessibilityIdentifier = engine.name
 
             if tableView.isEditing {

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -13,10 +13,7 @@ import Glean
 class SettingsTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-
-        let backgroundColorView = UIView()
-        backgroundColorView.backgroundColor = UIConstants.colors.cellSelected
-        selectedBackgroundView = backgroundColorView
+        selectionStyle = .gray
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Since selectable state was present for dark mode and for light mode, but on light the selection was not visible, I changed the selection style to .gray as is implemented on iPhone native settings.

This change was applied to Search Engine screen (here the selection before was not visible even if was dark mode), Settings Screen, About Screen (the selection color was black before for dark mode) and Autocomplete custom URL screen, where also the selectable state was implemented, but was not visible because it had the same color as the cell.

Demo:

https://user-images.githubusercontent.com/46751540/138297103-19b950fc-90f9-4130-8c29-49617be90335.mp4



