### PR TITLE
Fixes #2697 - The keyboard is dismissed after loading a page and tapping on the URL bar

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1081,6 +1081,7 @@ extension BrowserViewController: URLBarDelegate {
         toggleURLBarBackground(isBright: !webViewController.isLoading)
         shortcutsContainer.isHidden = urlBar.inBrowsingMode
         shortcutsBackground.isHidden = true
+        webViewController.focus()
     }
 
     func urlBarDidFocus(_ urlBar: URLBar) {
@@ -1541,7 +1542,6 @@ extension BrowserViewController: WebControllerDelegate {
         toggleToolbarBackground()
         toggleURLBarBackground(isBright: !urlBar.isEditing)
         urlBar.progressBar.hideProgressBar()
-        webViewController.focus()
         GleanMetrics.Browser.totalUriCount.add()
     }
 


### PR DESCRIPTION
Fixes #2697 - The keyboard is dismissed after loading a page and tapping on the URL bar