### PR TITLE
Update to A-S 91.0.0 and add direct Glean dependency

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		C8EADCD22742A00300E76AE6 /* MenuActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EADCD12742A00300E76AE6 /* MenuActionable.swift */; };
 		C8EADCD42742A0AB00E76AE6 /* MenuItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EADCD32742A0AB00E76AE6 /* MenuItemProvider.swift */; };
 		C8F3EABF2762558F00C2AF0C /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F3EABE2762558F00C2AF0C /* SplashView.swift */; };
+		CDFA746F27ABD43D0055FE55 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = CDFA746E27ABD43D0055FE55 /* Glean */; };
 		D025F225218B64D600B262D8 /* SearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D025F224218B64D600B262D8 /* SearchEngineTests.swift */; };
 		D0967A811EC50002009D937F /* TelemetryIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0967A801EC50002009D937F /* TelemetryIntegration.swift */; };
 		D30179071BC6CB19009AD388 /* BlockerEnabledDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30179061BC6CB19009AD388 /* BlockerEnabledDetector.swift */; };
@@ -1092,6 +1093,7 @@
 				F85F7A292655AD5800395515 /* SnapKit in Frameworks */,
 				1B56C58727221B1C00BB1152 /* RustLog in Frameworks */,
 				1B56C58927221B1C00BB1152 /* Viaduct in Frameworks */,
+				CDFA746F27ABD43D0055FE55 /* Glean in Frameworks */,
 				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
 				F8B92FBE279EC73700183998 /* Sentry in Frameworks */,
 				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
@@ -1740,6 +1742,7 @@
 				1B56C58627221B1C00BB1152 /* RustLog */,
 				1B56C58827221B1C00BB1152 /* Viaduct */,
 				F8B92FBD279EC73700183998 /* Sentry */,
+				CDFA746E27ABD43D0055FE55 /* Glean */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1919,6 +1922,7 @@
 				F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */,
 				1B56C58327221B1C00BB1152 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
 				F8B92FBC279EC73700183998 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				CDFA746D27ABD43D0055FE55 /* XCRemoteSwiftPackageReference "glean-swift" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -5475,7 +5479,15 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 90.0.0;
+				minimumVersion = 91.0.0;
+			};
+		};
+		CDFA746D27ABD43D0055FE55 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mozilla/glean-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 43.0.2;
 			};
 		};
 		F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {
@@ -5527,6 +5539,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1B56C58327221B1C00BB1152 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = Viaduct;
+		};
+		CDFA746E27ABD43D0055FE55 /* Glean */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDFA746D27ABD43D0055FE55 /* XCRemoteSwiftPackageReference "glean-swift" */;
+			productName = Glean;
 		};
 		F85F7A282655AD5800395515 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -30,9 +30,6 @@
 		16ABCD2621406D5500CABBF4 /* Intents.strings in Resources */ = {isa = PBXBuildFile; fileRef = 16ABCD2821406D5500CABBF4 /* Intents.strings */; };
 		16D465B12127891000FEC226 /* SiriFavoriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D465B02127891000FEC226 /* SiriFavoriteViewController.swift */; };
 		16D7169C2114EF76000C8A66 /* BlockerToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D7169B2114EF72000C8A66 /* BlockerToggle.swift */; };
-		1B56C58527221B1C00BB1152 /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 1B56C58427221B1C00BB1152 /* Nimbus */; };
-		1B56C58727221B1C00BB1152 /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 1B56C58627221B1C00BB1152 /* RustLog */; };
-		1B56C58927221B1C00BB1152 /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 1B56C58827221B1C00BB1152 /* Viaduct */; };
 		1D199EF220D813D300CDF976 /* DragAndDropTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D199EF120D813D300CDF976 /* DragAndDropTest.swift */; };
 		1D3BEDF920C5E6C70019B722 /* FindInPage.js in Resources */ = {isa = PBXBuildFile; fileRef = 1D3BEDF820C5E6C70019B722 /* FindInPage.js */; };
 		1D3BEDFB20C5E76B0019B722 /* FindInPageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3BEDFA20C5E76A0019B722 /* FindInPageBar.swift */; };
@@ -122,6 +119,7 @@
 		C8EADCD22742A00300E76AE6 /* MenuActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EADCD12742A00300E76AE6 /* MenuActionable.swift */; };
 		C8EADCD42742A0AB00E76AE6 /* MenuItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EADCD32742A0AB00E76AE6 /* MenuItemProvider.swift */; };
 		C8F3EABF2762558F00C2AF0C /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F3EABE2762558F00C2AF0C /* SplashView.swift */; };
