### PR TITLE
Fixes #2661 - Two shields icons are displayed

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -371,7 +371,7 @@ class URLBar: UIView {
         }
 
         truncatedUrlText.snp.makeConstraints { make in
-            make.centerY.equalTo(self).offset(4)
+            make.centerY.equalTo(self).offset(8)
             make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview().offset(UIConstants.layout.truncatedUrlTextOffset)
         }


### PR DESCRIPTION
| | |
| ------------- | ------------- |
| ![No se encuentra la](https://user-images.githubusercontent.com/26011662/147667056-f47829f8-a082-4b1c-a2d0-910254015366.PNG) | ![Support](https://user-images.githubusercontent.com/26011662/147667071-102df7a2-c3b1-4416-abfd-54c32ac98321.PNG)  |

## Commit Message
Fixes #2661 - Two shields icons are displayed