### PR TITLE
Fixes #2995 - Include Secret Settings to validate the Sentry integration

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		F861799D2795EE9800CFD324 /* InternalExperimentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F861799C2795EE9800CFD324 /* InternalExperimentDetailView.swift */; };
 		F861799F27961F4200CFD324 /* InternalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F861799E27961F4200CFD324 /* InternalSettings.swift */; };
 		F86D00612790978700E83177 /* InternalSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86D00602790978700E83177 /* InternalSettingsView.swift */; };
+		F8714D2127A1E1F400CEB695 /* InternalCrashReportingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8714D2027A1E1F400CEB695 /* InternalCrashReportingSettingsView.swift */; };
 		F8B92FBE279EC73700183998 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F8B92FBD279EC73700183998 /* Sentry */; };
 		F8BC6A0727224B170026AB9F /* NimbusExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BC6A0627224B170026AB9F /* NimbusExtensions.swift */; };
 		F8BC6A0927224B890026AB9F /* NimbusWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BC6A0827224B890026AB9F /* NimbusWrapper.swift */; };
@@ -1009,6 +1010,7 @@
 		F861799C2795EE9800CFD324 /* InternalExperimentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalExperimentDetailView.swift; sourceTree = "<group>"; };
 		F861799E27961F4200CFD324 /* InternalSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalSettings.swift; sourceTree = "<group>"; };
 		F86D00602790978700E83177 /* InternalSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalSettingsView.swift; sourceTree = "<group>"; };
+		F8714D2027A1E1F400CEB695 /* InternalCrashReportingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalCrashReportingSettingsView.swift; sourceTree = "<group>"; };
 		F8820C7126E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Intro.strings"; sourceTree = "<group>"; };
 		F8820C7226E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Intents.strings"; sourceTree = "<group>"; };
 		F8820C7326E19B1E006AB3B8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -1592,6 +1594,7 @@
 				F861799E27961F4200CFD324 /* InternalSettings.swift */,
 				F86D00602790978700E83177 /* InternalSettingsView.swift */,
 				F861799A2795D95E00CFD324 /* InternalExperimentsSettingsView.swift */,
+				F8714D2027A1E1F400CEB695 /* InternalCrashReportingSettingsView.swift */,
 				F861799C2795EE9800CFD324 /* InternalExperimentDetailView.swift */,
 				D5D067FA252F945D00C35227 /* metrics.yaml */,
 			);
@@ -2270,6 +2273,7 @@
 				D3561B2B1DB5925100A5EEAF /* GradientBackgroundView.swift in Sources */,
 				C82D143026EF62BE007B275C /* TipsPageViewController.swift in Sources */,
 				C8337DF42710898800093D42 /* ImageLoader.swift in Sources */,
+				F8714D2127A1E1F400CEB695 /* InternalCrashReportingSettingsView.swift in Sources */,
 				F8BC6A0727224B170026AB9F /* NimbusExtensions.swift in Sources */,
 				C8415DB326E9FA38008BAAA2 /* UIApplication+Orientation.swift in Sources */,
 				60D779C327469A2300DF8047 /* DesignSystem.swift in Sources */,

--- a/Blockzilla/InternalCrashReportingSettingsView.swift
+++ b/Blockzilla/InternalCrashReportingSettingsView.swift
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import SwiftUI
+import Sentry
+
+struct InternalCrashReportingSettingsView: View {
+    var body: some View {
+        Form {
+            SwiftUI.Section(header: Text("Crash Triggers")) {
+                Button("SentrySDK.crash()") {
+                    SentrySDK.crash()
+                }
+                Button("SentrySDK.capture(message:)") {
+                    SentrySDK.capture(message: "Test")
+                }
+                Button("SentrySDK.capture(exception:)") {
+                    SentrySDK.capture(exception: NSException(name: .genericException, reason: "Test Exception", userInfo: ["UserInfo": "Something"]))
+                }
+                Button("SentrySDK.capture(error:)") {
+                    SentrySDK.capture(error: NSError(domain: "TestDomain", code: 42, userInfo: ["UserInfo": "Something"]))
+                }
+            }
+        }.navigationBarTitle("Crash Reporting Settings")
+    }
+}
+
+struct InternalCrashReportingSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        InternalCrashReportingSettingsView()
+    }
+}

--- a/Blockzilla/InternalSettingsView.swift
+++ b/Blockzilla/InternalSettingsView.swift
@@ -13,6 +13,11 @@ struct InternalSettingsView: View {
                 }
             }
             SwiftUI.Section {
+                NavigationLink("Crash Reporting") {
+                    InternalCrashReportingSettingsView()
+                }
+            }
+            SwiftUI.Section {
                 Text("The settings in this section are used by Focus developers and testers.")
                     .font(.caption)
             }


### PR DESCRIPTION
This patch adds another internal settings screen to trigger Sentry crashes and reports. This is just for testing the Sentry integration.