### PR TITLE
upload docker-contexts in focus-ios decision tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -266,6 +266,14 @@ tasks:
                                   type: 'directory'
                                   path: '/builds/worker/artifacts'
                                   expires: {$fromNow: '1 year'}
+                              'public/docker-contexts':
+                                  type: 'directory'
+                                  path: '/builds/worker/checkouts/vcs/docker-contexts'
+                                  # This needs to be at least the deadline of the
+                                  # decision task + the docker-image task deadlines.
+                                  # It is set to a week to allow for some time for
+                                  # debugging, but they are not useful long-term.
+                                  expires: {$fromNow: '7 day'}
 
                       extra:
                           $merge:


### PR DESCRIPTION
Should fix the l10n screenshots tasks.

Essentially making sure our artifacts config looks like [firefox-ios'](https://github.com/mozilla-mobile/firefox-ios/blob/8ede4327589c42f6279d5c9d7f44dc5275d99dfe/.taskcluster.yml#L264-L276).