### PR TITLE
Fixes #3096 - Context Menu disappears after dismissing the keyboard, then rotating landscape, then portrait 

### DIFF
--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -841,7 +841,7 @@ class URLBar: UIView {
         toolset.backButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.forwardButton.alpha = shouldShowToolset ? expandAlpha : 0
         toolset.deleteButton.alpha = shouldShowToolset ? expandAlpha : 0
-        toolset.contextMenuButton.alpha = isEditing ? expandAlpha : (shouldShowToolset ? expandAlpha : 0)
+        toolset.contextMenuButton.alpha = expandAlpha
 
         collapsedTrackingProtectionBadge.alpha = 0
         if isEditing {


### PR DESCRIPTION
## Commit message
https://user-images.githubusercontent.com/51127880/157872866-70b80004-09b0-4aba-b6de-57f303b6754e.mp4

Fixes #3096 - Context Menu disappears after dismissing the keyboard, then rotating landscape, then portrait 