### PR TITLE
Fixes #2865 - The ETP menu is still displayed even in a new session with no website open 

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -320,6 +320,9 @@ class BrowserViewController: UIViewController {
                             // Clear the browser session, as the user failed to authenticate
                             self.resetBrowser(hidePreviousSession: true)
                             self.appSplashController.hideSplashView()
+                            if presentedViewController != nil {
+                                presentedViewController?.dismiss(animated: true)
+                            }
                         }
                     }
                 }
@@ -328,6 +331,9 @@ class BrowserViewController: UIViewController {
                 Settings.set(false, forToggle: SettingsToggle.biometricLogin)
                 self.resetBrowser()
                 self.appSplashController.hideSplashView()
+                if self.presentedViewController != nil {
+                    self.presentedViewController?.dismiss(animated: true)
+                }
             }
         }
     }


### PR DESCRIPTION
## Commit message

https://user-images.githubusercontent.com/51127880/157407058-92fe252a-1348-477a-972b-73112e0ffc89.mp4

https://user-images.githubusercontent.com/51127880/157282903-408a7b75-867b-41d8-a00a-39219851842e.mp4

Fixes #2865 - The ETP menu is still displayed even in a new session with no website open


 