+		CD2029FF27B1462600475C7F /* MozillaAppServices in Frameworks */ = {isa = PBXBuildFile; productRef = CD2029FE27B1462600475C7F /* MozillaAppServices */; };
 		CDFA746F27ABD43D0055FE55 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = CDFA746E27ABD43D0055FE55 /* Glean */; };
 		D025F225218B64D600B262D8 /* SearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D025F224218B64D600B262D8 /* SearchEngineTests.swift */; };
 		D0967A811EC50002009D937F /* TelemetryIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0967A801EC50002009D937F /* TelemetryIntegration.swift */; };
@@ -1091,10 +1089,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1B56C58527221B1C00BB1152 /* Nimbus in Frameworks */,
 				F85F7A292655AD5800395515 /* SnapKit in Frameworks */,
-				1B56C58727221B1C00BB1152 /* RustLog in Frameworks */,
-				1B56C58927221B1C00BB1152 /* Viaduct in Frameworks */,
+				CD2029FF27B1462600475C7F /* MozillaAppServices in Frameworks */,
 				CDFA746F27ABD43D0055FE55 /* Glean in Frameworks */,
 				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
 				F8B92FBE279EC73700183998 /* Sentry in Frameworks */,
@@ -1741,11 +1737,9 @@
 				F85F7A282655AD5800395515 /* SnapKit */,
 				F85F7A2A2655AD5800395515 /* Fuzi */,
 				F85F7A2E2655AD5800395515 /* Telemetry */,
-				1B56C58427221B1C00BB1152 /* Nimbus */,
-				1B56C58627221B1C00BB1152 /* RustLog */,
-				1B56C58827221B1C00BB1152 /* Viaduct */,
 				F8B92FBD279EC73700183998 /* Sentry */,
 				CDFA746E27ABD43D0055FE55 /* Glean */,
+				CD2029FE27B1462600475C7F /* MozillaAppServices */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -5483,7 +5477,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 91.0.0;
+				minimumVersion = 91.0.1;
 			};
 		};
 		CDFA746D27ABD43D0055FE55 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
@@ -5529,20 +5523,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1B56C58427221B1C00BB1152 /* Nimbus */ = {
+		CD2029FE27B1462600475C7F /* MozillaAppServices */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 1B56C58327221B1C00BB1152 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = Nimbus;
-		};
-		1B56C58627221B1C00BB1152 /* RustLog */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1B56C58327221B1C00BB1152 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = RustLog;
-		};
-		1B56C58827221B1C00BB1152 /* Viaduct */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1B56C58327221B1C00BB1152 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = Viaduct;
+			productName = MozillaAppServices;
 		};
 		CDFA746E27ABD43D0055FE55 /* Glean */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "4ca440b59654116dd4506f165d7876e9442f5b29",
-          "version": "90.0.0"
+          "revision": "53d2f85c6d2e579859605cbc73cc7b194484f83b",
+          "version": "91.0.0"
         }
       },
       {
@@ -44,15 +44,6 @@
           "branch": null,
           "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
           "version": "5.0.1"
-        }
-      },
-      {
-        "package": "SwiftKeychainWrapper",
-        "repositoryURL": "https://github.com/jrendel/SwiftKeychainWrapper",
-        "state": {
-          "branch": null,
-          "revision": "185a3165346a03767101c4f62e9a545a0fe0530f",
-          "version": "4.0.1"
         }
       },
       {

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "53d2f85c6d2e579859605cbc73cc7b194484f83b",
-          "version": "91.0.0"
+          "revision": "001d704cd61ee0b88f078cc125caefecd8180467",
+          "version": "91.0.1"
         }
       },
       {

--- a/Blockzilla/InternalExperimentDetailView.swift
+++ b/Blockzilla/InternalExperimentDetailView.swift
@@ -4,7 +4,7 @@
 
 import Combine
 import SwiftUI
-import Nimbus
+import MozillaAppServices
 
 private let notEnrolledBranchSlug = "not-enrolled"
 

--- a/Blockzilla/InternalExperimentsSettingsView.swift
+++ b/Blockzilla/InternalExperimentsSettingsView.swift
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import SwiftUI
-import Nimbus
+import MozillaAppServices
 
 struct InternalExperimentsSettingsView {
     let availableExperiments: [AvailableExperiment]

--- a/Blockzilla/NimbusExtensions.swift
+++ b/Blockzilla/NimbusExtensions.swift
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Nimbus
+import MozillaAppServices
 
 private let NimbusServerURLKey = "NimbusServerURL"
 private let NimbusStagingServerURLKey = "NimbusStagingServerURL"

--- a/Blockzilla/NimbusWrapper.swift
+++ b/Blockzilla/NimbusWrapper.swift
@@ -4,9 +4,7 @@
 
 import os.log
 
-import RustLog
-import Viaduct
-import Nimbus
+import MozillaAppServices
 
 
 let NimbusUseStagingServerDefault = "NimbusUseStagingServer"


### PR DESCRIPTION
rust-component 91 is dropping the Glean dependency.
It now needs to be cosumed directly again.

---

supersedes #3016 