### PR TITLE
Fixes #2890 - Leading margins are too small in Settings’s cells

### DIFF
--- a/Blockzilla/SettingsTableViewCell.swift
+++ b/Blockzilla/SettingsTableViewCell.swift
@@ -8,6 +8,7 @@ class SettingsTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .gray
+        contentView.layoutMargins = UIEdgeInsets(top: 0, left: UIConstants.layout.settingsCellLeftInset, bottom: 0, right: 0)        
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -138,6 +138,7 @@ struct UIConstants {
         static let actionSheetTablePadding: CGFloat = 6
         static let actionSheetTitleHeaderHeight: CGFloat = 36
         static let actionSheetSeparatorHeaderHeight: CGFloat = 12
+        static let settingsCellLeftInset: CGFloat = 20
      
     }
 


### PR DESCRIPTION
Fixes #2890 - Leading margins are too small in Settings’s cells
<img width="593" alt="Screen Shot 2021-12-28 at 11 36 49 AM" src="https://user-images.githubusercontent.com/46751540/147552743-2794742b-73ea-4b93-ae9a-06be08915a10.png">

