### PR TITLE
Fixes #3003 Migrate Legacy Telemetry for Search Suggestions 

### DIFF
--- a/Blockzilla/SearchSuggestionsPromptView.swift
+++ b/Blockzilla/SearchSuggestionsPromptView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import SnapKit
 import Telemetry
+import Glean
 
 protocol SearchSuggestionsPromptViewDelegate: AnyObject {
     func searchSuggestionsPromptView(_ searchSuggestionsPromptView: SearchSuggestionsPromptView, didEnable: Bool)
@@ -123,10 +124,12 @@ class SearchSuggestionsPromptView: UIView {
     @objc private func didPressDisable() {
         delegate?.searchSuggestionsPromptView(self, didEnable: false)
         Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionsOff)
+        GleanMetrics.ShowSearchSuggestions.disabledFromPanel.record()
     }
 
     @objc private func didPressEnable() {
         delegate?.searchSuggestionsPromptView(self, didEnable: true)
         Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionsOn)
+        GleanMetrics.ShowSearchSuggestions.enabledFromPanel.record()
     }
 }

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -560,6 +560,14 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         case .enableSearchSuggestions:
             UserDefaults.standard.set(true, forKey: SearchSuggestionsPromptView.respondedToSearchSuggestionsPrompt)
             updateSetting()
+            GleanMetrics
+                .ShowSearchSuggestions
+                .changedFromSettings
+                .record(
+                    GleanMetrics
+                        .ShowSearchSuggestions
+                        .ChangedFromSettingsExtra(isEnabled: sender.isOn)
+                )
         case .showHomeScreenTips:
             updateSetting()
             // This update must occur after the setting has been updated to properly take effect.

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -319,7 +319,7 @@ show_search_suggestions:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/5858
+      - https://github.com/mozilla-mobile/focus-ios/pull/3031
     data_sensitivity:
       - interaction
     notification_emails:
@@ -331,7 +331,7 @@ show_search_suggestions:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/5858
+      - https://github.com/mozilla-mobile/focus-ios/pull/3031
     data_sensitivity:
       - interaction
     notification_emails:
@@ -343,7 +343,7 @@ show_search_suggestions:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/5858
+      - https://github.com/mozilla-mobile/focus-ios/pull/3031
     data_sensitivity:
       - interaction
     notification_emails:
@@ -361,7 +361,7 @@ search_suggestions:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/5864
+      - https://github.com/mozilla-mobile/focus-ios/pull/3031
     data_sensitivity:
       - interaction
     notification_emails:
@@ -377,7 +377,7 @@ search_suggestions:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/5864
+      - https://github.com/mozilla-mobile/focus-ios/pull/3031
     data_sensitivity:
       - interaction
     notification_emails:
@@ -393,7 +393,7 @@ search_suggestions:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/5864
+      - https://github.com/mozilla-mobile/focus-ios/pull/3031
     data_sensitivity:
       - interaction
     notification_emails:

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -289,3 +289,113 @@ preferences:
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: "2022-10-01"
+
+browser_menu:
+  browser_menu_action:
+    type: event
+    description: The user has tapped on a browser menu item.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3004
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-ios/pull/3015
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-02"
+    extra_keys:
+      item:
+        description: |
+          A string containing the name of the item the user tapped:
+          settings, open_in_firefox, open_in_chrome, open_in_default_browser,
+          share, copy_url, desktop_view_off, desktop_view_on, find_in_page,
+          add_to_shortcuts, remove_from_shortcuts
+        type: string
+
+show_search_suggestions:
+  enabled_from_panel:
+    type: event
+    description: The "yes" option from the suggestion panel has been tapped.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3003
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5858
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-14"
+  disabled_from_panel:
+    type: event
+    description: The "no"" option from the suggestion panel has been tapped.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3003
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5858
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-14"
+  changed_from_settings:
+    type: event
+    description: The enabled state has been changed from the settings screen.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3003
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5858
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-14"
+    extra_keys:
+      is_enabled:
+        description: The new setting value, true for ON, false for OFF
+        type: boolean
+
+search_suggestions:
+  suggestion_tapped:
+    type: event
+    description: Search suggestion selected.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3003
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5864
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-14"
+    extra_keys:
+      engine_name:
+        description: The name of the engine used to perform the search.
+        type: string
+  search_tapped:
+    type: event
+    description: The typed text search was selected.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3003
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5864
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-14"
+    extra_keys:
+      engine_name:
+        description: The name of the engine used to perform the search.
+        type: string
+  autocomplete_arrow_tapped:
+    type: event
+    description: Search suggestion selected.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3003
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5864
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-14"


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_

How often do users choose items from search suggestions?
Are users enabling search suggestions, and how are they doing it?

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_

This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_

This is the only way.

_4) Can current instrumentation answer these questions?_

No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Search Suggestion tapped</td>
    <td>Category 2</td>
    <td>#3003</td>
 </tr>
<tr>
    <td>Typed text search tapped</td>
    <td>Category 2</td>
    <td>#3003</td>
 </tr>
<tr>
    <td>autocomplete arrow tapped</td>
    <td>Category 2</td>
    <td>#3003</td>
 </tr>
<tr>
    <td>Search suggestions enabled from prompt</td>
    <td>Category 2</td>
    <td>#3003</td>
 </tr>
<tr>
    <td>Search suggestions disabled from prompt</td>
    <td>Category 2</td>
    <td>#3003</td>
 </tr>
<tr>
    <td>Search suggestions toggled from settings</td>
    <td>Category 2</td>
    <td>#3003</td>
 </tr>
</table>

_6) How long will this data be collected?  Choose one of the following:_

Expiry for capturing data is set to "2023-02-14"

_7) What populations will you measure?_

All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_

 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._

 Glean 

_10) Where do you intend to share the results of your analysis?_

Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_

No.
