### PR TITLE
Fixes #3155 - The name of the shortcut overlaps with another one 

### DIFF
--- a/Blockzilla/AppShortcuts/ShortcutView.swift
+++ b/Blockzilla/AppShortcuts/ShortcutView.swift
@@ -44,6 +44,8 @@ class ShortcutView: UIView {
         let nameLabel = UILabel()
         nameLabel.textColor = .primaryText
         nameLabel.font = .footnote12
+        nameLabel.numberOfLines = 2
+        nameLabel.textAlignment = .center
         return nameLabel
     }()
     
@@ -83,6 +85,7 @@ class ShortcutView: UIView {
         nameLabel.snp.makeConstraints { make in
             make.top.equalTo(outerView.snp.bottom).offset(8)
             make.centerX.equalToSuperview()
+            make.trailing.lessThanOrEqualToSuperview().offset(8)
         }
         
         let interaction = UIContextMenuInteraction(delegate: self)


### PR DESCRIPTION
![DemoScreenshot](https://user-images.githubusercontent.com/51127880/160586814-6d5891eb-aafa-4188-ac9f-9fe37677dda1.jpeg)

## Commit message

Fixes #3155 - The name of the shortcut overlaps with another one 