### PR TITLE
For #2736 - XCUITests fix searchProvider tests

### DIFF
--- a/FullFunctionalTests.xctestplan
+++ b/FullFunctionalTests.xctestplan
@@ -28,6 +28,7 @@
         "OnboardingTest",
         "PastenGoTest\/testPastenGo()",
         "SettingAppearanceTest\/testCheckSetting()",
+        "SettingAppearanceTest\/testSafariIntegration()",
         "TrackingProtectionMenu\/testActiveProtectionSidebar()",
         "TrackingProtectionMenu\/testProtectionSidebar()",
         "WebsiteAccessTests\/testVisitWebsite()"

--- a/XCUITest/SearchProviderTest.swift
+++ b/XCUITest/SearchProviderTest.swift
@@ -99,8 +99,7 @@ class SearchProviderTest: BaseTestCase {
 		app.tables.cells["SettingsViewController.searchCell"].tap()
         waitForExistence(app.tables.staticTexts[provider], timeout: 5)
 		app.tables.staticTexts[provider].tap()
-		app.navigationBars.buttons.element(boundBy: 0).tap()
-
+        app.buttons["Done"].tap()
 	}
 
 	private func doSearch(searchWord: String, provider: String) {

--- a/XCUITest/WebsiteAccessTest.swift
+++ b/XCUITest/WebsiteAccessTest.swift
@@ -48,7 +48,7 @@ class WebsiteAccessTests: BaseTestCase {
         toggle.tap()
 
         app.navigationBars.buttons.element(boundBy: 0).tap()
-        app.navigationBars.buttons.element(boundBy: 0).tap()
+        app.navigationBars.buttons.element(boundBy: 1).tap()
 
         let searchOrEnterAddressTextField = app.textFields["URLBar.urlText"]
 
@@ -69,7 +69,7 @@ class WebsiteAccessTests: BaseTestCase {
         toggle.tap()
 
         app.navigationBars.buttons.element(boundBy: 0).tap()
-        app.navigationBars.buttons.element(boundBy: 0).tap()
+        app.navigationBars.buttons.element(boundBy: 1).tap()
 
         searchOrEnterAddressTextField.tap()
         searchOrEnterAddressTextField.typeText("mozilla")
@@ -95,7 +95,7 @@ class WebsiteAccessTests: BaseTestCase {
 
         app.navigationBars.buttons.element(boundBy: 0).tap()
         app.navigationBars.buttons.element(boundBy: 0).tap()
-        app.navigationBars.buttons.element(boundBy: 0).tap()
+        app.navigationBars.buttons.element(boundBy: 1).tap()
 
         // Test auto completing the domain
         let searchOrEnterAddressTextField = app.textFields["URLBar.urlText"]


### PR DESCRIPTION
Fixes #2736 by selecting the Done button as tests were clicking on the gift icon instead and were not able to close settings view