### PR TITLE
Fixes #2803 - Add Whats new button functionality like in previous versions

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -45,7 +45,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ModalDelegate {
     
     private lazy var browserViewController = BrowserViewController(
         authenticationManager: authenticationManager,
-        onboardingEventsHandler: onboardingEventsHandler
+        onboardingEventsHandler: onboardingEventsHandler,
+        whatsNewEventsHandler: whatsNewEventsHandler
     )
     
     private let nimbus = NimbusWrapper.shared

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -48,6 +48,7 @@ class BrowserViewController: UIViewController {
     private var background = UIImageView()
     private var cancellables = Set<AnyCancellable>()
     private var onboardingEventsHandler: OnboardingEventsHandler
+    private var whatsNewEventsHandler: WhatsNewEventsHandler
 
     private enum URLBarScrollState {
         case collapsed
@@ -87,12 +88,14 @@ class BrowserViewController: UIViewController {
         tipManager: TipManager = TipManager.shared,
         shortcutManager: ShortcutsManager = ShortcutsManager.shared,
         authenticationManager: AuthenticationManager,
-        onboardingEventsHandler: OnboardingEventsHandler
+        onboardingEventsHandler: OnboardingEventsHandler,
+        whatsNewEventsHandler: WhatsNewEventsHandler
     ) {
         self.tipManager = tipManager
         self.shortcutManager = shortcutManager
         self.authenticationManager = authenticationManager
         self.onboardingEventsHandler = onboardingEventsHandler
+        self.whatsNewEventsHandler = whatsNewEventsHandler
         super.init(nibName: nil, bundle: nil)
         shortcutManager.delegate = self
         KeyboardHelper.defaultHelper.addDelegate(delegate: self)
@@ -267,6 +270,15 @@ class BrowserViewController: UIViewController {
                 updateLockIcon(trackingProtectionStatus: status)
             }
             .store(in: &cancellables)
+        
+        whatsNewEventsHandler
+            .$shouldShowWhatsNew
+            .sink { [unowned self] shouldShow in
+                homeViewController.toolbar.toolset.setHighlightWhatsNew(shouldHighlight: shouldShow)
+                browserToolbar.toolset.setHighlightWhatsNew(shouldHighlight: shouldShow)
+                urlBar.setHighlightWhatsNew(shouldHighlight: shouldShow)
+            }
+            .store(in: &cancellables)
 
         
         guard shouldEnsureBrowsingMode else { return }
@@ -279,10 +291,7 @@ class BrowserViewController: UIViewController {
         super.viewWillAppear(animated)
         
         navigationController?.setNavigationBarHidden(true, animated: animated)
-        let homeViewToolset = homeViewController.toolbar.toolset
-        homeViewToolset.setHighlightWhatsNew(shouldHighlight: homeViewToolset.shouldShowWhatsNew())
         homeViewController.toolbar.layoutIfNeeded()
-        browserToolbar.toolset.setHighlightWhatsNew(shouldHighlight: browserToolbar.toolset.shouldShowWhatsNew())
         browserToolbar.layoutIfNeeded()
     }
     
@@ -341,7 +350,6 @@ class BrowserViewController: UIViewController {
                                 value: "finish"
                             )
                         UserDefaults.standard.set(true, forKey: OnboardingConstants.onboardingDidAppear)
-                        UserDefaults.standard.set(AppInfo.shortVersion, forKey: OnboardingConstants.whatsNewVersion)
                         urlBar.activateTextField()
                         onboardingEventsHandler.route = nil
                         onboardingEventsHandler.send(.enterHome)
@@ -1836,11 +1844,6 @@ extension BrowserViewController {
     }
 }
 
-protocol WhatsNewDelegate {
-    func shouldShowWhatsNew() -> Bool
-    func didShowWhatsNew()
-}
-
 extension BrowserViewController: MenuActionable {
     
     func openInFirefox(url: URL) {
@@ -1936,9 +1939,9 @@ extension BrowserViewController: MenuActionable {
 
         let settingsViewController = SettingsViewController(
             searchEngineManager: searchEngineManager,
-            whatsNew: browserToolbar.toolset,
             authenticationManager: authenticationManager,
             onboardingEventsHandler: onboardingEventsHandler,
+            whatsNewEventsHandler: whatsNewEventsHandler,
             shouldScrollToSiri: shouldScrollToSiri
         )
         let settingsNavController = UINavigationController(rootViewController: settingsViewController)

--- a/Blockzilla/Onboarding/OnboardingConstants.swift
+++ b/Blockzilla/Onboarding/OnboardingConstants.swift
@@ -7,7 +7,6 @@ import Foundation
 struct OnboardingConstants {
     static let onboardingDidAppear = "OnboardingDidAppear"
     static let whatsNewVersion = "whatsNewVersion"
-    static let whatsNewCounter = "WhatsNewCounter"
     static let alwaysShowOnboarding = "AlwaysShowOnboarding"
     static let ignoreOnboardingExperiment = "IgnoreOnboardingExperiment"
     static let showOldOnboarding = "ShowOldOnboarding"

--- a/Blockzilla/Onboarding/WhatsNewEventsHandler.swift
+++ b/Blockzilla/Onboarding/WhatsNewEventsHandler.swift
@@ -5,39 +5,22 @@
 import Foundation
 
 
-struct WhatsNewEventsHandler {
+class WhatsNewEventsHandler {
     
-    //TODO: check which should be the logic of implementation
-    var shouldShowWhatsNewButton: Bool {
-        UserDefaults.standard.integer(forKey: OnboardingConstants.whatsNewCounter) != 0
-    }
+    @Published public var shouldShowWhatsNew: Bool = false
     
-    func didShowWhatsNewButton() {
+    func didShowWhatsNew() {
         UserDefaults.standard.set(AppInfo.shortVersion, forKey: OnboardingConstants.whatsNewVersion)
-        UserDefaults.standard.removeObject(forKey: OnboardingConstants.whatsNewCounter)
+        shouldShowWhatsNew = false
     }
     
     func highlightWhatsNewButton() {
-        let onboardingDidAppear = UserDefaults.standard.bool(forKey: OnboardingConstants.onboardingDidAppear)
         
-        // Don't highlight whats new on a fresh install (onboardingDidAppear == false on a fresh install)
-        if let lastShownWhatsNew = UserDefaults.standard.string(forKey: OnboardingConstants.whatsNewVersion)?.first, let currentMajorRelease = AppInfo.shortVersion.first {
-            if onboardingDidAppear && lastShownWhatsNew != currentMajorRelease {
-                setupWhatsNewFeature()
-            }
-        }
-    }
-    
-    private func setupWhatsNewFeature () {
-        let counter = UserDefaults.standard.integer(forKey: OnboardingConstants.whatsNewCounter)
-        switch counter {
-        case 4:
-            // Shown three times, remove counter
+        // Don't highlight whats new on a fresh install, highlight on every release of the app
+        if let lastShownWhatsNew = UserDefaults.standard.string(forKey: OnboardingConstants.whatsNewVersion) {
+            shouldShowWhatsNew = (lastShownWhatsNew != AppInfo.shortVersion)
+        } else {
             UserDefaults.standard.set(AppInfo.shortVersion, forKey: OnboardingConstants.whatsNewVersion)
-            UserDefaults.standard.removeObject(forKey: OnboardingConstants.whatsNewCounter)
-        default:
-            // Show highlight
-            UserDefaults.standard.set(counter+1, forKey: OnboardingConstants.whatsNewCounter)
         }
     }
 }

--- a/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -48,15 +48,31 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         tableView.estimatedRowHeight = UITableView.automaticDimension
         return tableView
     }()
+    
+    private lazy var highlightsButton: UIBarButtonItem = {
+        let barButton = UIBarButtonItem(title: UIConstants.strings.whatsNewTitle, style: .plain, target: self, action: #selector(whatsNewClicked))
+        barButton.image = UIImage(named: "highlight")
+        barButton.accessibilityIdentifier = "SettingsViewController.whatsNewButton"
+        let barButtonDisabledColor: UIColor = UserDefaults.standard.theme == .device ? (traitCollection.userInterfaceStyle == .light ? .systemGray2 : .white) : (UserDefaults.standard.theme == .light ? .systemGray2 : .white)
+        barButton.tintColor = whatsNewEventsHandler.shouldShowWhatsNew ? .accent : barButtonDisabledColor
+        return barButton
+    }()
+    
+    private lazy var doneButton: UIBarButtonItem = {
+        let doneButton = UIBarButtonItem(title: UIConstants.strings.done, style: .plain, target: self, action: #selector(dismissSettings))
+        doneButton.tintColor = .accent
+        doneButton.accessibilityIdentifier = "SettingsViewController.doneButton"
+        return doneButton
+    }()
+    
     private var onboardingEventsHandler: OnboardingEventsHandler
+    private var whatsNewEventsHandler: WhatsNewEventsHandler
     // Hold a strong reference to the block detector so it isn't deallocated
     // in the middle of its detection.
     private let detector = BlockerEnabledDetector()
     private let authenticationManager: AuthenticationManager
     private var isSafariEnabled = false
     private let searchEngineManager: SearchEngineManager
-    private var highlightsButton = UIBarButtonItem()
-    private let whatsNew: WhatsNewDelegate
     private lazy var sections = {
         Section.getSections()
     }()
@@ -118,18 +134,19 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
 
     private var shouldScrollToSiri: Bool
+    
     init(
         searchEngineManager: SearchEngineManager,
-        whatsNew: WhatsNewDelegate,
         authenticationManager: AuthenticationManager,
         onboardingEventsHandler: OnboardingEventsHandler,
+        whatsNewEventsHandler: WhatsNewEventsHandler,
         shouldScrollToSiri: Bool = false
     ) {
         self.searchEngineManager = searchEngineManager
-        self.whatsNew = whatsNew
         self.shouldScrollToSiri = shouldScrollToSiri
         self.authenticationManager = authenticationManager
         self.onboardingEventsHandler = onboardingEventsHandler
+        self.whatsNewEventsHandler = whatsNewEventsHandler
         super.init(nibName: nil, bundle: nil)
         
         tableView.register(SettingsTableViewAccessoryCell.self, forCellReuseIdentifier: "accessoryCell")
@@ -149,21 +166,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         navigationBar.shadowImage = UIImage()
         navigationBar.layoutIfNeeded()
         navigationBar.titleTextAttributes = [.foregroundColor: UIColor.primaryText]
-
-        highlightsButton = UIBarButtonItem(title: UIConstants.strings.whatsNewTitle, style: .plain, target: self, action: #selector(whatsNewClicked))
-        highlightsButton.image = UIImage(named: "highlight")
-        highlightsButton.tintColor = .accent
-        highlightsButton.accessibilityIdentifier = "SettingsViewController.whatsNewButton"
-        
-        let doneButton = UIBarButtonItem(title: UIConstants.strings.done, style: .plain, target: self, action: #selector(dismissSettings))
-        doneButton.tintColor = .accent
-        doneButton.accessibilityIdentifier = "SettingsViewController.doneButton"
-
         navigationItem.rightBarButtonItems = [doneButton, highlightsButton]
-
-        if whatsNew.shouldShowWhatsNew() {
-            highlightsButton.tintColor = .accent
-        }
 
         view.addSubview(tableView)
         tableView.snp.makeConstraints { make in
@@ -494,7 +497,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     @objc private func whatsNewClicked() {
         highlightsButton.tintColor = UserDefaults.standard.theme == .light ? .systemGray2 : .white
         navigationController?.pushViewController(SettingsContentViewController(url: URL(forSupportTopic: .whatsNew)), animated: true)
-        whatsNew.didShowWhatsNew()
+        whatsNewEventsHandler.didShowWhatsNew()
     }
 
     @objc private func toggleSwitched(_ sender: UISwitch) {

--- a/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -53,8 +53,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         let barButton = UIBarButtonItem(title: UIConstants.strings.whatsNewTitle, style: .plain, target: self, action: #selector(whatsNewClicked))
         barButton.image = UIImage(named: "highlight")
         barButton.accessibilityIdentifier = "SettingsViewController.whatsNewButton"
-        let barButtonDisabledColor: UIColor = UserDefaults.standard.theme == .device ? (traitCollection.userInterfaceStyle == .light ? .systemGray2 : .white) : (UserDefaults.standard.theme == .light ? .systemGray2 : .white)
-        barButton.tintColor = whatsNewEventsHandler.shouldShowWhatsNew ? .accent : barButtonDisabledColor
+        barButton.tintColor = whatsNewButtonColor
         return barButton
     }()
     
@@ -92,6 +91,11 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             break
         }
         return themeName
+    }
+    
+    private var whatsNewButtonColor: UIColor {
+        let barButtonDisabledColor: UIColor = UserDefaults.standard.theme == .device ? (traitCollection.userInterfaceStyle == .light ? .systemGray2 : .white) : (UserDefaults.standard.theme == .light ? .systemGray2 : .white)
+        return whatsNewEventsHandler.shouldShowWhatsNew ? .accent : barButtonDisabledColor
     }
 
     private func getSectionIndex(_ section: Section) -> Int? {
@@ -495,7 +499,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
 
     @objc private func whatsNewClicked() {
-        highlightsButton.tintColor = UserDefaults.standard.theme == .light ? .systemGray2 : .white
+        highlightsButton.tintColor = whatsNewButtonColor
         navigationController?.pushViewController(SettingsContentViewController(url: URL(forSupportTopic: .whatsNew)), animated: true)
         whatsNewEventsHandler.didShowWhatsNew()
     }

--- a/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -499,9 +499,9 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
 
     @objc private func whatsNewClicked() {
-        highlightsButton.tintColor = whatsNewButtonColor
         navigationController?.pushViewController(SettingsContentViewController(url: URL(forSupportTopic: .whatsNew)), animated: true)
         whatsNewEventsHandler.didShowWhatsNew()
+        highlightsButton.tintColor = whatsNewButtonColor
     }
 
     @objc private func toggleSwitched(_ sender: UISwitch) {

--- a/Blockzilla/UIComponents/BrowserToolset.swift
+++ b/Blockzilla/UIComponents/BrowserToolset.swift
@@ -16,8 +16,7 @@ protocol BrowserToolsetDelegate: AnyObject {
 
 class BrowserToolset {
     weak var delegate: BrowserToolsetDelegate?
-    
-    var whatsNewEventsHandler = WhatsNewEventsHandler()
+    var shouldShowWhatsNew: Bool = false
     let backButton = InsetButton()
     let forwardButton = InsetButton()
     let stopReloadButton = InsetButton()
@@ -61,7 +60,7 @@ class BrowserToolset {
         contextMenuButton.contentEdgeInsets = UIConstants.layout.toolbarButtonInsets
         contextMenuButton.imageView?.snp.makeConstraints { $0.size.equalTo(UIConstants.layout.contextMenuIconSize) }
         
-        setHighlightWhatsNew(shouldHighlight: shouldShowWhatsNew())
+       setHighlightWhatsNew(shouldHighlight: shouldShowWhatsNew)
     }
 
     var canGoBack: Bool = false {
@@ -124,20 +123,6 @@ class BrowserToolset {
     }
 
     func setHighlightWhatsNew(shouldHighlight: Bool) {
-        if shouldHighlight {
-            contextMenuButton.setImage(UIImage(named: "preferences_updated"), for: .normal)
-        } else {
-            contextMenuButton.setImage(UIImage(named: "icon_hamburger_menu"), for: .normal)
-        }
-    }
-}
-
-extension BrowserToolset: WhatsNewDelegate {
-    func shouldShowWhatsNew() -> Bool {
-        whatsNewEventsHandler.shouldShowWhatsNewButton
-    }
-
-    func didShowWhatsNew() {
-        whatsNewEventsHandler.didShowWhatsNewButton()
+        contextMenuButton.setImage(UIImage(named: shouldHighlight ? "preferences_updated" : "icon_hamburger_menu"), for: .normal)
     }
 }

--- a/Blockzilla/UIComponents/URLBar.swift
+++ b/Blockzilla/UIComponents/URLBar.swift
@@ -445,6 +445,10 @@ class URLBar: UIView {
         urlText.isUserInteractionEnabled = false
         urlText.endEditing(true)
     }
+    
+    public func setHighlightWhatsNew(shouldHighlight: Bool) {
+        toolset.setHighlightWhatsNew(shouldHighlight: shouldHighlight)
+    }
 
     @objc func addCustomURL() {
         guard let url = self.url else { return }

--- a/ClientTests/BrowserViewControllerTests.swift
+++ b/ClientTests/BrowserViewControllerTests.swift
@@ -27,11 +27,14 @@ class BrowserViewControllerTests: XCTestCase {
             
         }
     )
+    
+    private lazy var whatsNewEventsHandler = WhatsNewEventsHandler()
 
     func testRequestReviewThreshold() {
         let bvc = BrowserViewController(
             authenticationManager: AuthenticationManager(),
-            onboardingEventsHandler: onboardingEventsHandler
+            onboardingEventsHandler: onboardingEventsHandler,
+            whatsNewEventsHandler: whatsNewEventsHandler
         )
         mockUserDefaults.clear()
 


### PR DESCRIPTION
When the app is fresh installed, Whats new button won’t be highlighted (since everything is new). On every app version update the button will appear highlighted and will remain highlighted until the user taps on the button to see what is new. (Also on the conte menu button will appear in this case a small blue dot - showing that there is an update).
After the user taps the button it will remain de-emphasized until  a new app version will be installed.

## Commit message

Fixes #2803 - Add Whats new button functionality like in previous versions
Fixes #2802  - The gift icon is still active after visiting the Whats new page