### PR TITLE
Fixes #3074 In certain languages, the "trackers blocked so far" View on the home screen sticks out.

### DIFF
--- a/Blockzilla/Pro Tips/ShareTrackersViewController.swift
+++ b/Blockzilla/Pro Tips/ShareTrackersViewController.swift
@@ -68,7 +68,7 @@ class ShareTrackersViewController: UIViewController {
             $0.height.equalTo(CGFloat.trackerStatsShareButtonHeight)
         }
         shieldLogo.snp.makeConstraints {
-            $0.width.height.equalTo(CGFloat.shieldLogoSize)
+            $0.size.equalTo(CGFloat.shieldLogoSize)
         }
         stackView.snp.makeConstraints {
             $0.center.equalToSuperview()


### PR DESCRIPTION
## Commit message
Fixes #3074 In certain languages, the "trackers blocked so far" View on the home screen sticks out. 