### PR TITLE
Fixes #3124 - The Save button is not grayed out when no text is entered in the shortcut name box (when renaming a shortcut)

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1327,7 +1327,7 @@ extension BrowserViewController: ShortcutViewDelegate {
             textfield.text = shortcut.name
             textfield.clearButtonMode = .always
             NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification, object: textfield, queue: OperationQueue.main, using: { _ in
-                alert.actions.last?.isEnabled = textfield.text?.trimmingCharacters(in: .whitespacesAndNewlines).count ?? 0 > 0
+                alert.actions.last?.isEnabled = !(textfield.text?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? false)
             })
         }
         

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1326,12 +1326,14 @@ extension BrowserViewController: ShortcutViewDelegate {
             textfield.placeholder = UIConstants.strings.renameShortcutAlertPlaceholder
             textfield.text = shortcut.name
             textfield.clearButtonMode = .always
+            NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification, object: textfield, queue: OperationQueue.main, using: { _ in
+                alert.actions.last?.isEnabled = textfield.text?.trimmingCharacters(in: .whitespacesAndNewlines).count ?? 0 > 0
+            })
         }
         
         alert.addAction(UIAlertAction(title: UIConstants.strings.renameShortcutAlertSecondaryAction, style: .cancel, handler: nil))
         alert.addAction(UIAlertAction(title: UIConstants.strings.renameShortcutAlertPrimaryAction, style: .default, handler: { [unowned alert] action in
             let newName = (alert.textFields?.first?.text ?? shortcut.name).trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !newName.isEmpty, newName != shortcut.name else { return }
             ShortcutsManager.shared.rename(shortcut: shortcut, newName: newName)
         }))
         self.show(alert, sender: nil)
@@ -1356,6 +1358,7 @@ extension BrowserViewController: ShortcutViewDelegate {
         GleanMetrics.Shortcuts.shortcutRemovedCounter["removed_from_home_screen"].add()
     }
 }
+
 
 extension BrowserViewController: ShortcutsManagerDelegate {
     func shortcutsUpdated() {


### PR DESCRIPTION
![356B8C16-2A93-4CF1-91E6-C0106DA55B40](https://user-images.githubusercontent.com/51127880/159486249-f73020e1-364c-46f7-bc48-7306f9848bb8.png)

## Commit message
Fixes #3124 - The Save button is not grayed out when no text is entered in the shortcut name box (when renaming a shortcut)

