### PR TITLE
For #1967 - Workflow to auto update Bitrise to latest Xcode stack available

### DIFF
--- a/.github/workflows/update-bitrise-xcode-version.yaml
+++ b/.github/workflows/update-bitrise-xcode-version.yaml
@@ -1,0 +1,50 @@
+name: Bitrise Xcode Check and Update
+
+on: 
+  schedule:
+  - cron: '0 */6 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ./github-actions-scripts/requirements.txt
+    - name: Modify bitrise.yml 
+      run: |
+        python ./github-actions-scripts/update-bitrise-file-latest-xcode.py
+    - name: Get new xcode version to be used in the PR info
+      run: |
+        cd github-actions-scripts/
+        chmod u+x read-xcode-new-version.sh
+        echo "version=$(./read-xcode-new-version.sh)" >> $GITHUB_ENV
+    - name: Remove temp file created to store the tag info
+      run: |
+        cd github-actions-scripts/
+        [ ! -e newest_xcode.txt ] || rm newest_xcode.txt
+    - name: Commit and push if bitrise.yml changed
+      run: |-
+        git diff
+        git diff --quiet || (git add bitrise.yml)
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        # Add the new xcode version to the branch and PR info
+        commit-message: Auto Update Bitrise.YML
+        author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        committer: GitHub <noreply@github.com>
+        title: Update Bitrise NewXcodeVersions Workflow Xcode Stack ${{ env.version }}
+        branch: update-br-new-xcode-version-${{ env.version }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        labels: Do Not Land

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -29,6 +29,11 @@ stages:
     - unit_test_klar: {}
     - unit_test_focus: {}
 
+meta:
+  bitrise.io:
+    stack: osx-xcode-14.0.x
+    machine_type_id: g2.8core
+
 workflows:
   configure_build:
     steps:
@@ -296,10 +301,6 @@ workflows:
             #!/usr/bin/env bash
             ./checkout.sh
         title: ContentBlockerGen
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-
 
   set-project-version:
     steps:
@@ -323,10 +324,6 @@ workflows:
         - build_version_offset: '3250'
         - plist_path: OpenInFocus/Info.plist
         title: Set OpenInFocus version numbers
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-
 
   configure-nimbus:
     steps:
@@ -340,10 +337,6 @@ workflows:
             /usr/libexec/PlistBuddy -c "Add :NimbusStagingServerURL string ${NIMBUS_STAGING_SERVER_URL}" Blockzilla/Info.plist
             /usr/libexec/PlistBuddy -c "Add :NimbusAppName string ${NIMBUS_APP_NAME}" Blockzilla/Info.plist
             /usr/libexec/PlistBuddy -c "Add :NimbusAppChannel string ${NIMBUS_APP_CHANNEL}" Blockzilla/Info.plist
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-
 
   configure-sentry:
     steps:
@@ -354,10 +347,6 @@ workflows:
             #!/usr/bin/env bash
             set -x
             /usr/libexec/PlistBuddy -c "Add :SentryDSN string ${SENTRY_DSN}" Blockzilla/Info.plist
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-
 
   set-default-browser-entitlement:
     steps:
@@ -369,10 +358,6 @@ workflows:
             set -x
             /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
             /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-
 
   release:
     steps:
@@ -414,10 +399,6 @@ workflows:
             set -x
             tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org mozilla --project klar-ios "$BITRISE_DSYM_DIR_PATH"
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-        machine_type_id: g2.8core
     before_run:
       - clone-and-build-dependencies
       - set-project-version
@@ -445,10 +426,6 @@ workflows:
         inputs:
         - access_token: "$FOCUS_PARALLEL"
     - deploy-to-bitrise-io@1: {}
-    meta:
-      bitrise.io:
-        stack: osx-xcode-14.0.x
-        machine_type_id: g2.4core
 
   runParallelTestsM1Beta:
     steps:
@@ -469,9 +446,6 @@ workflows:
         inputs:
         - access_token: "$FOCUS_PARALLEL"
     - deploy-to-bitrise-io@1: {}
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
 
   runFocus:
     steps:
@@ -486,7 +460,6 @@ workflows:
             set -e
             # debug log
             set -x
-
             # Check if it is a scheduled or regular build
             # to select the testPlan to run
             
@@ -498,7 +471,6 @@ workflows:
                 echo "Regular build, running Smoke Test"
                 envman add --key TEST_PLAN_NAME --value SmokeTest
             fi
-
         - title: Check if build is scheduled or regular to set the test plan
     - script@1:
         inputs:
@@ -547,10 +519,6 @@ workflows:
         - channel: "#focus-ios-alerts"
         - message: "The build run the testPlan: $TEST_PLAN_NAME"
         - webhook_url: "$SLACK_WEBHOOK"
-    meta:
-      bitrise.io:
-        stack: osx-xcode-14.0.x
-        machine_type_id: g2.8core
 
   runKlar:
     steps:
@@ -565,10 +533,8 @@ workflows:
             set -e
             # debug log
             set -x
-
             # Check if it is a scheduled or regular build
             # to select the testPlan to run
-
             if [[ $BITRISE_GIT_MESSAGE == Schedule* ]]
             then
                 echo "Scheduled build, running Full Functional Tests"
@@ -633,10 +599,6 @@ workflows:
         - channel: "#focus-ios-alerts"
         - message: "The build run the testPlan: $TEST_PLAN_NAME"
         - webhook_url: "$SLACK_WEBHOOK"
-    meta:
-      bitrise.io:
-        stack: osx-xcode-14.0.x
-        machine_type_id: g2.8core
   runFocus-iPad:
     steps:
     - activate-ssh-key@4:
@@ -680,10 +642,7 @@ workflows:
         - simulator_device:  iPad Pro (12.9-inch) (5th generation)
         - simulator_os_version: '15.4'
     - deploy-to-bitrise-io@1: {}
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-        machine_type_id: g2.8core
+
   L10nScreenshotsTests:
     steps:
     - activate-ssh-key@4:
@@ -703,15 +662,10 @@ workflows:
         inputs:
         - content: >-
             #!/usr/bin/env bash
-
             # fail if any commands fails
-
             set -e
-
             # debug log
-
             set -x
-
             echo "curl to Download derived data"
 
             curl --location --retry 5 --output l10n-screenshots-dd.zip "$MOZ_DERIVED_DATA_PATH"
@@ -744,10 +698,6 @@ workflows:
     - deploy-to-bitrise-io@1.10:
         inputs:
         - deploy_path: artifacts/
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-        machine_type_id: g2.4core
   L10nBuild:
     steps:
     - activate-ssh-key@4:
@@ -786,11 +736,6 @@ workflows:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-        machine_type_id: g2.4core
-
 app:
   envs:
   - opts:
@@ -799,8 +744,3 @@ app:
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: app-store
-
-meta:
-  bitrise.io:
-    stack: osx-xcode-13.3.x
-    machine_type_id: g2.4core

--- a/github-actions-scripts/read-xcode-new-version.sh
+++ b/github-actions-scripts/read-xcode-new-version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+filename="newest_xcode.txt"
+while read -r line; do
+    name="$line"
+done < "$filename"
+echo $name

--- a/github-actions-scripts/requirements.txt
+++ b/github-actions-scripts/requirements.txt
@@ -1,2 +1,4 @@
+semver
 requests
+ruamel.yaml
 pygithub

--- a/github-actions-scripts/update-bitrise-file-latest-xcode.py
+++ b/github-actions-scripts/update-bitrise-file-latest-xcode.py
@@ -81,7 +81,6 @@ if __name__ == '__main__':
 
         y = obj_yaml.load(infile)
 
-        #current_semver = y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack']
         current_semver = y['meta']['bitrise.io']['stack']
 
         # remove pattern prefix from current_semver to compare with largest
@@ -93,7 +92,6 @@ if __name__ == '__main__':
             print('New Xcode version available: {0} ... updating bitrise.yml!'.format(largest_semver))
             # add prefix pattern back to be recognizable by bitrise
             # as a valid stack value
-            #y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
             y['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
             with open(tmp_file, 'w+') as tmpfile:
                 obj_yaml.dump(y, tmpfile)

--- a/github-actions-scripts/update-bitrise-file-latest-xcode.py
+++ b/github-actions-scripts/update-bitrise-file-latest-xcode.py
@@ -1,0 +1,105 @@
+import os
+import re
+import sys
+import pathlib
+from shutil import copyfile
+from ruamel.yaml import YAML
+
+
+import requests
+import semver
+from requests.exceptions import HTTPError
+
+
+BITRISE_STACK_INFO = 'https://app.bitrise.io/app/6c06d3a40422d10f/all_stack_info'
+'''
+curl ${BITRISE_STACK_INFO} | jq ' . | keys'
+[
+  "available_stacks",
+  "project_types_with_default_stacks",
+  "running_builds_on_private_cloud"
+]
+'''
+pattern = 'osx-xcode-'
+BITRISE_YML = 'bitrise.yml'
+
+resp = requests.get(BITRISE_STACK_INFO)
+resp.raise_for_status()
+resp_json = resp.json()
+
+def parse_semver(raw_str):
+    parsed = raw_str.split(pattern)[1]
+    if parsed[-1] == 'x':
+        p = parsed.split('.x')[0]
+        return '{0}.0'.format(p)
+    else:
+        return False
+
+
+def available_stacks():
+    try:
+        resp = requests.get(BITRISE_STACK_INFO)
+        resp_json = resp.json()
+        return resp_json['available_stacks']
+    except HTTPError as http_error:
+        print('An HTTP error has occurred: {http_error}')
+    except Exception as err:
+        print('An exception has occurred: {err}')
+
+
+def largest_version():
+    stacks = available_stacks()
+    count = 0
+    for item in stacks:
+        if pattern in item:
+            p = parse_semver(item)
+            if p:
+                if count == 0 or semver.compare(largest, p) == -1:
+                    largest = p
+                count += 1
+    return '{0}.x'.format('.'.join(largest.split('.')[0:2]))
+
+if __name__ == '__main__':
+    '''
+    STEPS
+    1. check bitrise API stack info for latest XCode version
+    2. compare latest with current bitrise.yml stack version in repo
+    3. if same exit, if not, continue
+    4. modify bitrise.yml (update stack value)
+    '''
+
+    largest_semver = largest_version()
+    tmp_file = 'tmp.yml'
+
+    with open(BITRISE_YML, 'r') as infile:
+
+        obj_yaml = YAML()
+
+        # prevents re-formatting of yml file
+        obj_yaml.preserve_quotes = True
+        obj_yaml.width = 4096
+
+        y = obj_yaml.load(infile)
+
+        #current_semver = y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack']
+        current_semver = y['meta']['bitrise.io']['stack']
+
+        # remove pattern prefix from current_semver to compare with largest
+        current_semver = current_semver.split(pattern)[1]
+
+        if current_semver == largest_semver:
+            print('Xcode version unchanged! aborting.')
+        else:
+            print('New Xcode version available: {0} ... updating bitrise.yml!'.format(largest_semver))
+            # add prefix pattern back to be recognizable by bitrise
+            # as a valid stack value
+            #y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
+            y['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
+            with open(tmp_file, 'w+') as tmpfile:
+                obj_yaml.dump(y, tmpfile)
+                copyfile(tmp_file, BITRISE_YML)
+                os.remove(tmp_file)
+
+            # Save the newer xcode version to be used in the PR info
+            f= open("github-actions-scripts/newest_xcode.txt","w+")
+            f.write(y['meta']['bitrise.io']['stack']+"\n")


### PR DESCRIPTION
This PR would fix #1967. It adds:
- a new workflow to detect new stacks on bitrise by running a cron job
- script to use the new stack detected on bitrise
- github action to automatically create a PR with the new xcode version
- build will run using that new stack so that we will know if the project builds or not with newest xcode