### PR TITLE
Fixes #2797 - Create a test build with the version set to 95.0

### DIFF
--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>95.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ContentBlocker/Info.plist
+++ b/ContentBlocker/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>95.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FocusIntentExtension/Info.plist
+++ b/FocusIntentExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>95.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/OpenInFocus/Info.plist
+++ b/OpenInFocus/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>95.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
This patch only sets the app version to 95.0 for testing purposes. This is not supposed to land, it is just to have a branch we can build for testing.