### PR TITLE
change default stack which is not supported

### DIFF
--- a/SmokeTest.xctestplan
+++ b/SmokeTest.xctestplan
@@ -15,6 +15,7 @@
     {
       "skippedTests" : [
         "AsianLocaleTest",
+        "BasicBrowsing\/testLaunchExternalApp()",
         "CollapsedURLTest",
         "CopyTest",
         "DragAndDropTest",

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -13,9 +13,9 @@ trigger_map:
   workflow: release
 
 meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-        machine_type_id: g2.4core
+  bitrise.io:
+    stack: osx-xcode-13.3.x
+    machine_type_id: g2.4core
 
 workflows:
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,6 +12,10 @@ trigger_map:
 - tag: "*"
   workflow: release
 
+meta:
+      bitrise.io:
+        stack: osx-xcode-13.3.x
+        machine_type_id: g2.4core
 
 workflows:
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,11 +12,6 @@ trigger_map:
 - tag: "*"
   workflow: release
 
-meta:
-  bitrise.io:
-    stack: osx-xcode-13.3.x
-    machine_type_id: g2.4core
-
 workflows:
 
   clone-and-build-dependencies:
@@ -519,3 +514,8 @@ app:
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: app-store
+
+meta:
+  bitrise.io:
+    stack: osx-xcode-13.3.x
+    machine_type_id: g2.4core


### PR DESCRIPTION
I realized the default workflow is not supported, not sure if this could be the cause of all the builds being Aborted