### PR TITLE
Fixes #2777 Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value ()

### DIFF
--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -282,7 +282,7 @@ extension WebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         delegate?.webControllerDidStartNavigation(self)
         if case .on = trackingProtectionStatus { trackingInformation = TPPageStats() }
-        currentContentMode = navigation.effectiveContentMode
+        currentContentMode = navigation?.effectiveContentMode
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {


### PR DESCRIPTION
Access navigation as Optional.

## Commit message
Fixes #2777 Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value ()