### PR TITLE
Fixes #3000 Migrate Legacy Telemetry for Siri

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -270,6 +270,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
             browserViewController.resetBrowser(hidePreviousSession: true)
             Settings.setSiriRequestErase(to: false)
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.siri, object: TelemetryEventObject.eraseInBackground)
+            GleanMetrics.Siri.eraseInBackground.record()
         }
         Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.foreground, object: TelemetryEventObject.app)
 
@@ -323,6 +324,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
         case "org.mozilla.ios.Klar.eraseAndOpen":
             browserViewController.resetBrowser(hidePreviousSession: true)
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.siri, object: TelemetryEventObject.eraseAndOpen)
+            GleanMetrics.Siri.eraseAndOpen.record()
         case "org.mozilla.ios.Klar.openUrl":
             guard let urlString = userActivity.userInfo?["url"] as? String,
                 let url = URL(string: urlString) else { return false }
@@ -331,10 +333,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate, AppSplashC
             browserViewController.deactivateUrlBarOnHomeView()
             browserViewController.submit(url: url)
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.siri, object: TelemetryEventObject.openFavoriteSite)
+            GleanMetrics.Siri.openFavoriteSite.record()
         case "EraseIntent":
             guard userActivity.interaction?.intent as? EraseIntent != nil else { return false }
             browserViewController.resetBrowser()
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.siri, object: TelemetryEventObject.eraseInBackground)
+            GleanMetrics.Siri.eraseInBackground.record()
         default: break
         }
         return true

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -349,3 +349,41 @@ url_interaction:
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: "2023-02-15"
+
+siri:
+  open_favorite_site:
+    type: event
+    description: Siri request open favorite site.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3000
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-ios/pull/3035
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-16"
+  erase_and_open:
+    type: event
+    description: Siri request erase session and open.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3000
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-ios/pull/3035
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-16"
+  erase_in_background:
+    type: event
+    description: Siri request erase session.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3000
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-ios/pull/3035
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-02-16"

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -357,7 +357,7 @@ siri:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3000
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-ios/pull/3035
+      - https://github.com/mozilla-mobile/focus-ios/pull/3040
     data_sensitivity:
       - interaction
     notification_emails:
@@ -369,7 +369,7 @@ siri:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3000
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-ios/pull/3035
+      - https://github.com/mozilla-mobile/focus-ios/pull/3040
     data_sensitivity:
       - interaction
     notification_emails:
@@ -381,7 +381,7 @@ siri:
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3000
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-ios/pull/3035
+      - https://github.com/mozilla-mobile/focus-ios/pull/3040
     data_sensitivity:
       - interaction
     notification_emails:


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_

How often do users use Siri to request request open favorite site?
How often do users use Siri to request erase session and open app?
How often do users use Siri to request erase session?

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_

This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_

This is the only way.

_4) Can current instrumentation answer these questions?_

No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Siri request open favorite site</td>
    <td>Category 2</td>
    <td>#3000</td>
 </tr>
<tr>
    <td>Siri request erase session and open</td>
    <td>Category 2</td>
    <td>#3000</td>
 </tr>
<tr>
    <td>Siri request erase session</td>
    <td>Category 2</td>
    <td>#3000</td>
 </tr>
</table>

_6) How long will this data be collected?  Choose one of the following:_

Expiry for capturing data is set to "2023-02-16"

_7) What populations will you measure?_

All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_

 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._

 Glean 

_10) Where do you intend to share the results of your analysis?_

Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_

No.
