### PR TITLE
Fixes #3099 The Tracking Protection state (on or off) is reset if restarting the app or deleting the history 

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -624,9 +624,6 @@ class BrowserViewController: UIViewController {
         interaction.donate { (error) in
             if let error = error { print(error.localizedDescription) }
         }
-        
-        // Reenable tracking protection after reset
-        Settings.set(true, forToggle: .trackingProtection)
     }
 
     private func clearBrowser() {
@@ -644,6 +641,7 @@ class BrowserViewController: UIViewController {
         homeViewController.refreshTipsDisplay()
         homeViewController.view.isHidden = false
         createURLBar()
+        updateLockIcon(trackingProtectionStatus: trackingProtectionManager.trackingProtectionStatus)
         shortcutsContainer.isHidden = false
         shortcutsBackground.isHidden = true
 

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -14,8 +14,11 @@ import Combine
 class BrowserViewController: UIViewController {
     private let mainContainerView = UIView(frame: .zero)
     let darkView = UIView()
-
-    private let webViewController = WebViewController()
+    private lazy var trackingProtectionManager = TrackingProtectionManager(
+        isTrackingEnabled: {
+            Settings.getToggle(.trackingProtection)
+        })
+    private lazy var webViewController = WebViewController(trackingProtectionManager: trackingProtectionManager)
     private let webViewContainer = UIView()
 
     var modalDelegate: ModalDelegate?
@@ -50,12 +53,6 @@ class BrowserViewController: UIViewController {
         case expanded
         case transitioning
         case animating
-    }
-
-    private var trackingProtectionStatus: TrackingProtectionStatus = .on(TPPageStats()) {
-        didSet {
-            updateLockIcon()
-        }
     }
 
     private var homeViewContainer = UIView()
@@ -351,6 +348,13 @@ class BrowserViewController: UIViewController {
                 }
             }
             .store(in: &cancellables)
+        
+        trackingProtectionManager
+            .$trackingProtectionStatus
+            .sink { [unowned self] status in
+                updateLockIcon(trackingProtectionStatus: status)
+            }
+            .store(in: &cancellables)
        
         guard shouldEnsureBrowsingMode else { return }
         ensureBrowsingMode()
@@ -420,7 +424,7 @@ class BrowserViewController: UIViewController {
         }
     }
     
-    private func updateLockIcon() {
+    private func updateLockIcon(trackingProtectionStatus: TrackingProtectionStatus) {
         urlBar.updateTrackingProtectionBadge(trackingStatus: trackingProtectionStatus, shouldDisplayShieldIcon:  urlBar.inBrowsingMode ? self.webViewController.connectionIsSecure : true)
     }
 
@@ -1229,13 +1233,6 @@ extension BrowserViewController: URLBarDelegate {
             .replaceError(with: .defaultFavicon)
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
-
-        switch trackingProtectionStatus {
-        case .on:
-            Settings.set(true, forToggle: .trackingProtection)
-        case .off:
-            Settings.set(false, forToggle: .trackingProtection)
-        }
         
         let state: TrackingProtectionState = urlBar.inBrowsingMode
         ? .browsing(status: SecureConnectionStatus(
@@ -1582,9 +1579,6 @@ extension BrowserViewController: WebControllerDelegate {
         browserToolbar.canDelete = true
         toggleURLBarBackground(isBright: false)
         updateURLBar()
-        if trackingProtectionStatus == .off {
-            updateLockIcon()
-        }
     }
 
     func webControllerDidFinishNavigation(_ controller: WebController) {
@@ -1714,12 +1708,12 @@ extension BrowserViewController: WebControllerDelegate {
     func webController(_ controller: WebController, didUpdateTrackingProtectionStatus trackingStatus: TrackingProtectionStatus) {
         // Calculate the number of trackers blocked and add that to lifetime total
         if case .on(let info) = trackingStatus,
-           case .on(let oldInfo) = trackingProtectionStatus {
+           case .on(let oldInfo) = trackingStatus {
             let differenceSinceLastUpdate = max(0, info.total - oldInfo.total)
             let numberOfTrackersBlocked = getNumberOfLifetimeTrackersBlocked()
             setNumberOfLifetimeTrackersBlocked(numberOfTrackers: numberOfTrackersBlocked + differenceSinceLastUpdate)
         }
-        trackingProtectionStatus = trackingStatus
+        updateLockIcon(trackingProtectionStatus: trackingStatus)
     }
 
     private func showToolbars() {

--- a/Blockzilla/Lib/TrackingProtection/TrackingProtection.swift
+++ b/Blockzilla/Lib/TrackingProtection/TrackingProtection.swift
@@ -4,10 +4,23 @@
 
 import Foundation
 
-enum TrackingProtectionStatus: Equatable {
+enum TrackingProtectionStatus {
     case on(TPPageStats)
     case off
     
+    var trackingInformation: TPPageStats? {
+        get {
+            guard case let .on(value) = self else { return nil }
+            return value
+        }
+        set {
+            guard case .on = self, let newValue = newValue else { return }
+            self = .on(newValue)
+        }
+    }
+}
+
+extension TrackingProtectionStatus: Equatable {
     static func == (lhs: TrackingProtectionStatus, rhs: TrackingProtectionStatus) -> Bool {
         switch (lhs, rhs) {
         case (.on, .on), (.off, .off):

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -236,7 +236,6 @@ class WebViewController: UIViewController, WebController {
 
         setupBlockLists()
         setupTrackingProtectionScripts()
-        trackingProtectionManager.trackingProtectionStatus = .on(TPPageStats())
     }
 
     func evaluate(_ javascript: String, completion: ((Any?, Error?) -> Void)?) {

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -105,7 +105,6 @@ class WebViewController: UIViewController, WebController {
         browserView.load(URLRequest(url: URL(string: "about:blank")!))
         browserView.navigationDelegate = nil
         browserView.removeFromSuperview()
-        trackingProtectionManager.trackingProtectionStatus = .on(TPPageStats())
         setupWebview()
         self.browserView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
     }
@@ -233,9 +232,9 @@ class WebViewController: UIViewController, WebController {
 
     func enableTrackingProtection() {
         guard case .off = trackingProtectionManager.trackingProtectionStatus else { return }
-
         setupBlockLists()
         setupTrackingProtectionScripts()
+        trackingProtectionManager.trackingProtectionStatus = .on(TPPageStats())
     }
 
     func evaluate(_ javascript: String, completion: ((Any?, Error?) -> Void)?) {

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -158,15 +158,13 @@ class WebViewController: UIViewController, WebController {
             self.delegate?.webController(self, didUpdateEstimatedProgress: webView.estimatedProgress)
         }
         
-        switch trackingProtectionManager.trackingProtectionStatus {
-        case .on(_):
-            setupFindInPageScripts()
-            setupMetadataScripts()
-            setupFullScreen()
-            enableTrackingProtection()
-        case .off:
-            disableTrackingProtection()
+        if case .on(_) = trackingProtectionManager.trackingProtectionStatus {
+            setupBlockLists()
+            setupTrackingProtectionScripts()
         }
+        setupFindInPageScripts()
+        setupMetadataScripts()
+        setupFullScreen()
 
         view.addSubview(browserView)
         browserView.snp.makeConstraints { make in

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -44,6 +44,15 @@ protocol WebControllerDelegate: AnyObject {
     func webController(_ controller: WebController, didUpdateFindInPageResults currentResult: Int?, totalResults: Int?)
 }
 
+class TrackingProtectionManager {
+    @Published var trackingProtectionStatus: TrackingProtectionStatus
+    
+    init(isTrackingEnabled: () -> Bool) {
+        let isTrackingEnabled = isTrackingEnabled()
+        self.trackingProtectionStatus = isTrackingEnabled ? .on(TPPageStats()) : .off
+    }
+}
+
 class WebViewController: UIViewController, WebController {
     private enum ScriptHandlers: String, CaseIterable {
         case focusTrackingProtection
@@ -64,19 +73,7 @@ class WebViewController: UIViewController, WebController {
     var browserView: WKWebView!
     private var progressObserver: NSKeyValueObservation?
     private var currentBackForwardItem: WKBackForwardListItem?
-    private var trackingProtectionStatus = TrackingProtectionStatus.on(TPPageStats()) {
-        didSet {
-            delegate?.webController(self, didUpdateTrackingProtectionStatus: trackingProtectionStatus)
-        }
-    }
-
-    private var trackingInformation = TPPageStats() {
-        didSet {
-            if case .on = trackingProtectionStatus {
-                trackingProtectionStatus = .on(trackingInformation)
-            }
-        }
-    }
+    private let trackingProtectionManager: TrackingProtectionManager
 
     var pageTitle: String? {
         return browserView.title
@@ -93,17 +90,22 @@ class WebViewController: UIViewController, WebController {
     var printFormatter: UIPrintFormatter { return browserView.viewPrintFormatter() }
     var scrollView: UIScrollView { return browserView.scrollView }
 
-    convenience init() {
-        self.init(nibName: nil, bundle: nil)
+    init(trackingProtectionManager: TrackingProtectionManager) {
+        self.trackingProtectionManager = trackingProtectionManager
+        super.init(nibName: nil, bundle: nil)
         setupWebview()
         ContentBlockerHelper.shared.handler = reloadBlockers(_:)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     func reset() {
         browserView.load(URLRequest(url: URL(string: "about:blank")!))
         browserView.navigationDelegate = nil
         browserView.removeFromSuperview()
-        trackingProtectionStatus = .on(TPPageStats())
+        trackingProtectionManager.trackingProtectionStatus = .on(TPPageStats())
         setupWebview()
         self.browserView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
     }
@@ -156,12 +158,16 @@ class WebViewController: UIViewController, WebController {
         progressObserver = browserView.observe(\WKWebView.estimatedProgress) { (webView, value) in
             self.delegate?.webController(self, didUpdateEstimatedProgress: webView.estimatedProgress)
         }
-
-        setupBlockLists()
-        setupTrackingProtectionScripts()
-        setupFindInPageScripts()
-        setupMetadataScripts()
-        setupFullScreen()
+        
+        switch trackingProtectionManager.trackingProtectionStatus {
+        case .on(_):
+            setupFindInPageScripts()
+            setupMetadataScripts()
+            setupFullScreen()
+            enableTrackingProtection()
+        case .off:
+            disableTrackingProtection()
+        }
 
         view.addSubview(browserView)
         browserView.snp.makeConstraints { make in
@@ -213,7 +219,7 @@ class WebViewController: UIViewController, WebController {
     }
 
     func disableTrackingProtection() {
-        guard case .on = trackingProtectionStatus else { return }
+        guard case .on = trackingProtectionManager.trackingProtectionStatus else { return }
         ScriptHandlers.allCases.forEach {
             browserView.configuration.userContentController.removeScriptMessageHandler(forName: $0.rawValue)
         }
@@ -221,15 +227,16 @@ class WebViewController: UIViewController, WebController {
         browserView.configuration.userContentController.removeAllContentRuleLists()
         setupFindInPageScripts()
         setupMetadataScripts()
-        trackingProtectionStatus = .off
+        setupFullScreen()
+        trackingProtectionManager.trackingProtectionStatus = .off
     }
 
     func enableTrackingProtection() {
-        guard case .off = trackingProtectionStatus else { return }
+        guard case .off = trackingProtectionManager.trackingProtectionStatus else { return }
 
         setupBlockLists()
         setupTrackingProtectionScripts()
-        trackingProtectionStatus = .on(TPPageStats())
+        trackingProtectionManager.trackingProtectionStatus = .on(TPPageStats())
     }
 
     func evaluate(_ javascript: String, completion: ((Any?, Error?) -> Void)?) {
@@ -320,7 +327,7 @@ extension WebViewController: UIScrollViewDelegate {
 extension WebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         delegate?.webControllerDidStartNavigation(self)
-        if case .on = trackingProtectionStatus { trackingInformation = TPPageStats() }
+        trackingProtectionManager.trackingProtectionStatus.trackingInformation = TPPageStats()
         currentContentMode = navigation?.effectiveContentMode
     }
 
@@ -485,9 +492,10 @@ extension WebViewController: WKScriptMessageHandler {
         guard let url = components.url else { return }
 
         let enabled = Utils.getEnabledLists().compactMap { BlocklistName(rawValue: $0) }
-        TPStatsBlocklistChecker.shared.isBlocked(url: url, enabledLists: enabled).uponQueue(.main) { listItem in
+        TPStatsBlocklistChecker.shared.isBlocked(url: url, enabledLists: enabled).uponQueue(.main) { [unowned self] listItem in
             if let listItem = listItem {
-                self.trackingInformation = self.trackingInformation.create(byAddingListItem: listItem)
+                let currentInfo = trackingProtectionManager.trackingProtectionStatus.trackingInformation
+                trackingProtectionManager.trackingProtectionStatus.trackingInformation = currentInfo.map { $0.create(byAddingListItem: listItem) }
             }
         }
     }


### PR DESCRIPTION
## Commit message
Fixes #3099 The Tracking Protection state (on or off) is reset if restarting the app or deleting the history 