### PR TITLE
For #2905 - Add permission to github action workflow

### DIFF
--- a/.github/workflows/check-rust-component-dependency.yml
+++ b/.github/workflows/check-rust-component-dependency.yml
@@ -1,4 +1,9 @@
 name: Create a PR to build the app using newest rust-component version available
+
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 20 * * *'


### PR DESCRIPTION
Fixes #2905 by adding permission so that the github action workflow can create a PR in the repo