### PR TITLE
Fixes #2977 - Integrate Sentry

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		F85F7A292655AD5800395515 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A282655AD5800395515 /* SnapKit */; };
 		F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2A2655AD5800395515 /* Fuzi */; };
 		F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2E2655AD5800395515 /* Telemetry */; };
+		F8B92FBE279EC73700183998 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F8B92FBD279EC73700183998 /* Sentry */; };
 		F8BC6A0727224B170026AB9F /* NimbusExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BC6A0627224B170026AB9F /* NimbusExtensions.swift */; };
 		F8BC6A0927224B890026AB9F /* NimbusWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BC6A0827224B890026AB9F /* NimbusWrapper.swift */; };
 		F8DE0EC826CC887800A31419 /* SupportUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DE0EC726CC887800A31419 /* SupportUtilsTest.swift */; };
@@ -1082,6 +1083,7 @@
 				1B56C58727221B1C00BB1152 /* RustLog in Frameworks */,
 				1B56C58927221B1C00BB1152 /* Viaduct in Frameworks */,
 				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
+				F8B92FBE279EC73700183998 /* Sentry in Frameworks */,
 				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1722,6 +1724,7 @@
 				1B56C58427221B1C00BB1152 /* Nimbus */,
 				1B56C58627221B1C00BB1152 /* RustLog */,
 				1B56C58827221B1C00BB1152 /* Viaduct */,
+				F8B92FBD279EC73700183998 /* Sentry */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1900,6 +1903,7 @@
 				F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */,
 				F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */,
 				1B56C58327221B1C00BB1152 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
+				F8B92FBC279EC73700183998 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -5478,6 +5482,14 @@
 				kind = branch;
 			};
 		};
+		F8B92FBC279EC73700183998 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = exactVersion;
+				version = 7.9.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -5510,6 +5522,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */;
 			productName = Telemetry;
