### PR TITLE
Fixes #3171 The trash icon is way too close to the hamburger menu button in landscape mode

### DIFF
--- a/Blockzilla/UIComponents/UIConstants.swift
+++ b/Blockzilla/UIComponents/UIConstants.swift
@@ -142,6 +142,7 @@ struct UIConstants {
         static let contextMenuButtonSize: CGFloat = 36
         static let contextMenuButtonMargin: CGFloat = 14
         static let contextMenuIconSize: CGFloat = 28
+        static let deleteButtonMarginContextMenu: CGFloat = 16
     }
 
     struct strings {

--- a/Blockzilla/UIComponents/UIConstants.swift
+++ b/Blockzilla/UIComponents/UIConstants.swift
@@ -142,7 +142,7 @@ struct UIConstants {
         static let contextMenuButtonSize: CGFloat = 36
         static let contextMenuButtonMargin: CGFloat = 14
         static let contextMenuIconSize: CGFloat = 28
-        static let deleteButtonMarginContextMenu: CGFloat = 16
+        static let deleteButtonMarginContextMenu: CGFloat = -16
     }
 
     struct strings {

--- a/Blockzilla/UIComponents/URLBar.swift
+++ b/Blockzilla/UIComponents/URLBar.swift
@@ -298,7 +298,7 @@ class URLBar: UIView {
         }
         
         toolset.deleteButton.snp.makeConstraints { make in
-            make.trailing.equalTo(toolset.contextMenuButton.snp.leading).offset(isIPadRegularDimensions ? UIConstants.layout.deleteButtonOffset : 0)
+            make.trailing.equalTo(toolset.contextMenuButton.snp.leading).offset(isIPadRegularDimensions ? UIConstants.layout.deleteButtonOffset : -UIConstants.layout.deleteButtonMarginContextMenu)
             make.centerY.equalTo(self)
             make.size.equalTo(toolset.backButton)
         }

--- a/Blockzilla/UIComponents/URLBar.swift
+++ b/Blockzilla/UIComponents/URLBar.swift
@@ -298,7 +298,7 @@ class URLBar: UIView {
         }
         
         toolset.deleteButton.snp.makeConstraints { make in
-            make.trailing.equalTo(toolset.contextMenuButton.snp.leading).offset(isIPadRegularDimensions ? UIConstants.layout.deleteButtonOffset : -UIConstants.layout.deleteButtonMarginContextMenu)
+            make.trailing.equalTo(toolset.contextMenuButton.snp.leading).inset(isIPadRegularDimensions ? UIConstants.layout.deleteButtonOffset : UIConstants.layout.deleteButtonMarginContextMenu)
             make.centerY.equalTo(self)
             make.size.equalTo(toolset.backButton)
         }


### PR DESCRIPTION
Preview for Iphone landscape:
<img width="925" alt="Screenshot 2022-04-12 at 18 05 55" src="https://user-images.githubusercontent.com/16647663/162993906-96adb9d5-7abd-4d2b-872e-84116103e720.png">

Preview for Ipad:
<img width="664" alt="Screenshot 2022-04-12 at 18 06 05" src="https://user-images.githubusercontent.com/16647663/162994147-e1d7ced0-c727-4335-b744-8cd84ed69ad9.png">

## Commit Message
Fixes #3171 The trash icon is way too close to the hamburger menu button in landscape mode