### PR TITLE
For #2840 - Add mergify to codeowners for strings files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,6 @@
 
 /bitrise.yml @mozilla-mobile/releng @isabelrios @st3fan
 
+# Changes to string files can be reviewed and approved by mergify
+
+/Blockzilla/**/*.strings @mergify


### PR DESCRIPTION
Tries to fix #2840 by adding mergify as codeowner for specific strings files