### PR TITLE
Fixes #3114 - The PB icon on the new onboarding card is way too dark

### DIFF
--- a/Blockzilla/Assets.xcassets/icon_private_mode.imageset/Contents.json
+++ b/Blockzilla/Assets.xcassets/icon_private_mode.imageset/Contents.json
@@ -11,7 +11,7 @@
           "value" : "dark"
         }
       ],
-      "filename" : "Private Mode-24.pdf",
+      "filename" : "Private mode-24.pdf",
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION

## Commit message
Fixes #3114 The PB icon on the new onboarding card is way too dark