### PR TITLE
Fixes #3061 - Tools options (nav arrow, trash button, hamburger menu) don't appear when rotating the device in circle after reaching second landscape mode 

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -111,7 +111,7 @@ class URLBar: UIView {
             guard oldValue != showToolset else { return }
             isIPadRegularDimensions = showToolset
             activateConstraints(showToolset, shownConstraints: showToolsetConstraints, hiddenConstraints: hideToolsetConstraints)
-            guard UIDevice.current.orientation.isLandscape else { return }
+            guard UIDevice.current.orientation.isLandscape && UIDevice.current.userInterfaceIdiom == .phone else { return }
             showToolset = false
         }
     }

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -111,6 +111,8 @@ class URLBar: UIView {
             guard oldValue != showToolset else { return }
             isIPadRegularDimensions = showToolset
             activateConstraints(showToolset, shownConstraints: showToolsetConstraints, hiddenConstraints: hideToolsetConstraints)
+            guard UIDevice.current.orientation.isLandscape else { return }
+            showToolset = false
         }
     }
     private var hideToolsetConstraints = [Constraint]()


### PR DESCRIPTION
## Commit message

Fixes #3061 - Tools options (nav arrow, trash button, hamburger menu) don't appear when rotating the device in circle after reaching second landscape mode

https://user-images.githubusercontent.com/51127880/156341095-e85d92bc-f451-4750-bfb7-c5e6fcaa9661.mp4

 