### PR TITLE
Fixes #3115 - The Trash icon tooltip re-appears when rotating the device from landscape to portrait or vice versa 

### DIFF
--- a/Blockzilla/TooltipViewController.swift
+++ b/Blockzilla/TooltipViewController.swift
@@ -40,8 +40,12 @@ class TooltipViewController: UIViewController {
 
 // MARK: - Delegates
 extension TooltipViewController: UIPopoverPresentationControllerDelegate {
-    public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        return .none
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        .none
+    }
+    
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        dismiss?()
     }
 }
 


### PR DESCRIPTION
## Commit message

https://user-images.githubusercontent.com/51127880/158788399-41b3e169-ca89-46ab-80a5-24ac6dfc4ce8.mp4

Fixes #3115 - The Trash icon tooltip re-appears when rotating the device from landscape to portrait or vice versa 
