### PR TITLE
2949-Improve-URLExtensions-isIPv4-isIPv6

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		1DE903CE20C751D7002E53ED /* FindInPageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE903CD20C751D7002E53ED /* FindInPageTest.swift */; };
 		24433101219DA46F00778D02 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24433100219DA46F00778D02 /* Debouncer.swift */; };
 		2696EB04211F540600F0C73F /* SearchHistoryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */; };
+		2981645327FBD7CA0033FA0A /* URLExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2981645227FBD7CA0033FA0A /* URLExtensionsTests.swift */; };
 		30DFF98021810BF20055707C /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30DFF97F21810BF20055707C /* SearchSuggestClient.swift */; };
 		31421EB12176492A0015F48B /* TitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */; };
 		3AEC0B3E267DE30A007B7850 /* URIFixupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEC0B3D267DE30A007B7850 /* URIFixupTests.swift */; };
@@ -421,6 +422,7 @@
 		1DE903CD20C751D7002E53ED /* FindInPageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindInPageTest.swift; sourceTree = "<group>"; };
 		24433100219DA46F00778D02 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryUtils.swift; sourceTree = "<group>"; };
+		2981645227FBD7CA0033FA0A /* URLExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtensionsTests.swift; sourceTree = "<group>"; };
 		29B90C056305836CB297FF79 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		30DFF97F21810BF20055707C /* SearchSuggestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProvider.swift; sourceTree = "<group>"; };
@@ -1634,6 +1636,7 @@
 				D8E0156D1FD9E40F00CA3B9F /* DomainCompletionTests.swift */,
 				3AEC0B3D267DE30A007B7850 /* URIFixupTests.swift */,
 				F8DE0EC726CC887800A31419 /* SupportUtilsTest.swift */,
+				2981645227FBD7CA0033FA0A /* URLExtensionsTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -2265,6 +2268,7 @@
 				D831FEE2205247A400EAE19A /* BrowserViewControllerTests.swift in Sources */,
 				D8E0155F1FCF409F00CA3B9F /* SearchEngineManagerTests.swift in Sources */,
 				F8DE0EC926CC88B200A31419 /* SupportUtils.swift in Sources */,
+				2981645327FBD7CA0033FA0A /* URLExtensionsTests.swift in Sources */,
 				D8E0156E1FD9E40F00CA3B9F /* DomainCompletionTests.swift in Sources */,
 				D025F225218B64D600B262D8 /* SearchEngineTests.swift in Sources */,
 				F8DE0EC826CC887800A31419 /* SupportUtilsTest.swift in Sources */,

--- a/Blockzilla/Extensions/URLExtensions.swift
+++ b/Blockzilla/Extensions/URLExtensions.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Network
 
 private struct ETLDEntry: CustomStringConvertible {
     let entry: String
@@ -195,7 +196,7 @@ extension URL {
      :returns: The base domain string for the given host name.
      */
     public var baseDomain: String? {
-        guard !isIPv4 && !isIPv6, let host = host else { return host }
+        guard let host = host, !isIPv4(host: host), !isIPv6(host: host) else { return host }
 
         // If this is just a hostname and not a FQDN, use the entire hostname.
         if !host.contains(".") {
@@ -285,14 +286,12 @@ extension URL {
         return host.lowercased() == "localhost" || host == "127.0.0.1"
     }
 
-    public var isIPv4: Bool {
-        let ipv4Pattern = #"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"#
-        
-        return host?.range(of: ipv4Pattern, options: .regularExpression) != nil
+    public func isIPv4(host: String) -> Bool {
+        return IPv4Address(host) != nil;
     }
 
-    public var isIPv6: Bool {
-        return host?.contains(":") ?? false
+    public func isIPv6(host: String) -> Bool {
+        return IPv6Address(host) != nil;
     }
 
     /**

--- a/ClientTests/URLExtensionsTests.swift
+++ b/ClientTests/URLExtensionsTests.swift
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+import Foundation
+
+class URLExtensionsTests: XCTestCase {
+    
+    // MARK: -- IPV4 Tests
+    func testIPV4_Valid_Input_ShouldReturnTrue() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertTrue(url.isIPv4(host: "64.233.177.105"), "Test should not fail here for valid ipv4 hosts")
+    }
+    
+    func testIPV4_Invalid_IP6Input_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv4(host: "2607:f8b0:4002:c02::67"), "isIPv4 should always return false for IPV6 addresses")
+    }
+    
+    func testIPV4_Invalid_EmptyInput_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv4(host: ""), "isIPv4 should always return false for empty hosts.")
+    }
+    
+    // MARK: -- IPV6 Tests
+    func testIPV6_Valid_Input_ShouldReturnTrue() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertTrue(url.isIPv6(host: "2607:f8b0:4002:c02::67"), "Test should not fail here for valid ipv6 hosts")
+    }
+    
+    func testIPV4_Invalid_IP4Input_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv6(host: "64.233.177.105"), "isIPv6 should always return false for IPV4 addresses")
+    }
+    
+    func testIPV6_Invalid_EmptyInput_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv6(host: ""), "isIPv6 should always return false for empty hosts.")
+    }
+    
+    
+}


### PR DESCRIPTION
Update isIPv4 and isIPv6 function definitions to use Standard Network Library Functions
Added Unit Tests 