### PR TITLE
Add template header

### DIFF
--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string> This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/</string>
+</dict>
+</plist>

--- a/Blockzilla.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Blockzilla.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string> This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/</string>
+</dict>
+</plist>


### PR DESCRIPTION
Automatically add Mozilla copyright header on file creation.

![Screenshot 2022-07-20 at 17 00 32](https://user-images.githubusercontent.com/26011662/180001418-1e43cf05-f5be-4ab5-9eb0-580829210202.png)

