### PR TITLE
Fixes #1871 - Implement search telemetry with Glean

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -209,6 +209,8 @@
 		F7FF8B5B2194084000CCA80F /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FF8B5A2194084000CCA80F /* UIDeviceExtensions.swift */; };
 		F805722F1DBEE504004339C1 /* WebCacheUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F805722E1DBEE504004339C1 /* WebCacheUtils.swift */; };
 		F81DF84F2653477F00C83C61 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81DF84E2653477F00C83C61 /* AutocompleteTextField.swift */; };
+		F827EA412742F01300F21E12 /* Ads.js in Resources */ = {isa = PBXBuildFile; fileRef = F827EA402742F01300F21E12 /* Ads.js */; };
+		F827EA432742F93600F21E12 /* SearchProviderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F827EA422742F93600F21E12 /* SearchProviderModel.swift */; };
 		F8324CE4264EA223007E4BFA /* gpl.html in Resources */ = {isa = PBXBuildFile; fileRef = F8324CDF264EA223007E4BFA /* gpl.html */; };
 		F8324CE5264EA223007E4BFA /* licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE0264EA223007E4BFA /* licenses.html */; };
 		F8324CE6264EA223007E4BFA /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE1264EA223007E4BFA /* style.css */; };
@@ -985,6 +987,8 @@
 		F7FF8B5A2194084000CCA80F /* UIDeviceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtensions.swift; sourceTree = "<group>"; };
 		F805722E1DBEE504004339C1 /* WebCacheUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebCacheUtils.swift; sourceTree = "<group>"; };
 		F81DF84E2653477F00C83C61 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
+		F827EA402742F01300F21E12 /* Ads.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = Ads.js; sourceTree = "<group>"; };
+		F827EA422742F93600F21E12 /* SearchProviderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchProviderModel.swift; sourceTree = "<group>"; };
 		F8324CDF264EA223007E4BFA /* gpl.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = gpl.html; sourceTree = "<group>"; };
 		F8324CE0264EA223007E4BFA /* licenses.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = licenses.html; sourceTree = "<group>"; };
 		F8324CE1264EA223007E4BFA /* style.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = style.css; sourceTree = "<group>"; };
@@ -1452,6 +1456,8 @@
 				B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */,
 				1D3BEDF820C5E6C70019B722 /* FindInPage.js */,
 				C83FB7D1273AA13200B78CC5 /* MetadataHelper.js */,
+				F827EA402742F01300F21E12 /* Ads.js */,
+				F827EA422742F93600F21E12 /* SearchProviderModel.swift */,
 				1D3BEDFA20C5E76A0019B722 /* FindInPageBar.swift */,
 				846A23172668CC4500DB3C37 /* FullScreen.js */,
 				747ADA171FC38EFC00970132 /* IntroViewController.swift */,
@@ -1942,6 +1948,7 @@
 				B3D23BEF1FA3A9E500D9C50F /* postload.js in Resources */,
 				F8324CE7264EA223007E4BFA /* rights-focus.html in Resources */,
 				D50939A91FBF807A005D4316 /* Settings.bundle in Resources */,
+				F827EA412742F01300F21E12 /* Ads.js in Resources */,
 				F8324CE4264EA223007E4BFA /* gpl.html in Resources */,
 				D3E54FD51DEFB25B003E1AFF /* SearchPlugins in Resources */,
 				D3E2C8FF1D9F17AC00DEBE3D /* web-fonts.json in Resources */,
