### PR TITLE
Fixes #3091 - The ETP tooltip is not centered on the shield icon

### DIFF
--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -14,7 +14,7 @@ struct UIConstants {
         static let deleteAnimationDuration: TimeInterval = 0.25
         static let shieldIconInset: Float = 9
         static let shieldIconIPadInset: Float = 15
-        static let shieldIconSize: Float = 19
+        static let shieldIconSize: Float = 24
         static let overlayAnimationDuration: TimeInterval = 0.25
         static let autocompleteAnimationDuration: TimeInterval = 0.2
         static let autocompleteAfterDelayDuration: TimeInterval = 0.5


### PR DESCRIPTION

<img width="593" alt="Screen Shot 2022-03-15 at 11 37 47 AM" src="https://user-images.githubusercontent.com/46751540/158352146-d47dff6a-6983-40e4-b391-19213be86e41.png">

<img width="1064" alt="Screen Shot 2022-03-15 at 11 37 52 AM" src="https://user-images.githubusercontent.com/46751540/158352195-b1219fe5-116e-42e0-8b5a-677fe0c654ba.png">


## Commit message
Fixes #3091 - The ETP tooltip is not centered on the shield icon