### PR TITLE
Fixes #3122 - The Hamburger menu tooltip is not displayed if restarting Focus before pressing Start Browsing 

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -52,7 +52,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
     private var queuedString: String?
     private let whatsNewEventsHandler = WhatsNewEventsHandler()
     private var cancellables = Set<AnyCancellable>()
-    private var shownTips: Set<OnboardingEventsHandler.ToolTipRoute>?
     
     private lazy var onboardingEventsHandler = OnboardingEventsHandler(
         alwaysShowOnboarding: {
@@ -73,13 +72,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
             #endif
         },
         getShownTips: {
-            shownTips = UserDefaults
+            return UserDefaults
                 .standard
                 .data(forKey: OnboardingConstants.shownTips)
                 .flatMap {
                     try? JSONDecoder().decode(Set<OnboardingEventsHandler.ToolTipRoute>.self, from: $0)
-                }
-            return shownTips ?? []
+                } ?? []
         }, setShownTips: { tips in
             let data = try? JSONEncoder().encode(tips)
             UserDefaults.standard.set(data, forKey: OnboardingConstants.shownTips)
@@ -181,10 +179,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
                 onboardingEventsHandler.send(.applicationDidLaunch)
             }
             return true
-        }
-        
-        if shownTips?.count == 1 {
-            onboardingEventsHandler.send(.enterHome)
         }
         
         onboardingEventsHandler.send(.applicationDidLaunch)

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -52,6 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
     private var queuedString: String?
     private let whatsNewEventsHandler = WhatsNewEventsHandler()
     private var cancellables = Set<AnyCancellable>()
+    private var shownTips: Set<OnboardingEventsHandler.ToolTipRoute>?
     
     private lazy var onboardingEventsHandler = OnboardingEventsHandler(
         alwaysShowOnboarding: {
@@ -72,12 +73,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
             #endif
         },
         getShownTips: {
-            return UserDefaults
+            shownTips = UserDefaults
                 .standard
                 .data(forKey: OnboardingConstants.shownTips)
                 .flatMap {
                     try? JSONDecoder().decode(Set<OnboardingEventsHandler.ToolTipRoute>.self, from: $0)
-                } ?? []
+                }
+            return shownTips ?? []
         }, setShownTips: { tips in
             let data = try? JSONEncoder().encode(tips)
             UserDefaults.standard.set(data, forKey: OnboardingConstants.shownTips)
@@ -179,6 +181,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
                 onboardingEventsHandler.send(.applicationDidLaunch)
             }
             return true
+        }
+        
+        if shownTips?.count == 1 {
+            onboardingEventsHandler.send(.enterHome)
         }
         
         onboardingEventsHandler.send(.applicationDidLaunch)

--- a/Blockzilla/Onboarding/OnboardingEventsHandler.swift
+++ b/Blockzilla/Onboarding/OnboardingEventsHandler.swift
@@ -61,7 +61,11 @@ class OnboardingEventsHandler {
         switch action {
         case .applicationDidLaunch:
             let onboardingRoute = ToolTipRoute.onboarding(OnboardingType(shouldShowNewOnboarding()))
-            show(route: onboardingRoute)
+            if shownTips.contains(onboardingRoute) {
+                show(route: .menu)
+            } else {
+                show(route: onboardingRoute)
+            }
             
         case .enterHome:
             guard shouldShowNewOnboarding() else { return }


### PR DESCRIPTION
## Commit message

https://user-images.githubusercontent.com/51127880/159427072-d2e3cd8a-8ef0-4809-8d7f-3084c0e9a613.mp4

Fixes #3122 - The Hamburger menu tooltip is not displayed if restarting Focus before pressing Start Browsing 
