### PR TITLE
Fixes #3012 - Add Glean debug settings to Internal Settings

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		D8E0156E1FD9E40F00CA3B9F /* DomainCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E0156D1FD9E40F00CA3B9F /* DomainCompletionTests.swift */; };
 		E40AFB141DC939FF00DA5651 /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB131DC939FF00DA5651 /* SupportUtils.swift */; };
 		E40AFC741DDDE96D00DA5651 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E40AFC761DDDE96D00DA5651 /* InfoPlist.strings */; };
+		E439815127AAD63200F382B0 /* InternalTelemetrySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E439815027AAD63200F382B0 /* InternalTelemetrySettingsView.swift */; };
 		E44A346A1E0A18C100BFD777 /* SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44A34691E0A18C100BFD777 /* SnapshotTests.swift */; };
 		E44A34761E0A198000BFD777 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44A34751E0A198000BFD777 /* SnapshotHelper.swift */; };
 		E4BC84F11E2A862400833B45 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E4BC84F31E2A862400833B45 /* InfoPlist.strings */; };
@@ -825,6 +826,7 @@
 		E436961C1E4AC70F0023D5F0 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E436961D1E4AC70F0023D5F0 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E436961E1E4AC70F0023D5F0 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E439815027AAD63200F382B0 /* InternalTelemetrySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalTelemetrySettingsView.swift; sourceTree = "<group>"; };
 		E447176720B5C33C00CC8507 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/Intro.strings; sourceTree = "<group>"; };
 		E447176820B5C33C00CC8507 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E447176C20B5C33C00CC8507 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1596,6 +1598,7 @@
 				F861799A2795D95E00CFD324 /* InternalExperimentsSettingsView.swift */,
 				F8714D2027A1E1F400CEB695 /* InternalCrashReportingSettingsView.swift */,
 				F861799C2795EE9800CFD324 /* InternalExperimentDetailView.swift */,
+				E439815027AAD63200F382B0 /* InternalTelemetrySettingsView.swift */,
 				D5D067FA252F945D00C35227 /* metrics.yaml */,
 			);
 			path = Blockzilla;
@@ -2235,6 +2238,7 @@
 				D33A1AB11BC48FAC0003D929 /* SettingsViewController.swift in Sources */,
 				747ADA181FC38EFC00970132 /* IntroViewController.swift in Sources */,
 				D30AEEBB1DE4CB1B0096A2E7 /* FileManagerExtensions.swift in Sources */,
+				E439815127AAD63200F382B0 /* InternalTelemetrySettingsView.swift in Sources */,
 				D36C1BAA1DB02EBB0073C1AB /* OpenUtils.swift in Sources */,
 				D364DC261DC4163700562991 /* BrowserToolset.swift in Sources */,
 				D3E54FD11DEFB063003E1AFF /* SearchEngineManager.swift in Sources */,

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -423,10 +423,20 @@ extension AppDelegate {
             .flatMap(UUID.init(uuidString:)) {
             GleanMetrics.LegacyIds.clientId.set(clientId)
         }
+        
+        if UserDefaults.standard.bool(forKey: GleanLogPingsToConsole) {
+            Glean.shared.handleCustomUrl(url: URL(string: "focus-glean-settings://glean?logPings=true")!)
+        }
+        
+        if UserDefaults.standard.bool(forKey: GleanEnableDebugView) {
+            if let tag = UserDefaults.standard.string(forKey: GleanDebugViewTag), !tag.isEmpty, let encodedTag = tag.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed) {
+                Glean.shared.handleCustomUrl(url: URL(string: "focus-glean-settings://glean?debugViewTag=\(encodedTag)")!)
+            }
+        }
 
         let channel = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" ? "testflight" : "release"
         Glean.shared.initialize(uploadEnabled: Settings.getToggle(.sendAnonymousUsageData), configuration: Configuration(channel: channel), buildInfo: GleanMetrics.GleanBuild.info)
-        
+
         // Send "at startup" telemetry
         GleanMetrics.Shortcuts.shortcutsOnHomeNumber.set(Int64(ShortcutsManager.shared.numberOfShortcuts))
         GleanMetrics.TrackingProtection.hasAdvertisingBlocked.set(Settings.getToggle(.blockAds))

--- a/Blockzilla/InternalSettings.swift
+++ b/Blockzilla/InternalSettings.swift
@@ -5,6 +5,10 @@
 import Foundation
 import Combine
 
