### PR TITLE
Fixes #2911 - First search’s suggestions are not tappable in landscape orientation

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -243,7 +243,7 @@ class BrowserViewController: UIViewController {
         overlayView.snp.makeConstraints { make in
             make.top.equalTo(urlBarContainer.snp.bottom)
             make.leading.trailing.equalTo(mainContainerView)
-            make.bottom.equalTo(homeViewController.tipViewTop)
+            make.bottom.equalToSuperview().inset(UIConstants.layout.toolbarHeight + UIConstants.layout.tipViewHeight)
         }
 
         // Listen for request desktop site notifications


### PR DESCRIPTION
Fixes #2911 - First search’s suggestions are not tappable in landscape orientation