### PR TITLE
Fixes #2484 Home screen tips that are not actionable should be renderered differently

### DIFF
--- a/Blockzilla/NimbusWrapper.swift
+++ b/Blockzilla/NimbusWrapper.swift
@@ -59,4 +59,6 @@ class NimbusWrapper {
         self.nimbus?.applyPendingExperiments()
         self.nimbus?.fetchExperiments()
     }
+    
+    var shouldHaveBoldTitle: Bool { nimbus?.getVariables(featureId: .nimbusValidation).getBool("bold-tip-title") == true }
 }

--- a/Blockzilla/Pro Tips/TipViewController.swift
+++ b/Blockzilla/Pro Tips/TipViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class TipViewController: UIViewController {
     
-    // Mark depency explicit
+    // Mark dependency explicit
     private let nimbus = NimbusWrapper.shared
     
     private lazy var tipTitleLabel: UILabel = {

--- a/Blockzilla/Pro Tips/TipViewController.swift
+++ b/Blockzilla/Pro Tips/TipViewController.swift
@@ -6,10 +6,13 @@ import UIKit
 
 class TipViewController: UIViewController {
     
+    // Mark depency explicit
+    private let nimbus = NimbusWrapper.shared
+    
     private lazy var tipTitleLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .secondaryText
-        label.font = UIConstants.fonts.shareTrackerStatsLabel
+        label.textColor = .secondaryLabel
+        label.font = nimbus.shouldHaveBoldTitle == true ? UIConstants.fonts.tipTitleBold : UIConstants.fonts.tipTitleMedium
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
@@ -18,7 +21,7 @@ class TipViewController: UIViewController {
     private lazy var tipDescriptionButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitleColor(.accent, for: .normal)
-        button.setTitleColor(.accent, for: .highlighted)
+        button.setTitleColor(.secondaryLabel, for: .disabled)
         button.titleLabel?.font = UIConstants.fonts.shareTrackerStatsLabel
         button.titleLabel?.textAlignment = .center
         button.titleLabel?.numberOfLines = 0
@@ -60,12 +63,6 @@ class TipViewController: UIViewController {
         view.addGestureRecognizer(tap)
         
         tipTitleLabel.text = tip.title
-        
-        if let variables = NimbusWrapper.shared.nimbus?.getVariables(featureId: .nimbusValidation), variables.getBool("bold-tip-title") == true {
-            tipTitleLabel.font = UIConstants.fonts.shareTrackerStatsLabelBold
-        } else {
-            tipTitleLabel.font = UIConstants.fonts.shareTrackerStatsLabel
-        }
         
         tipDescriptionButton.setTitle(tip.description, for: .normal)
         tipDescriptionButton.addTarget(self, action: #selector(tapTip), for: .touchUpInside)

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -160,6 +160,8 @@ struct UIConstants {
         static let trackingProtectionHeader = UIFont.systemFont(ofSize: 15, weight: .regular)
         static let trackingProtectionStatsText = UIFont.systemFont(ofSize: 15)
         static let trackingProtectionStatsDetail = UIFont.systemFont(ofSize: 20)
+        static let tipTitleMedium = UIFont.systemFont(ofSize: 14, weight: .medium)
+        static let tipTitleBold = UIFont.systemFont(ofSize: 14, weight: .bold)
     }
 
     struct layout {


### PR DESCRIPTION
| Dark  | Light |
| ------------- | ------------- |
| ![Firefox Focus](https://user-images.githubusercontent.com/26011662/140921758-0b3cdc71-ba52-4b06-ade1-496317ab1bdf.PNG)  | ![Firefox Focus](https://user-images.githubusercontent.com/26011662/140921897-6c44b913-a7de-4b87-aca2-3786ee50edd1.PNG)  |
| ![Firefox Focus](https://user-images.githubusercontent.com/26011662/140921780-bc22173c-fae4-47b7-8b55-82652b07172b.PNG)  | ![Firefox Focus](https://user-images.githubusercontent.com/26011662/140921875-a5c58710-ac08-48cb-becc-975c3cb1030c.PNG) |













## Commit message
Fixes #2484 Home screen tips that are not actionable should be renderered differently