### PR TITLE
Fixes #3144 - There is a flicker when opening the ETP menu (if ETP is turned OFF)

### DIFF
--- a/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -339,7 +339,9 @@ class TrackingProtectionViewController: UIViewController {
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        calculatePreferredSize()
+        DispatchQueue.main.async {
+            self.calculatePreferredSize()
+        }
     }
     
     @objc private func doneTapped() {


### PR DESCRIPTION
## Commit message

Fixes #3144 - There is a flicker when opening the ETP menu (if ETP is turned OFF)