### PR TITLE
Fixes #2660 - Find in Page textfield background should be themed

### DIFF
--- a/Blockzilla/FindInPageBar.swift
+++ b/Blockzilla/FindInPageBar.swift
@@ -68,6 +68,7 @@ class FindInPageBar: UIView {
 
         searchText.addTarget(self, action: #selector(didTextChange), for: .editingChanged)
         searchText.textColor = FindInPageUX.SearchTextColor
+        searchText.tintColor = FindInPageUX.SearchTextColor
         searchText.font = FindInPageUX.SearchTextFont
         searchText.autocapitalizationType = .none
         searchText.autocorrectionType = .no


### PR DESCRIPTION
Fixes #2660 - Find in Page textfield background should be themed




![Simulator Screen Shot - iPhone 13 Pro - 2021-10-25 at 14 29 02](https://user-images.githubusercontent.com/46751540/138687383-d2db3733-e09f-49c2-9b3c-eed2b87aa1fc.png)

![Simulator Screen Shot - iPhone 13 Pro - 2021-10-25 at 14 26 50](https://user-images.githubusercontent.com/46751540/138687225-f4931d3b-922e-4a5f-9820-0c3d490d5dea.png)

