### PR TITLE
Fixes #2731 After using cmd+L on hardware keyboard to focus the URL bar, the search suggestion frame is displayed.

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -835,8 +835,9 @@ class BrowserViewController: UIViewController {
     @objc private func selectLocationBar() {
         showToolbars()
         urlBar.activateTextField()
-        shortcutsContainer.isHidden = false
-        shortcutsBackground.isHidden = !urlBar.inBrowsingMode
+        let shouldShowShortcuts = shortcutManager.numberOfShortcuts != 0
+        shortcutsContainer.isHidden = !shouldShowShortcuts
+        shortcutsBackground.isHidden = !shouldShowShortcuts || !urlBar.inBrowsingMode
     }
 
     @objc private func reload() {


### PR DESCRIPTION
## Commit message
Fixes #2731 After using cmd+L on hardware keyboard to focus the URL bar, the search suggestion frame is displayed.