### PR TITLE
Fixes #3090 - The settings tooltip is not centered to the hamburger menu

### DIFF
--- a/Blockzilla/BrowserToolset.swift
+++ b/Blockzilla/BrowserToolset.swift
@@ -59,6 +59,7 @@ class BrowserToolset {
         contextMenuButton.accessibilityLabel = UIConstants.strings.browserSettings
         contextMenuButton.accessibilityIdentifier = "HomeView.settingsButton"
         contextMenuButton.contentEdgeInsets = UIConstants.layout.toolbarButtonInsets
+        contextMenuButton.imageView?.snp.makeConstraints { $0.size.equalTo(28) }
         
         setHighlightWhatsNew(shouldHighlight: shouldShowWhatsNew())
     }

--- a/Blockzilla/BrowserToolset.swift
+++ b/Blockzilla/BrowserToolset.swift
@@ -59,7 +59,7 @@ class BrowserToolset {
         contextMenuButton.accessibilityLabel = UIConstants.strings.browserSettings
         contextMenuButton.accessibilityIdentifier = "HomeView.settingsButton"
         contextMenuButton.contentEdgeInsets = UIConstants.layout.toolbarButtonInsets
-        contextMenuButton.imageView?.snp.makeConstraints { $0.size.equalTo(28) }
+        contextMenuButton.imageView?.snp.makeConstraints { $0.size.equalTo(UIConstants.layout.contextMenuIconSize) }
         
         setHighlightWhatsNew(shouldHighlight: shouldShowWhatsNew())
     }

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -301,7 +301,7 @@ class BrowserViewController: UIViewController {
                 case .menu:
                     let controller = self.tooltipController(
                         anchoredBy: self.urlBar.contextMenuButton,
-                        sourceRect: CGRect(x: self.urlBar.contextMenuButton.bounds.maxX, y: self.urlBar.contextMenuButton.bounds.midY + 10, width: 0, height: 0),
+                        sourceRect: CGRect(x: self.urlBar.contextMenuButton.bounds.maxX, y: self.urlBar.contextMenuButton.bounds.midY + 12, width: 0, height: 0),
                         body: UIConstants.strings.tootipBodyTextForContextMenuIcon,
                         dismiss: { self.onboardingEventsHandler.route = nil }
                     )

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -15,6 +15,9 @@ struct UIConstants {
         static let shieldIconInset: Float = 9
         static let shieldIconIPadInset: Float = 15
         static let shieldIconSize: Float = 19
+        static let contextMenuButtonSize: CGFloat = 36
+        static let contextMenuButtonMargin: CGFloat = 14
+        static let contextMenuIconSize: CGFloat = 28
         static let overlayAnimationDuration: TimeInterval = 0.25
         static let autocompleteAnimationDuration: TimeInterval = 0.2
         static let autocompleteAfterDelayDuration: TimeInterval = 0.5

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -14,10 +14,6 @@ struct UIConstants {
         static let deleteAnimationDuration: TimeInterval = 0.25
         static let shieldIconInset: Float = 9
         static let shieldIconIPadInset: Float = 15
-        static let shieldIconSize: Float = 19
-        static let contextMenuButtonSize: CGFloat = 36
-        static let contextMenuButtonMargin: CGFloat = 14
-        static let contextMenuIconSize: CGFloat = 28
         static let shieldIconSize: Float = 24
         static let overlayAnimationDuration: TimeInterval = 0.25
         static let autocompleteAnimationDuration: TimeInterval = 0.2
@@ -155,6 +151,9 @@ struct UIConstants {
         static let onboardingLayoutMarginBottom: CGFloat = 0
         static let onboardingButtonButtomInsetDivider: CGFloat = 20
         static let onboardingButtonLeadingTrailingInsetDivider: CGFloat = 5
+        static let contextMenuButtonSize: CGFloat = 36
+        static let contextMenuButtonMargin: CGFloat = 14
+        static let contextMenuIconSize: CGFloat = 28
     }
 
     struct strings {

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -291,10 +291,10 @@ class URLBar: UIView {
             if inBrowsingMode {
                 make.trailing.equalTo(safeAreaLayoutGuide)
             }else {
-                make.trailing.equalTo(safeAreaLayoutGuide).offset(-UIConstants.layout.urlBarMargin)
+                make.trailing.equalTo(safeAreaLayoutGuide).offset(-14)
             }
             make.centerY.equalTo(self)
-            make.size.equalTo(toolset.backButton)
+            make.size.equalTo(36)
         }
         
         toolset.deleteButton.snp.makeConstraints { make in
@@ -311,7 +311,7 @@ class URLBar: UIView {
             if inBrowsingMode {
                 compressedBarConstraints.append(make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).inset(UIConstants.layout.urlBarMargin).constraint)
             } else {
-                compressedBarConstraints.append(make.trailing.equalTo(contextMenuButton.snp.leading).offset(-UIConstants.layout.urlBarMargin).constraint)
+                compressedBarConstraints.append(make.trailing.equalTo(contextMenuButton.snp.leading).constraint)
             }
 
             expandedBarConstraints.append(make.trailing.equalTo(rightBarViewLayoutGuide.snp.trailing).constraint)

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -290,11 +290,11 @@ class URLBar: UIView {
         toolset.contextMenuButton.snp.makeConstraints { make in
             if inBrowsingMode {
                 make.trailing.equalTo(safeAreaLayoutGuide)
-            }else {
-                make.trailing.equalTo(safeAreaLayoutGuide).offset(-14)
+            } else {
+                make.trailing.equalTo(safeAreaLayoutGuide).offset(-UIConstants.layout.contextMenuButtonMargin)
             }
             make.centerY.equalTo(self)
-            make.size.equalTo(36)
+            make.size.equalTo(UIConstants.layout.contextMenuButtonSize)
         }
         
         toolset.deleteButton.snp.makeConstraints { make in
@@ -311,7 +311,7 @@ class URLBar: UIView {
             if inBrowsingMode {
                 compressedBarConstraints.append(make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).inset(UIConstants.layout.urlBarMargin).constraint)
             } else {
-                compressedBarConstraints.append(make.trailing.equalTo(contextMenuButton.snp.leading).constraint)
+                compressedBarConstraints.append(make.trailing.equalTo(contextMenuButton.snp.leading).offset(-UIConstants.layout.contextMenuButtonMargin).constraint)
             }
 
             expandedBarConstraints.append(make.trailing.equalTo(rightBarViewLayoutGuide.snp.trailing).constraint)


### PR DESCRIPTION
## Commit message

<img width="483" alt="Screenshot 2022-03-16 at 10 57 49" src="https://user-images.githubusercontent.com/51127880/158554696-3e3a8668-f1c3-42eb-80b4-44d456b2a60e.png">
<img width="740" alt="Screenshot 2022-03-16 at 10 58 04" src="https://user-images.githubusercontent.com/51127880/158554715-86910814-bf28-40de-8510-00361c4895b2.png">
<img width="954" alt="Screenshot 2022-03-15 at 13 15 08" src="https://user-images.githubusercontent.com/51127880/158366320-9c43727c-8aa3-4b0b-b58f-43b821dfca95.png">
<img width="693" alt="Screenshot 2022-03-15 at 13 14 53" src="https://user-images.githubusercontent.com/51127880/158366341-956ae530-c680-49b8-817a-6eb372df850a.png">

Fixes #3090 - The settings tooltip is not centered to the hamburger menu 
