### PR TITLE
Fixes #2732 - [Dark Theme]The radio buttons color flashes when opening the tracking protection menu

### DIFF
--- a/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -252,12 +252,6 @@ class TrackingProtectionViewController: UIViewController {
         }
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        calculatePreferredSize()
-        view.layoutIfNeeded()
-    }
-    
     private func calculatePreferredSize() {
         guard state != .settings else { return }
         
@@ -271,6 +265,11 @@ class TrackingProtectionViewController: UIViewController {
                 height: tableView.contentSize.height + (headerHeight?.layoutConstraints[0].constant ?? .zero)
             )
         }
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        calculatePreferredSize()
     }
     
     @objc private func doneTapped() {

--- a/Blockzilla/Tracking Protection/Views/ImageCell.swift
+++ b/Blockzilla/Tracking Protection/Views/ImageCell.swift
@@ -12,6 +12,7 @@ class ImageCell: UITableViewCell {
         textLabel?.text = title
         textLabel?.textColor = .primaryText
         textLabel?.numberOfLines = 0
+        backgroundColor = .secondarySystemGroupedBackground
         selectionStyle = .none
     }
     

--- a/Blockzilla/Tracking Protection/Views/SubtitleCell.swift
+++ b/Blockzilla/Tracking Protection/Views/SubtitleCell.swift
@@ -15,6 +15,7 @@ class SubtitleCell: UITableViewCell {
         detailTextLabel?.text = subtitle
         detailTextLabel?.textColor = .primaryText
         detailTextLabel?.font = UIConstants.fonts.trackingProtectionStatsDetail
+        backgroundColor = .secondarySystemGroupedBackground
         selectionStyle = .none
     }
     

--- a/Blockzilla/Tracking Protection/Views/SwitchTableViewCell.swift
+++ b/Blockzilla/Tracking Protection/Views/SwitchTableViewCell.swift
@@ -30,6 +30,7 @@ class SwitchTableViewCell: UITableViewCell {
         textLabel?.textColor = .primaryText
         textLabel?.numberOfLines = 0
         accessoryView = PaddedSwitch(switchView: toggle)
+        backgroundColor = .secondarySystemGroupedBackground
         selectionStyle = .none
     }
     


### PR DESCRIPTION
Fixes #2732 - [Dark Theme]The radio buttons color flashes when opening the tracking protection menu