### PR TITLE
Fixes #3009 - Strings for Internal Settings should not be exported

### DIFF
--- a/Blockzilla/InternalCrashReportingSettingsView.swift
+++ b/Blockzilla/InternalCrashReportingSettingsView.swift
@@ -8,7 +8,7 @@ import Sentry
 struct InternalCrashReportingSettingsView: View {
     var body: some View {
         Form {
-            SwiftUI.Section(header: Text("Crash Triggers")) {
+            SwiftUI.Section(header: Text(verbatim: "Crash Triggers")) {
                 Button("SentrySDK.crash()") {
                     SentrySDK.crash()
                 }
@@ -22,7 +22,7 @@ struct InternalCrashReportingSettingsView: View {
                     SentrySDK.capture(error: NSError(domain: "TestDomain", code: 42, userInfo: ["UserInfo": "Something"]))
                 }
             }
-        }.navigationBarTitle("Crash Reporting Settings")
+        }.navigationBarTitle(Text(verbatim: "Crash Reporting Settings"))
     }
 }
 

--- a/Blockzilla/InternalCrashReportingSettingsView.swift
+++ b/Blockzilla/InternalCrashReportingSettingsView.swift
@@ -9,17 +9,17 @@ struct InternalCrashReportingSettingsView: View {
     var body: some View {
         Form {
             SwiftUI.Section(header: Text(verbatim: "Crash Triggers")) {
-                Button("SentrySDK.crash()") {
-                    SentrySDK.crash()
+                Button(action: { SentrySDK.crash() }) {
+                    Text(verbatim: "SentrySDK.crash()")
                 }
-                Button("SentrySDK.capture(message:)") {
-                    SentrySDK.capture(message: "Test")
+                Button(action: { SentrySDK.capture(message: "Test") }) {
+                    Text(verbatim: "SentrySDK.capture(message:)")
                 }
-                Button("SentrySDK.capture(exception:)") {
-                    SentrySDK.capture(exception: NSException(name: .genericException, reason: "Test Exception", userInfo: ["UserInfo": "Something"]))
+                Button(action: { SentrySDK.capture(exception: NSException(name: .genericException, reason: "Test Exception", userInfo: ["UserInfo": "Something"])) }) {
+                    Text(verbatim: "SentrySDK.capture(exception:)")
                 }
-                Button("SentrySDK.capture(error:)") {
-                    SentrySDK.capture(error: NSError(domain: "TestDomain", code: 42, userInfo: ["UserInfo": "Something"]))
+                Button(action: { SentrySDK.capture(error: NSError(domain: "TestDomain", code: 42, userInfo: ["UserInfo": "Something"])) }) {
+                    Text(verbatim: "SentrySDK.capture(error:)")
                 }
             }
         }.navigationBarTitle(Text(verbatim: "Crash Reporting Settings"))

--- a/Blockzilla/InternalExperimentDetailView.swift
+++ b/Blockzilla/InternalExperimentDetailView.swift
@@ -24,24 +24,24 @@ extension InternalExperimentDetailView: View {
     var body: some View {
         Form {
             SwiftUI.Section {
-                Text(experiment.userFacingDescription)
+                Text(verbatim: experiment.userFacingDescription)
             }
-            SwiftUI.Section(header: Text("Available Branches")) {
+            SwiftUI.Section(header: Text(verbatim: "Available Branches")) {
                 ForEach(experiment.branches, id: \.slug) { branch in
                     HStack {
-                        Text(branch.slug)
+                        Text(verbatim: branch.slug)
                         Spacer()
-                        Text("\(branch.ratio)")
+                        Text(verbatim: "\(branch.ratio)")
                     }
                 }
             }
             SwiftUI.Section {
-                Picker(selection: $selectedBranchSlug, label: Text("Active Branch")) {
+                Picker(selection: $selectedBranchSlug, label: Text(verbatim: "Active Branch")) {
                     ForEach(pickerBranches, id: \.self) { branch in
                         if branch == notEnrolledBranchSlug {
-                            Text("Not Enrolled")
+                            Text(verbatim: "Not Enrolled")
                         } else {
-                            Text(branch)
+                            Text(verbatim: branch)
                         }
                     }
                 }.onReceive(Just(selectedBranchSlug)) { newValue in
@@ -58,7 +58,7 @@ extension InternalExperimentDetailView: View {
                     }
                 }
             }
-        }.navigationBarTitle(experiment.userFacingName)
+        }.navigationBarTitle(Text(verbatim: experiment.userFacingName))
     }
 }
 

--- a/Blockzilla/InternalExperimentsSettingsView.swift
+++ b/Blockzilla/InternalExperimentsSettingsView.swift
@@ -13,35 +13,35 @@ struct InternalExperimentsSettingsView {
 extension InternalExperimentsSettingsView: View {
     var body: some View {
         Form {
-            SwiftUI.Section(header: Text("Settings")) {
+            SwiftUI.Section(header: Text(verbatim: "Settings")) {
                 Toggle(isOn: $internalSettings.useStagingServer) {
                     VStack(alignment: .leading) {
-                        Text("Use Staging Server")
-                        Text("Requires app restart").font(.caption)
+                        Text(verbatim: "Use Staging Server")
+                        Text(verbatim: "Requires app restart").font(.caption)
                     }
                 }
                 Toggle(isOn: $internalSettings.usePreviewCollection) {
                     VStack(alignment: .leading) {
-                        Text("Use Preview Collection")
-                        Text("Requires app restart").font(.caption)
+                        Text(verbatim: "Use Preview Collection")
+                        Text(verbatim: "Requires app restart").font(.caption)
                     }
                 }
             }
-            SwiftUI.Section(header: Text("Available Experiments")) {
+            SwiftUI.Section(header: Text(verbatim: "Available Experiments")) {
                 if availableExperiments.isEmpty {
-                    Text("No Experiments Found")
+                    Text(verbatim: "No Experiments Found")
                 } else {
                     ForEach(availableExperiments, id: \.slug) { experiment in
                         NavigationLink(destination: InternalExperimentDetailView(experiment: experiment)) {
                             VStack(alignment: .leading) {
-                                Text(experiment.userFacingName)
-                                Text(experiment.slug).font(.caption)
+                                Text(verbatim: experiment.userFacingName)
+                                Text(verbatim: experiment.slug).font(.caption)
                             }
                         }
                     }
                 }
             }
-        }.navigationBarTitle("Experiments Settings")
+        }.navigationBarTitle(Text(verbatim: "Experiments Settings"))
     }
 }
 

--- a/Blockzilla/InternalSettingsView.swift
+++ b/Blockzilla/InternalSettingsView.swift
@@ -8,13 +8,13 @@ struct InternalSettingsView: View {
     var body: some View {
         Form {
             SwiftUI.Section {
-                NavigationLink("Experiments") {
-                    InternalExperimentsSettingsView(availableExperiments: NimbusWrapper.shared.getAvailableExperiments())
+                NavigationLink(destination: InternalExperimentsSettingsView(availableExperiments: NimbusWrapper.shared.getAvailableExperiments())) {
+                    Text(verbatim: "Experiments")
                 }
             }
             SwiftUI.Section {
-                NavigationLink("Crash Reporting") {
-                    InternalCrashReportingSettingsView()
+                NavigationLink(destination: InternalCrashReportingSettingsView()) {
+                    Text(verbatim: "Crash Reporting")
                 }
             }
             SwiftUI.Section {

--- a/Blockzilla/InternalSettingsView.swift
+++ b/Blockzilla/InternalSettingsView.swift
@@ -18,10 +18,10 @@ struct InternalSettingsView: View {
                 }
             }
             SwiftUI.Section {
-                Text("The settings in this section are used by Focus developers and testers.")
+                Text(verbatim: "The settings in this section are used by Focus developers and testers.")
                     .font(.caption)
             }
-        }.navigationBarTitle("Internal Settings")
+        }.navigationBarTitle(Text(verbatim: "Internal Settings"))
     }
 }
 


### PR DESCRIPTION
This patch changes all `Text()` objects in the internal settings to `Text(verbatim:)`. Using `verbatim:` prevents the strings from being exported by `xcodebuild -exportLocalizations`.