+let GleanEnableDebugView = "GleanEnableDebugView"
+let GleanDebugViewTag = "GleanDebugViewTag"
+let GleanLogPingsToConsole = "GleanLogPingsToConsole"
+
 final class InternalSettings: ObservableObject {
     let objectWillChange = PassthroughSubject<Void, Never>()
 
@@ -17,6 +21,27 @@ final class InternalSettings: ObservableObject {
 
     @UserDefault(key: NimbusUsePreviewCollectionDefault, defaultValue: false)
     var usePreviewCollection: Bool {
+        willSet {
+            objectWillChange.send()
+        }
+    }
+
+    @UserDefault(key: GleanEnableDebugView, defaultValue: false)
+    var gleanEnableDebugView: Bool {
+        willSet {
+            objectWillChange.send()
+        }
+    }
+
+    @UserDefault(key: GleanDebugViewTag, defaultValue: "")
+    var gleanDebugViewTag: String {
+        willSet {
+            objectWillChange.send()
+        }
+    }
+
+    @UserDefault(key: GleanLogPingsToConsole, defaultValue: false)
+    var gleanLogPingsToConsole: Bool {
         willSet {
             objectWillChange.send()
         }

--- a/Blockzilla/InternalSettingsView.swift
+++ b/Blockzilla/InternalSettingsView.swift
@@ -13,6 +13,11 @@ struct InternalSettingsView: View {
                 }
             }
             SwiftUI.Section {
+                NavigationLink(destination: InternalTelemetrySettingsView()) {
+                    Text(verbatim: "Telemetry")
+                }
+            }
+            SwiftUI.Section {
                 NavigationLink(destination: InternalCrashReportingSettingsView()) {
                     Text(verbatim: "Crash Reporting")
                 }

--- a/Blockzilla/InternalTelemetrySettingsView.swift
+++ b/Blockzilla/InternalTelemetrySettingsView.swift
@@ -31,7 +31,7 @@ extension InternalTelemetrySettingsView {
 extension InternalTelemetrySettingsView: View {
     var body: some View {
         Form {
-            if #available(iOS 16, *) {
+            if #available(iOS 14, *) {
                 SwiftUI.Section(header: Text(verbatim: "Logging")) {
                     Toggle(isOn: $internalSettings.gleanLogPingsToConsole) {
                         VStack(alignment: .leading) {

--- a/Blockzilla/InternalTelemetrySettingsView.swift
+++ b/Blockzilla/InternalTelemetrySettingsView.swift
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Combine
+import SwiftUI
+import Glean
+
+private let GleanDebugViewURL = URL(string: "https://debug-ping-preview.firebaseapp.com")!
+
+struct InternalTelemetrySettingsView {
+    @ObservedObject var internalSettings = InternalSettings()
+}
+
+extension InternalTelemetrySettingsView {
+    func sendPendingEventPings() {
+        Glean.shared.handleCustomUrl(url: URL(string: "focus-glean-settings://glean?sendPing=events")!)
+    }
+    
+    func changeLogPingsToConsole(_ value: Bool) {
+        Glean.shared.handleCustomUrl(url: URL(string: "focus-glean-settings://glean?logPings=\(value)")!)
+    }
+    
+    func changeDebugViewTag(_ tag: String) {
+        if let encodedTag = tag.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed) {
+            Glean.shared.handleCustomUrl(url: URL(string: "focus-glean-settings://glean?debugViewTag=\(encodedTag)")!)
+        }
+    }
+}
+
+extension InternalTelemetrySettingsView: View {
+    var body: some View {
+        Form {
+            if #available(iOS 16, *) {
+                SwiftUI.Section(header: Text(verbatim: "Logging")) {
+                    Toggle(isOn: $internalSettings.gleanLogPingsToConsole) {
+                        VStack(alignment: .leading) {
+                            Text(verbatim: "Log Pings to Console")
+                        }
+                    }.onChange(of: internalSettings.gleanLogPingsToConsole, perform: changeLogPingsToConsole)
+                }
+                
+                SwiftUI.Section(header: Text(verbatim: "Debug View")) {
+                    Toggle(isOn: $internalSettings.gleanEnableDebugView) {
+                        VStack(alignment: .leading) {
+                            Text(verbatim: "Enable Debug View")
+                            Text(verbatim: "Requires app restart").font(.caption)
+                        }
+                    }.disabled(internalSettings.gleanDebugViewTag.isEmpty)
+                    
+                    VStack(alignment: .leading) {
+                        TextField("Debug View Tag", text: $internalSettings.gleanDebugViewTag)
+                            .onChange(of: internalSettings.gleanDebugViewTag, perform: changeDebugViewTag)
+                    }
+                    
+                    Button(action: { UIApplication.shared.open(GleanDebugViewURL) }) {
+                        Text(verbatim: "Open Debug View (In Default Browser)")
+                    }
+
+                    Button(action: { UIPasteboard.general.url = GleanDebugViewURL }) {
+                        Text(verbatim: "Copy Debug View Link")
+                    }
+                }
+
+                SwiftUI.Section {
+                    Button(action: { sendPendingEventPings() }) {
+                        Text(verbatim: "Send Pending Event Pings")
+                    }
+                }
+            } else {
+                Text(verbatim: "Internal Telemetry Settings are only available on iOS 14 and newer.")
+            }
+        }.navigationBarTitle(Text(verbatim: "Telemetry"))
+    }
+}
+
+struct InternalTelemetrySettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        InternalTelemetrySettingsView()
+    }
+}


### PR DESCRIPTION
This patch adds a _Telemetry Settings_ section to the _Internal Settings_. From there you can enable loggins, the Glean Debug View and also send all pending event pings.

Because of some SwiftUI issues I made this view require iOS 14. I think for testing that is not a problem.