### PR TITLE
Fixes #2935 - The hamburger menu and shield icon are not correctly displayed in landscape when the URL bar is hidden

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -837,8 +837,9 @@ class URLBar: UIView {
         toolset.backButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.forwardButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.deleteButton.alpha = shouldShowToolset ? expandAlpha : 0
+        toolset.contextMenuButton.alpha = shouldShowToolset ? expandAlpha : 0
 
-        collapsedTrackingProtectionBadge.alpha = collapseAlpha
+        collapsedTrackingProtectionBadge.alpha = 0
         if isEditing {
             shieldIcon.alpha = collapseAlpha
         } else {

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -837,7 +837,7 @@ class URLBar: UIView {
         toolset.backButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.forwardButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.deleteButton.alpha = shouldShowToolset ? expandAlpha : 0
-        toolset.contextMenuButton.alpha = shouldShowToolset ? expandAlpha : 0
+        toolset.contextMenuButton.alpha = isEditing ? expandAlpha : (shouldShowToolset ? expandAlpha : 0)
 
         collapsedTrackingProtectionBadge.alpha = 0
         if isEditing {


### PR DESCRIPTION
Fixes #2935 - The hamburger menu and shield icon are not correctly displayed in landscape when the URL bar is hidden

<img width="1064" alt="Screen Shot 2022-01-07 at 2 44 14 PM" src="https://user-images.githubusercontent.com/46751540/148546169-1b7df1ab-8332-4f5f-a71e-201d7690e066.png">
<img width="593" alt="Screen Shot 2022-01-07 at 2 44 05 PM" src="https://user-images.githubusercontent.com/46751540/148546181-75906b9a-6d5d-428f-92ea-89833c453100.png">

