### PR TITLE
Fixes #3220 - Start Browsing button text does not fit on iPad, landscape orientation

### DIFF
--- a/BlockzillaPackage/Sources/Onboarding/OnboardingViewController.swift
+++ b/BlockzillaPackage/Sources/Onboarding/OnboardingViewController.swift
@@ -183,7 +183,7 @@ public class OnboardingViewController: UIViewController {
             mainStackView.layoutMargins = .init(top: .layoutMarginTop, left: size.width / .layoutMarginLeadingTrailingDivider, bottom: .layoutMarginBottom, right: size.width / .layoutMarginLeadingTrailingDivider)
             mainStackView.spacing = size.height / .spacingDividerPad
         }
-        
+
         updateStartButtonConstraints(for: size)
     }
 
@@ -191,11 +191,11 @@ public class OnboardingViewController: UIViewController {
         super.viewDidLoad()
         addSubViews()
     }
-    
+
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateStartButtonConstraints(for: view.frame.size)
-        
+
     }
 
     func addSubViews() {
@@ -240,7 +240,7 @@ public class OnboardingViewController: UIViewController {
             make.top.equalTo(scrollView.snp.bottom).inset(CGFloat.buttonBottomInset)
         }
     }
-    
+
     private func updateStartButtonConstraints(for size: CGSize) {
         startBrowsingButton.snp.updateConstraints { make in
             make.bottom.equalToSuperview().inset(size.height / .buttonButtomInsetDivider)

--- a/BlockzillaPackage/Sources/Onboarding/OnboardingViewController.swift
+++ b/BlockzillaPackage/Sources/Onboarding/OnboardingViewController.swift
@@ -183,16 +183,19 @@ public class OnboardingViewController: UIViewController {
             mainStackView.layoutMargins = .init(top: .layoutMarginTop, left: size.width / .layoutMarginLeadingTrailingDivider, bottom: .layoutMarginBottom, right: size.width / .layoutMarginLeadingTrailingDivider)
             mainStackView.spacing = size.height / .spacingDividerPad
         }
-
-        startBrowsingButton.snp.updateConstraints { make in
-            make.bottom.equalToSuperview().inset(size.height / .buttonButtomInsetDivider)
-            make.leading.trailing.equalToSuperview().inset(size.width / .buttonLeadingTrailingInsetDivider)
-        }
+        
+        updateStartButtonConstraints(for: size)
     }
 
     public override func viewDidLoad() {
         super.viewDidLoad()
         addSubViews()
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateStartButtonConstraints(for: view.frame.size)
+        
     }
 
     func addSubViews() {
@@ -235,6 +238,13 @@ public class OnboardingViewController: UIViewController {
             make.bottom.equalToSuperview().inset(view.frame.height / .buttonButtomInsetDivider)
             make.leading.trailing.equalToSuperview().inset(view.frame.width / .buttonLeadingTrailingInsetDivider)
             make.top.equalTo(scrollView.snp.bottom).inset(CGFloat.buttonBottomInset)
+        }
+    }
+    
+    private func updateStartButtonConstraints(for size: CGSize) {
+        startBrowsingButton.snp.updateConstraints { make in
+            make.bottom.equalToSuperview().inset(size.height / .buttonButtomInsetDivider)
+            make.leading.trailing.equalToSuperview().inset(size.width / .buttonLeadingTrailingInsetDivider)
         }
     }
 


### PR DESCRIPTION

<img width="1073" alt="Screen Shot 2022-04-27 at 2 54 29 PM" src="https://user-images.githubusercontent.com/46751540/165512855-bb6730d3-8e71-4e09-8355-db0ab5deadc0.png">


## Commit message
Fixes #3220 - Start Browsing button text does not fit on iPad, landscape orientation