@@ -2086,6 +2093,7 @@
 			files = (
 				D0967A811EC50002009D937F /* TelemetryIntegration.swift in Sources */,
 				C89AA96E271720330089838F /* ThemeTableViewToggleCell.swift in Sources */,
+				F827EA432742F93600F21E12 /* SearchProviderModel.swift in Sources */,
 				C8337DE22710893700093D42 /* UIImage+AppImages.swift in Sources */,
 				C8337DF82710898800093D42 /* TrackingProtectionDelegate.swift in Sources */,
 				16837EA62135EFCC000424BB /* TipManager.swift in Sources */,

--- a/Blockzilla/Ads.js
+++ b/Blockzilla/Ads.js
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+(function() {
+
+    /**
+     * Send
+     * - current URL
+     * - cookies of this page
+     * - all links found in this page
+     * to the native application.
+     */
+    function sendCurrentState() {
+        let message = {
+            'url': document.location.href,
+            'urls': getLinks(),
+            'cookies': getCookies()
+        };
+        
+        webkit.messageHandlers.adsMessageHandler.postMessage(message);
+    }
+
+    /**
+     * Get all links in the current page.
+     *
+     * @return {Array<string>} containing all current links in the current page.
+     */
+    function getLinks() {
+        let urls = [];
+
+        let anchors = document.getElementsByTagName("a");
+        for (let anchor of anchors) {
+            if (!anchor.href) {
+                continue;
+            }
+            urls.push(anchor.href);
+        }
+
+        return urls;
+    }
+
+    /**
+     * Get all cookies for the current document.
+     *
+     * @return {Array<{name: string, value: string}>} containing all cookies.
+     */
+    function getCookies() {
+        let cookiesList = document.cookie.split("; ");
+        let result = [];
+
+        cookiesList.forEach(cookie => {
+            var [name, ...value] = cookie.split('=');
+            // For that special cases where the value contains '='.
+            value = value.join("=")
+
+            result.push({
+                "name" : name,
+                "value" : value
+            });
+        });
+
+        return result;
+    }
+
+    // Whenever a page is first accessed or when loaded from cache
+    // send all needed data about the ads provider to the app.
+    const events = ["pageshow", "load"];
+    const eventLogger = event => {
+        switch (event.type) {
+        case "load":
+            sendCurrentState();
+            break;
+        case "pageshow":
+            if (event.persisted) {
+                sendCurrentState();
+            }
+            break;
+        default:
+            console.log('Event:', event.type);
+        }
+    };
+    
+    console.log("Installing handlers");
+    events.forEach(eventName => window.addEventListener(eventName, eventLogger));
+
+})();

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -389,7 +389,8 @@ extension AppDelegate {
         let defaultSearchEngineProvider = activeSearchEngine.isCustom ? "custom" : activeSearchEngine.name
         telemetryConfig.defaultSearchEngineProvider = defaultSearchEngineProvider
         
-        GleanMetrics.Search.defaultEngine.set(defaultSearchEngineProvider)
+        print(activeSearchEngine.isCustom ? "custom" : activeSearchEngine.id)
+        GleanMetrics.Search.defaultEngine.set(activeSearchEngine.isCustom ? "custom" : activeSearchEngine.id)
 
         telemetryConfig.measureUserDefaultsSetting(forKey: SearchEngineManager.prefKeyEngine, withDefaultValue: defaultSearchEngineProvider)
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockAds, withDefaultValue: Settings.getToggle(.blockAds))

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -388,6 +388,8 @@ extension AppDelegate {
         let activeSearchEngine = SearchEngineManager(prefs: UserDefaults.standard).activeEngine
         let defaultSearchEngineProvider = activeSearchEngine.isCustom ? "custom" : activeSearchEngine.name
         telemetryConfig.defaultSearchEngineProvider = defaultSearchEngineProvider
+        
+        GleanMetrics.Search.defaultEngine.set(defaultSearchEngineProvider)
 
         telemetryConfig.measureUserDefaultsSetting(forKey: SearchEngineManager.prefKeyEngine, withDefaultValue: defaultSearchEngineProvider)
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockAds, withDefaultValue: Settings.getToggle(.blockAds))

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -389,9 +389,6 @@ extension AppDelegate {
         let defaultSearchEngineProvider = activeSearchEngine.isCustom ? "custom" : activeSearchEngine.name
         telemetryConfig.defaultSearchEngineProvider = defaultSearchEngineProvider
         
-        print(activeSearchEngine.isCustom ? "custom" : activeSearchEngine.id)
-        GleanMetrics.Search.defaultEngine.set(activeSearchEngine.isCustom ? "custom" : activeSearchEngine.id)
-
         telemetryConfig.measureUserDefaultsSetting(forKey: SearchEngineManager.prefKeyEngine, withDefaultValue: defaultSearchEngineProvider)
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockAds, withDefaultValue: Settings.getToggle(.blockAds))
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockAnalytics, withDefaultValue: Settings.getToggle(.blockAnalytics))
@@ -434,6 +431,7 @@ extension AppDelegate {
         GleanMetrics.TrackingProtection.hasSocialBlocked.set(Settings.getToggle(.blockSocial))
         GleanMetrics.MozillaProducts.hasFirefoxInstalled.set(UIApplication.shared.canOpenURL(URL(string: "firefox://")!))
         GleanMetrics.Preferences.userTheme.set(UserDefaults.standard.theme.telemetryValue)
+        GleanMetrics.Browser.defaultSearchEngine.set(activeSearchEngine.id)
     }
         
     func setupExperimentation() {

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -708,6 +708,10 @@ class BrowserViewController: UIViewController {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
             url = searchEngineManager.activeEngine.urlForQuery(text)
+            
+            // Record this search in Telemetry
+            let id = searchEngineManager.activeEngine.isCustom ? "custom" : searchEngineManager.activeEngine.id
+            GleanMetrics.Search.counts["\(id).actionbar"].add()
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)
         }

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -707,13 +707,11 @@ class BrowserViewController: UIViewController {
         if url == nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            GleanMetrics.SearchBar.performedSearch.record(.init(engineName: searchEngineManager.activeEngine.id))
             url = searchEngineManager.activeEngine.urlForQuery(text)
-            
-            // Record this search in Telemetry
-            let id = searchEngineManager.activeEngine.isCustom ? "custom" : searchEngineManager.activeEngine.id
-            GleanMetrics.Search.counts["\(id).actionbar"].add()
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)
+            GleanMetrics.SearchBar.enteredUrl.record()
         }
         
         if let url = url {
@@ -1071,9 +1069,11 @@ extension BrowserViewController: URLBarDelegate {
         if url == nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            GleanMetrics.SearchBar.performedSearch.record(.init(engineName: searchEngineManager.activeEngine.id))
             url = searchEngineManager.activeEngine.urlForQuery(text)
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)
+            GleanMetrics.SearchBar.enteredUrl.record()
         }
         if let urlBarURL = url {
             submit(url: urlBarURL)
@@ -1454,6 +1454,7 @@ extension BrowserViewController: OverlayViewDelegate {
         if searchEngineManager.activeEngine.urlForQuery(query) != nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.selectQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            GleanMetrics.SearchBar.performedSearch.record(.init(engineName: searchEngineManager.activeEngine.id))
             urlBar(urlBar, didSubmitText: query)
         }
 
@@ -1492,9 +1493,11 @@ extension BrowserViewController: OverlayViewDelegate {
         if url == nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            GleanMetrics.SearchBar.performedSearch.record(.init(engineName: searchEngineManager.activeEngine.id))
             url = searchEngineManager.activeEngine.urlForQuery(text)
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)
+            GleanMetrics.SearchBar.enteredUrl.record()
         }
         if let overlayURL = url {
             submit(url: overlayURL)

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -378,11 +378,11 @@ extension WebViewController: WKNavigationDelegate {
             case .reload:
                 delegate?.webControllerDidReload(self)
             case .linkActivated:
-                
-                if let url = navigationAction.request.url {
-                    print("MOO URL Clicked is \(url.absoluteString)")
-                    if adsTelemetryUrlList.contains(url.absoluteString) && !adsProviderName.isEmpty{
-                        recordAdsClickedOnPage(providerName: adsProviderName)
+                if let url = navigationAction.request.url, adsTelemetryUrlList.count > 0 {
+                    if adsTelemetryUrlList.contains(url.absoluteString) {
+                        if !adsProviderName.isEmpty {
+                            GleanMetrics.BrowserSearch.adClicks["provider-\(adsProviderName)"].add()
+                        }
                         adsTelemetryUrlList.removeAll()
                         adsProviderName = ""
                     }
@@ -494,9 +494,9 @@ extension WebViewController: WKScriptMessageHandler {
             let adUrls = provider.listAdUrls(urls: urls)
             
             if !adUrls.isEmpty {
-                recordAdsFoundOnPage(providerName: provider.name)
-                adsProviderName = provider.name // TODO
-                adsTelemetryUrlList = adUrls // TODO
+                GleanMetrics.BrowserSearch.withAds["provider-\(provider.name)"].add()
+                adsProviderName = provider.name
+                adsTelemetryUrlList = adUrls
             }
             
             return
@@ -549,15 +549,5 @@ extension WebViewController {
             }
         }
         return nil
-    }
-
-    public func recordAdsFoundOnPage(providerName: String) {
-        print("MOO recordAdsFoundOnPage: provider-\(providerName)")
-        GleanMetrics.BrowserSearch.withAds["provider-\(providerName)"].add()
-    }
-
-    public func recordAdsClickedOnPage(providerName: String) {
-        print("MOO recordAdsClickedOnPage: provider-\(providerName)")
-        GleanMetrics.BrowserSearch.adClicks["provider-\(providerName)"].add()
     }
 }

--- a/Blockzilla/OpenSearchParser.swift
+++ b/Blockzilla/OpenSearchParser.swift
@@ -28,6 +28,12 @@ class OpenSearchParser {
             print("Invalid search file")
             return nil
         }
+        
+        // The ID of a search engine is simply the filename without extension
+        let searchEngineID = file.deletingPathExtension().lastPathComponent
+        if searchEngineID == "" {
+            return nil
+        }
 
         guard let doc = try? XMLDocument(data: data),
               let rootElem = doc.root else {
@@ -126,6 +132,6 @@ class OpenSearchParser {
             image = nil
         }
 
-        return SearchEngine(name: shortName, image: image, searchTemplate: template, suggestionsTemplate: suggestionsTemplate)
+        return SearchEngine(id: searchEngineID, name: shortName, image: image, searchTemplate: template, suggestionsTemplate: suggestionsTemplate)
     }
 }

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -453,7 +453,7 @@ class OverlayView: UIView {
         
         if sender.getIndex() == 0 {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionNotSelected)
-            GleanMetrics.SearchSuggestions.suggestionTapped.record()
+            GleanMetrics.SearchSuggestions.searchTapped.record()
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionSelected)
             GleanMetrics.SearchSuggestions.suggestionTapped.record()

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import SnapKit
 import Telemetry
+import Glean
 
 protocol OverlayViewDelegate: AnyObject {
     func overlayViewDidTouchEmptyArea(_ overlayView: OverlayView)
@@ -450,6 +451,11 @@ class OverlayView: UIView {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionNotSelected)
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionSelected)
+
+            // Record this search in Telemetry
+            let activeSearchEngine = SearchEngineManager(prefs: UserDefaults.standard).activeEngine
+            let id = activeSearchEngine.isCustom ? "custom" : activeSearchEngine.id
+            GleanMetrics.Search.counts["\(id).suggestion"].add()
         }
     }
     @objc private func didPressCopy() {

--- a/Blockzilla/OverlayView.swift
+++ b/Blockzilla/OverlayView.swift
@@ -438,6 +438,7 @@ class OverlayView: UIView {
     @objc private func didPressArrowButton(sender: UIButton) {
         if let index = arrowButtons.firstIndex(of: sender) {
             delegate?.overlayView(self, didTapArrowText: searchSuggestions[index + 1])
+            GleanMetrics.SearchSuggestions.autocompleteArrowTapped.record()
         }
     }
 
@@ -446,16 +447,16 @@ class OverlayView: UIView {
         let immutableSearchSuggestions = searchSuggestions
         delegate?.overlayView(self, didSearchForQuery: immutableSearchSuggestions[sender.getIndex()])
 
-        if !Settings.getToggle(.enableSearchSuggestions) { return }
+        if !Settings.getToggle(.enableSearchSuggestions) {
+            return
+        }
+        
         if sender.getIndex() == 0 {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionNotSelected)
+            GleanMetrics.SearchSuggestions.suggestionTapped.record()
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionSelected)
-
-            // Record this search in Telemetry
-            let activeSearchEngine = SearchEngineManager(prefs: UserDefaults.standard).activeEngine
-            let id = activeSearchEngine.isCustom ? "custom" : activeSearchEngine.id
-            GleanMetrics.Search.counts["\(id).suggestion"].add()
+            GleanMetrics.SearchSuggestions.suggestionTapped.record()
         }
     }
     @objc private func didPressCopy() {

--- a/Blockzilla/SearchEngine.swift
+++ b/Blockzilla/SearchEngine.swift
@@ -5,6 +5,7 @@
 import UIKit
 
 class SearchEngine: NSObject, NSCoding {
+    let id: String
     let name: String
     let image: UIImage?
     var isCustom: Bool = false
@@ -14,7 +15,8 @@ class SearchEngine: NSObject, NSCoding {
     private let SearchTermComponent = "{searchTerms}"
     private let LocaleTermComponent = "{moz:locale}"
 
-    init(name: String, image: UIImage?, searchTemplate: String, suggestionsTemplate: String?, isCustom: Bool = false) {
+    init(id: String, name: String, image: UIImage?, searchTemplate: String, suggestionsTemplate: String?, isCustom: Bool = false) {
+        self.id = id
         self.name = name
         self.image = image ?? SearchEngine.generateImage(name: name)
         self.searchTemplate = searchTemplate
@@ -28,6 +30,7 @@ class SearchEngine: NSObject, NSCoding {
                 return nil
         }
 
+        self.id = "custom" // Only custom search engines are encoded
         self.name = name
         self.searchTemplate = searchTemplate
         image = aDecoder.decodeObject(forKey: "image") as? UIImage

--- a/Blockzilla/SearchEngineManager.swift
+++ b/Blockzilla/SearchEngineManager.swift
@@ -31,7 +31,7 @@ class SearchEngineManager {
 
     func addEngine(name: String, template: String) -> SearchEngine {
         let correctedTemplate = template.replacingOccurrences(of: "%s", with: "{searchTerms}")
-        let engine = SearchEngine(name: name, image: nil, searchTemplate: correctedTemplate, suggestionsTemplate: nil, isCustom: true)
+        let engine = SearchEngine(id: "custom", name: name, image: nil, searchTemplate: correctedTemplate, suggestionsTemplate: nil, isCustom: true)
 
         // Persist
         var customEngines = readCustomEngines()

--- a/Blockzilla/SearchProviderModel.swift
+++ b/Blockzilla/SearchProviderModel.swift
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+import Glean
+
+public enum BasicSearchProvider: String {
+    case google
+    case duckduckgo
+    case yahoo
+    case bing
+}
+
+public struct SearchProviderModel {
+    typealias Predicate = (String) -> Bool
+    let name: String
+    let regexp: String
+    let queryParam: String
+    let codeParam: String
+    let codePrefixes: [String]
+    let followOnParams: [String]
+    let extraAdServersRegexps: [String]
+    
+    public static let searchProviderList = [
+        SearchProviderModel(
+            name: BasicSearchProvider.google.rawValue,
+            regexp: #"^https:\/\/www\.google\.(?:.+)\/search"#,
+            queryParam: "q",
+            codeParam: "client",
+            codePrefixes: ["firefox"],
+            followOnParams: ["oq", "ved", "ei"],
+            extraAdServersRegexps: [
+                #"^https?:\/\/www\.google(?:adservices)?\.com\/(?:pagead\/)?aclk"#,
+                #"^(http|https):\/\/clickserve.dartsearch.net\/link\/"#
+            ]
+        ),
+        SearchProviderModel(
+            name: BasicSearchProvider.duckduckgo.rawValue,
+            regexp: #"^https:\/\/duckduckgo\.com\/"#,
+            queryParam: "q",
+            codeParam: "t",
+            codePrefixes: ["f"],
+            followOnParams: [],
+            extraAdServersRegexps: [
+                #"^https:\/\/duckduckgo.com\/y\.js"#,
+                #"^https:\/\/www\.amazon\.(?:[a-z.]{2,24}).*(?:tag=duckduckgo-)"#
+            ]
+        ),
+        // Note: Yahoo shows ads from bing and google
+        SearchProviderModel(
+            name: BasicSearchProvider.yahoo.rawValue,
+            regexp: #"^https:\/\/(?:.*)search\.yahoo\.com\/search"#,
+            queryParam: "p",
+            codeParam: "",
+            codePrefixes: [],
+            followOnParams: [],
+            extraAdServersRegexps: [#"^(http|https):\/\/clickserve.dartsearch.net\/link\/"#,
+                                    #"^https:\/\/www\.bing\.com\/acli?c?k"#,
+                                    #"^https:\/\/www\.bing\.com\/fd\/ls\/GLinkPingPost\.aspx.*acli?c?k"#]
+        ),
+        SearchProviderModel(
+            name: BasicSearchProvider.bing.rawValue,
+            regexp: #"^https:\/\/www\.bing\.com\/search"#,
+            queryParam: "q",
+            codeParam: "pc",
+            codePrefixes: ["MOZ", "MZ"],
+            followOnParams: ["oq"],
+            extraAdServersRegexps: [
+                #"^https:\/\/www\.bing\.com\/acli?c?k"#,
+                #"^https:\/\/www\.bing\.com\/fd\/ls\/GLinkPingPost\.aspx.*acli?c?k"#
+            ]
+        ),
+    ]
+}
+
+extension SearchProviderModel {
+    func listAdUrls(urls: [String]) -> [String] {
+        let predicates: [Predicate] = extraAdServersRegexps.map { regex in
+            return { url in
+                return url.range(of: regex, options: .regularExpression) != nil
+            }
+        }
+
+        var adUrls = [String]()
+        for url in urls {
+            for predicate in predicates {
+                guard predicate(url) else { continue }
+                adUrls.append(url)
+            }
+        }
+        
+        return adUrls
+    }
+}

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -40,6 +40,20 @@ browser:
       - focus-ios-data-stewards@mozilla.com
       - sarentz@mozilla.com
     expires: never
+  default_search_engine:
+    type: string
+    lifetime: application
+    description: |
+      A string containing the default search engine name.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/4545
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5065#issuecomment-894328647
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-07-01"
 
 mozilla_products:
   has_firefox_installed:
@@ -290,81 +304,107 @@ preferences:
       - focus-ios-data-stewards@mozilla.com
     expires: "2022-10-01"
 
-# Search and search releated metrics
-search:
-  counts:
-    type: labeled_counter
-    description: |
-      The labels for this counter are `{search-engine-name}.{source}`
-
-      If the search engine is bundled with Firefox-iOS, then
-      `search-engine-name` will be the name of the search engine. If
-      it is a custom search engine, the value will be `custom`.
-
-      The value of `source` will reflect the source from which the
-      search started.  One of:
-      * quicksearch
-      * suggestion
-      * actionbar
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2022-01-01"
-  default_engine:
-    type: string
-    lifetime: application
-    description: |
-      The default search engine identifier if the search engine is
-      pre-loaded with Firefox-iOS.  If it's a custom search engine,
-      then the value will be 'custom'.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2022-01-01"
-  in_content:
-    type: labeled_counter
-    description: |
-      Records the type of interaction a user has on SERP pages.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/7602
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/7702
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2022-01-01"
-
 browser_search:
   with_ads:
     type: labeled_counter
     description: |
       Records counts of SERP pages with adverts displayed.
-      The key format is ‘<provider-name>’.
+      The key format is `<provider-name>`.
     send_in_pings:
       - metrics
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/7616
+      - https://github.com/mozilla-mobile/fenix/issues/4967
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/8970
+      - https://github.com/mozilla-mobile/focus-android/pull/4968#issuecomment-879256443
+    data_sensitivity:
+      - interaction
     notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2022-02-09"
+      - android-probes@mozilla.com
+    expires: "2022-07-01"
   ad_clicks:
     type: labeled_counter
     description: |
       Records clicks of adverts on SERP pages.
-      The key format is ‘<provider-name>’.
+      The key format is `<provider-name>`.
     send_in_pings:
       - metrics
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/7616
+      - https://github.com/mozilla-mobile/fenix/issues/4967
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/8970
+      - https://github.com/mozilla-mobile/focus-android/pull/4968#issuecomment-879256443
+    data_sensitivity:
+      - interaction
     notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2022-02-09"
+      - android-probes@mozilla.com
+    expires: "2022-07-01"
+  in_content:
+    type: labeled_counter
+    description: |
+      Records the type of interaction a user has on SERP pages.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/4967
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/4968#issuecomment-879256443
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-07-01"
+
+search_bar:
+  entered_url:
+    type: event
+    description: The user has entered a full url.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5546
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5660
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+  performed_search:
+    type: event
+    description: The user has entered text and performed a search.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5546
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5660
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      engine_name:
+        description: The name of the engine used to perform the search.
+        type: string
+
+search_suggestions:
+  suggestion_tapped:
+    type: event
+    description: Search suggestion selected.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5662
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+  autocomplete_arrow_tapped:
+    type: event
+    description: Search suggestion selected.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5662
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -327,18 +327,6 @@ search:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-01-01"
-  start_search_pressed:
-    type: counter
-    description: |
-      Counts the number of times the start search button is
-      pressed
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2022-01-01"
   in_content:
     type: labeled_counter
     description: |

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -338,3 +338,33 @@ search:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-01-01"
+
+browser_search:
+  with_ads:
+    type: labeled_counter
+    description: |
+      Records counts of SERP pages with adverts displayed.
+      The key format is ‘<provider-name>’.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/7616
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8970
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-02-09"
+  ad_clicks:
+    type: labeled_counter
+    description: |
+      Records clicks of adverts on SERP pages.
+      The key format is ‘<provider-name>’.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/7616
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8970
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-02-09"

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -289,3 +289,64 @@ preferences:
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: "2022-10-01"
+
+# Search and search releated metrics
+search:
+  counts:
+    type: labeled_counter
+    description: |
+      The labels for this counter are `{search-engine-name}.{source}`
+
+      If the search engine is bundled with Firefox-iOS, then
+      `search-engine-name` will be the name of the search engine. If
+      it is a custom search engine, the value will be `custom`.
+
+      The value of `source` will reflect the source from which the
+      search started.  One of:
+      * quicksearch
+      * suggestion
+      * actionbar
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  default_engine:
+    type: string
+    lifetime: application
+    description: |
+      The default search engine identifier if the search engine is
+      pre-loaded with Firefox-iOS.  If it's a custom search engine,
+      then the value will be 'custom'.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  start_search_pressed:
+    type: counter
+    description: |
+      Counts the number of times the start search button is
+      pressed
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  in_content:
+    type: labeled_counter
+    description: |
+      Records the type of interaction a user has on SERP pages.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/7602
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/7702
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -384,6 +384,18 @@ search_bar:
         type: string
 
 search_suggestions:
+  search_tapped:
+    type: event
+    description: The original query is selected.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5662
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
   suggestion_tapped:
     type: event
     description: Search suggestion selected.


### PR DESCRIPTION
## Implementation Notes

### `search.default_engine`

Instead of recoding the _Short Name_ of the search engine we now record the _Search Engine ID_, which is the name of the file from which the search engine definition came. This is more similar to Firefox iOS, although there, the Google definition is not just called `google`, it also contains the client id like `google-b-1m`.

### `search.counts`

TODO

### `search.start_search_pressed`

Focus does not have a search button like Firefox has. So this metric was not implemented.

### `search.in_content`

TODO

### `search.google_topsite_pressed`

Focus does not have search top site tiles, so this metric was not implemented.
