### PR TITLE
Fixes #3071 -  Implement a staging experiment for testing new vs old onboarding

### DIFF
--- a/Blockzilla/InternalOnboardingSettingsView.swift
+++ b/Blockzilla/InternalOnboardingSettingsView.swift
@@ -11,6 +11,9 @@ struct InternalOnboardingSettingsView {
 extension InternalOnboardingSettingsView: View {
     var body: some View {
         Form {
+            Toggle(isOn: $internalSettings.ignoreOnboardingExperiment) {
+                Text(verbatim: "Ignore Onboarding Experiment")
+            }
             Toggle(isOn: $internalSettings.alwaysShowOnboarding) {
                 Text(verbatim: "Always Show Onboarding")
             }

--- a/Blockzilla/InternalSettings.swift
+++ b/Blockzilla/InternalSettings.swift
@@ -10,6 +10,7 @@ let GleanDebugViewTag = "GleanDebugViewTag"
 let GleanLogPingsToConsole = "GleanLogPingsToConsole"
 let AlwaysShowOnboarding = "AlwaysShowOnboarding"
 let ShowNewOnboarding = "ShowNewOnboarding"
+let IgnoreOnboardingExperiment = "IgnoreOnboardingExperiment"
 
 final class InternalSettings: ObservableObject {
     let objectWillChange = PassthroughSubject<Void, Never>()
@@ -58,6 +59,13 @@ final class InternalSettings: ObservableObject {
 
     @UserDefault(key: ShowNewOnboarding, defaultValue: false)
     var showNewOnboarding: Bool {
+        willSet {
+            objectWillChange.send()
+        }
+    }
+    
+    @UserDefault(key: IgnoreOnboardingExperiment, defaultValue: false)
+    var ignoreOnboardingExperiment: Bool {
         willSet {
             objectWillChange.send()
         }

--- a/Blockzilla/NimbusWrapper.swift
+++ b/Blockzilla/NimbusWrapper.swift
@@ -94,4 +94,5 @@ extension NimbusWrapper {
 
 extension NimbusWrapper {
     var shouldHaveBoldTitle: Bool { nimbus?.getVariables(featureId: .nimbusValidation).getBool("bold-tip-title") == true }
+    var shouldShowNewOnboarding: Bool { nimbus?.getVariables(featureId: .nimbusValidation).getBool("show-new-onboarding") == true }
 }

--- a/Blockzilla/Onboarding/OnboardingEventsHandler.swift
+++ b/Blockzilla/Onboarding/OnboardingEventsHandler.swift
@@ -7,12 +7,16 @@ import Combine
 
 class OnboardingEventsHandler {
     
+    private let nimbus = NimbusWrapper.shared
+    
     var shouldShowNewOnboarding: Bool {
     #if DEBUG
+        guard UserDefaults.standard.bool(forKey: "IgnoreOnboardingExperiment") else {
+            return nimbus.shouldShowNewOnboarding
+        }
         return UserDefaults.standard.bool(forKey: "ShowNewOnboarding")
     #else
-        //TODO: Replace with suitable value from A/B Testing
-        return true
+        return nimbus.shouldShowNewOnboarding
     #endif
     }
     


### PR DESCRIPTION
This PR implements a Nimbus staging experiment in order to show the new or old onboarding.
This can be selected from Internal Settings, Experiments Section, onboarding-screen experiment and choose Control branch for showing the new onboarding or Treatment 1 branch for showing old onboarding.

(Since we also had the possibility to choose the old / new onboarding screen from Onboarding section in Internal Settings for DEBUG, I added a new toggle "Ignore Onboarding Experiment" that will ignore the experiment for the app, since now the value that comes from Nimbus is the main/default value depending on which we will update the onboarding UI.)


## Commit message
Fixes #3071 -  Implement a staging experiment for testing new vs old onboarding