### PR TITLE
Fixes #2939 - [iPad] The "Suggestion view" background is dismissed and the website shortcuts are visible in the page view

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -994,6 +994,16 @@ extension BrowserViewController: FindInPageBarDelegate {
         let escaped = text.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
         webViewController.evaluate("__firefox__.\(function)(\"\(escaped)\")", completion: nil)
     }
+    
+    private func shortcutContextMenuIsOpenOnIpad() -> Bool {
+        var shortcutContextMenuIsDisplayed: Bool =  false
+        for element in shortcutsContainer.subviews {
+            if let shortcut = element as? ShortcutView, shortcut.contextMenuIsDisplayed {
+                shortcutContextMenuIsDisplayed = true
+            }
+        }
+        return isIPadRegularDimensions && shortcutContextMenuIsDisplayed
+    }
 }
 
 extension BrowserViewController: URLBarDelegate {
@@ -1101,6 +1111,8 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidDismiss(_ urlBar: URLBar) {
+       
+        guard !shortcutContextMenuIsOpenOnIpad() else { return }
         overlayView.dismiss()
         toggleURLBarBackground(isBright: !webViewController.isLoading)
         shortcutsContainer.isHidden = urlBar.inBrowsingMode
@@ -1225,6 +1237,12 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
 }
 
 extension BrowserViewController: ShortcutViewDelegate {
+    
+    func dismissShortcut() {
+        guard isIPadRegularDimensions else { return }
+        urlBarDidDismiss(urlBar)
+    }
+    
     func shortcutTapped(shortcut: Shortcut) {
         ensureBrowsingMode()
         urlBar.url = shortcut.url

--- a/Blockzilla/ShortcutView.swift
+++ b/Blockzilla/ShortcutView.swift
@@ -10,9 +10,11 @@ import CoreHaptics
 protocol ShortcutViewDelegate: AnyObject {
     func shortcutTapped(shortcut: Shortcut)
     func removeFromShortcutsAction(shortcut: Shortcut)
+    func dismissShortcut()
 }
 
 class ShortcutView: UIView {
+    var contextMenuIsDisplayed = false
     private var shortcut: Shortcut
     weak var delegate: ShortcutViewDelegate?
     
@@ -115,5 +117,14 @@ extension ShortcutView: UIContextMenuInteractionDelegate {
             }
             return UIMenu(children: [removeFromShortcutsAction])
         })
+    }
+    
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        contextMenuIsDisplayed =  true
+    }
+    
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willEndFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        contextMenuIsDisplayed = false
+        self.delegate?.dismissShortcut()
     }
 }


### PR DESCRIPTION
Fixes #2939 - [iPad] The "Suggestion view" background is dismissed and the website shortcuts are visible in the page view

https://user-images.githubusercontent.com/46751540/148382395-a52e2b8a-be97-4f28-90ad-640a9893d56f.mov


