### PR TITLE
Fixes #2650 - The selector should have a lighter color when tapping on Settings button

### DIFF
--- a/Blockzilla/PhotonActionSheet.swift
+++ b/Blockzilla/PhotonActionSheet.swift
@@ -245,7 +245,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
 
     func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
         let cell  = tableView.cellForRow(at: indexPath)
-        cell?.contentView.backgroundColor = PhotonActionSheetCellUX.SelectedOverlayColor
+        cell?.contentView.backgroundColor = .systemGray4
     }
 
     func tableView(_ tableView: UITableView, didUnhighlightRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Fixes #2650 - The selector should have a lighter color when tapping on Settings button

![Simulator Screen Shot - iPhone 11 - 2021-10-26 at 12 53 09](https://user-images.githubusercontent.com/47420700/138855116-0e386126-3148-4a4e-91a7-c240554df879.png)