+		};
+		F8B92FBD279EC73700183998 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8B92FBC279EC73700183998 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "Sentry",
+        "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
+        "state": {
+          "branch": null,
+          "revision": "967f04b3cd6989df3f9ced3060481a21646c146d",
+          "version": "7.9.0"
+        }
+      },
+      {
         "package": "SnapKit",
         "repositoryURL": "https://github.com/SnapKit/SnapKit",
         "state": {

--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+import Sentry
 
 class AboutViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, AboutHeaderViewDelegate {
     
@@ -230,8 +231,19 @@ private class AboutHeaderView: UIView {
         self.init(frame: CGRect.zero)
         addSubviews()
         configureConstraints()
+    
+        // TODO REMOVE THIS IS JUST FOR TESTING
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleSecretMenuActivation(sender:)))
+        gestureRecognizer.numberOfTapsRequired = 5
+        logo.isUserInteractionEnabled = true
+        logo.addGestureRecognizer(gestureRecognizer)
     }
-
+    
+    // TODO REMOVE THIS IS JUST FOR TESTING
+    @objc private func handleSecretMenuActivation(sender: UITapGestureRecognizer) {
+        SentrySDK.crash()
+    }
+    
     @objc private func didPressLearnMore() {
         delegate?.aboutHeaderViewDidPressLearnMore(self)
     }
@@ -248,6 +260,8 @@ private class AboutHeaderView: UIView {
         logo.snp.makeConstraints { make in
             make.centerX.equalTo(self)
             make.top.equalTo(self).offset(50)
+            
+            
         }
 
         versionNumber.snp.makeConstraints { make in

--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -231,17 +231,6 @@ private class AboutHeaderView: UIView {
         self.init(frame: CGRect.zero)
         addSubviews()
         configureConstraints()
-    
-        // TODO REMOVE THIS IS JUST FOR TESTING
-        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleSecretMenuActivation(sender:)))
-        gestureRecognizer.numberOfTapsRequired = 5
-        logo.isUserInteractionEnabled = true
-        logo.addGestureRecognizer(gestureRecognizer)
-    }
-    
-    // TODO REMOVE THIS IS JUST FOR TESTING
-    @objc private func handleSecretMenuActivation(sender: UITapGestureRecognizer) {
-        SentrySDK.capture(exception: NSException(name: .genericException, reason: "SomethingReason", userInfo: nil))
     }
     
     @objc private func didPressLearnMore() {

--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -241,7 +241,7 @@ private class AboutHeaderView: UIView {
     
     // TODO REMOVE THIS IS JUST FOR TESTING
     @objc private func handleSecretMenuActivation(sender: UITapGestureRecognizer) {
-        SentrySDK.capture(exception: NSException(name: "SomethingName", reason: "SomethingReason", userInfo: nil))
+        SentrySDK.capture(exception: NSException(name: .genericException, reason: "SomethingReason", userInfo: nil))
     }
     
     @objc private func didPressLearnMore() {

--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -241,7 +241,7 @@ private class AboutHeaderView: UIView {
     
     // TODO REMOVE THIS IS JUST FOR TESTING
     @objc private func handleSecretMenuActivation(sender: UITapGestureRecognizer) {
-        SentrySDK.crash()
+        SentrySDK.capture(exception: NSException(name: "SomethingName", reason: "SomethingReason", userInfo: nil))
     }
     
     @objc private func didPressLearnMore() {

--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import UIKit
-import Sentry
 
 class AboutViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, AboutHeaderViewDelegate {
     
@@ -232,7 +231,7 @@ private class AboutHeaderView: UIView {
         addSubviews()
         configureConstraints()
     }
-    
+
     @objc private func didPressLearnMore() {
         delegate?.aboutHeaderViewDidPressLearnMore(self)
     }
@@ -249,8 +248,6 @@ private class AboutHeaderView: UIView {
         logo.snp.makeConstraints { make in
             make.centerX.equalTo(self)
             make.top.equalTo(self).offset(50)
-            
-            
         }
 
         versionNumber.snp.makeConstraints { make in

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Telemetry
 import Glean
+import Sentry
 
 protocol AppSplashController {
     var splashView: SplashView { get }
@@ -49,6 +50,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
             UserDefaults.standard.removePersistentDomain(forName: AppInfo.sharedContainerIdentifier)
         }
 
+        setupCrashReporting()
         setupTelemetry()
         setupExperimentation()
         
@@ -350,6 +352,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
             make.edges.equalTo(window!)
         }
         splashView.animateHidden(false, duration: 0.25)
+    }
+}
+
+
+// MARK: - Crash Reporting
+
+private let SentryDSNKey = "SentryDSN"
+
+extension AppDelegate {
+    func setupCrashReporting() {
+        if let sentryDSN = Bundle.main.object(forInfoDictionaryKey: SentryDSNKey) as? String {
+            SentrySDK.start { options in
+                options.dsn = sentryDSN
+            }
+        }
     }
 }
 

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -363,7 +363,7 @@ private let SentryDSNKey = "SentryDSN"
 extension AppDelegate {
     func setupCrashReporting() {
         // Do not enable crash reporting if collection of anonymous usage data is disabled.
-        if Settings.getToggle(.sendAnonymousUsageData) {
+        if !Settings.getToggle(.sendAnonymousUsageData) {
             return
         }
         

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -362,6 +362,11 @@ private let SentryDSNKey = "SentryDSN"
 
 extension AppDelegate {
     func setupCrashReporting() {
+        // Do not enable crash reporting if collection of anonymous usage data is disabled.
+        if Settings.getToggle(.sendAnonymousUsageData) {
+            return
+        }
+        
         if let sentryDSN = Bundle.main.object(forInfoDictionaryKey: SentryDSNKey) as? String {
             SentrySDK.start { options in
                 options.dsn = sentryDSN

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -243,7 +243,7 @@ class BrowserViewController: UIViewController {
         overlayView.snp.makeConstraints { make in
             make.top.equalTo(urlBarContainer.snp.bottom)
             make.leading.trailing.equalTo(mainContainerView)
-            make.bottom.equalTo(homeViewController.tipViewTop)
+            make.bottom.equalToSuperview().inset(UIConstants.layout.toolbarHeight + UIConstants.layout.tipViewHeight)
         }
 
         // Listen for request desktop site notifications

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -103,6 +103,7 @@ workflows:
             set -x
             DWARF_DSYM_FOLDER_PATH=$(xcodebuild -showBuildSettings \
               | grep DWARF_DSYM_FOLDER_PATH | awk '{split($0,a," = "); print a[2]}')
+            find "$DWARF_DSYM_FOLDER_PATH" -ls
             tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$DWARF_DSYM_FOLDER_PATH"
     meta:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -58,7 +58,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-13.2.x
-    before_run: []
 
 
   configure-nimbus:
@@ -76,7 +75,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-13.2.x
-    before_run: []
 
 
   configure-sentry:
@@ -91,7 +89,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-13.2.x
-    before_run: []
 
 
   set-default-browser-entitlement:
@@ -107,7 +104,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-13.2.x
-    before_run: []
 
 
   release:
@@ -130,7 +126,6 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            find "$BITRISE_DSYM_DIR_PATH" -ls
             tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org mozilla --project focus-ios "$BITRISE_DSYM_DIR_PATH"
     - xcode-archive@3:
@@ -149,7 +144,6 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            find "$BITRISE_DSYM_DIR_PATH" -ls
             tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org mozilla --project klar-ios "$BITRISE_DSYM_DIR_PATH"
     meta:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,25 +93,6 @@ workflows:
     before_run: []
 
 
-  upload-symbols:
-    steps:
-    - script@1:
-        title: Upload Symbols
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -x
-            DWARF_DSYM_FOLDER_PATH=$(xcodebuild -showBuildSettings \
-              | grep DWARF_DSYM_FOLDER_PATH | awk '{split($0,a," = "); print a[2]}')
-            find "$DWARF_DSYM_FOLDER_PATH" -ls
-            tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
-              --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$DWARF_DSYM_FOLDER_PATH"
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.2.x
-    before_run: []
-
-
   set-default-browser-entitlement:
     steps:
     - script@1:
@@ -142,6 +123,15 @@ workflows:
         - connection: 'off'
         - app_password: "$APPLE_ACCOUNT_PW"
         - itunescon_user: "$APPLE_ACCOUNT_ID"
+    - script@1:
+        title: Upload Focus Symbols
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -x
+            find "$BITRISE_DSYM_DIR_PATH" -ls
+            tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
+              --org mozilla --project focus-ios "$BITRISE_DSYM_DIR_PATH"
     - xcode-archive@3:
         inputs:
         - scheme: Klar
@@ -152,6 +142,15 @@ workflows:
         - connection: 'off'
         - app_password: "$APPLE_ACCOUNT_PW"
         - itunescon_user: "$APPLE_ACCOUNT_ID"
+    - script@1:
+        title: Upload Klar Symbols
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -x
+            find "$BITRISE_DSYM_DIR_PATH" -ls
+            tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
+              --org mozilla --project klar-ios "$BITRISE_DSYM_DIR_PATH"
     meta:
       bitrise.io:
         stack: osx-xcode-13.2.x
@@ -162,8 +161,6 @@ workflows:
       - set-default-browser-entitlement
       - configure-nimbus
       - configure-sentry
-    after_run:
-      - upload-symbols
 
 
   runParallelTests:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -103,7 +103,7 @@ workflows:
             set -x
             DWARF_DSYM_FOLDER_PATH=$(xcodebuild -showBuildSettings \
               | grep DWARF_DSYM_FOLDER_PATH | awk '{split($0,a," = "); print a[2]}')
-            sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
+            /usr/local/bin/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$DWARF_DSYM_FOLDER_PATH"
     meta:
       bitrise.io:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,6 +93,24 @@ workflows:
     before_run: []
 
 
+  upload-symbols:
+    steps:
+    - script@1:
+        title: Upload Symbols
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -x
+            DWARF_DSYM_FOLDER_PATH=$(xcodebuild -showBuildSettings \
+              | grep DWARF_DSYM_FOLDER_PATH | awk '{split($0,a," = "); print a[2]}')
+            sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
+              --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$DWARF_DSYM_FOLDER_PATH"
+    meta:
+      bitrise.io:
+        stack: osx-xcode-13.2.x
+    before_run: []
+
+
   set-default-browser-entitlement:
     steps:
     - script@1:
@@ -143,6 +161,8 @@ workflows:
       - set-default-browser-entitlement
       - configure-nimbus
       - configure-sentry
+    after_run:
+      - upload-symbols
 
 
   runParallelTests:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -78,6 +78,21 @@ workflows:
     before_run: []
 
 
+  configure-sentry:
+    steps:
+    - script@1:
+        title: Configure Sentry
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -x
+            /usr/libexec/PlistBuddy -c "Add :SentryDSN string ${SENTRY_DSN}" Blockzilla/Info.plist
+    meta:
+      bitrise.io:
+        stack: osx-xcode-13.2.x
+    before_run: []
+
+
   set-default-browser-entitlement:
     steps:
     - script@1:
@@ -127,6 +142,7 @@ workflows:
       - set-project-version
       - set-default-browser-entitlement
       - configure-nimbus
+      - configure-sentry
 
 
   runParallelTests:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -103,7 +103,7 @@ workflows:
             set -x
             DWARF_DSYM_FOLDER_PATH=$(xcodebuild -showBuildSettings \
               | grep DWARF_DSYM_FOLDER_PATH | awk '{split($0,a," = "); print a[2]}')
-            /usr/local/bin/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
+            tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$DWARF_DSYM_FOLDER_PATH"
     meta:
       bitrise.io:


### PR DESCRIPTION
This patch does a minimal Sentry integration, similar to what we had previously. It also includes CI changes to upload symbols for every release build for both _Focus_ and _Klar_.

Example report https://sentry.io/organizations/mozilla/issues/2957361602/?project=6162501

Because Bitrise did not include `sentry-cli` on their workers, I included it in our projects under `tools/` - I am not sure how I feel about this, but it is nice to pin to a specific known working version and vendor it so that we do not have to download it all the time for every build.

## Notes

I'm pulling in the latest Sentry SDK (7.9) as an SPM. If you are using Sentry against the (old) Mozilla Sentry service then you must upgrade. The older SDK versions do not work with the hosted Sentry service. There are also some API changes in the newer SDK but nothing too complicated.

The Bitrise integration is pretty simple - as part of the `release` task we call `sentry-cli` to upload the `.dSYM` files to Sentry. However this only works if _Bitcode_ is disabled for the iOS project. I think this is the case for both Focus and Firefox but newer projects may default to having it enabled. In that case symbols will have to be downloaded from AppStoreConnect and then uploaded to Sentry. Or we can also give Sentry an AppStoreConnect API Key so that it will do that on its own. That may need some additional work though. Disabling _Bitcode_ may also be an option - I never understood the advantage of it. 

The Rust situation is unclear. I did not see `.dSYM` files for the Rust libraries so those may not be symbolicated. Mabye @skhamis knows more about this? Uploading the symbols is simple, we just need to point to a directory that contains them.

The Sentry API Key for `sentry-cli` is from my own account. It is kept in a Bitrise secret and only enabled in non-PR builds so that it cannot leak. (The `release` workflow). It would be good to replace this API key with a service account probably.