### PR TITLE
Fixes #3203 The URL bar is not focused when closing the settings menu

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1433,6 +1433,7 @@ extension BrowserViewController: BrowserToolsetDelegate {
 
     func browserToolsetDidPressContextMenu(_ browserToolbar: BrowserToolset, menuButton: InsetButton) {
         updateFindInPageVisibility(visible: false)
+        urlBar.dismiss()
         presentContextMenu(from: menuButton)
     }
 }


### PR DESCRIPTION
This PR will prevent URL bar from being focused when the user taps on the Menu button.

https://user-images.githubusercontent.com/46751540/164028899-1f708664-0784-49d9-b06b-f3155d36ac08.mov


## Commit message

Fixes #3203 The URL bar is not focused when closing the settings menu