### PR TITLE
For #3345 - Add missing locales

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -2028,6 +2028,7 @@
 				"en-GB",
 				co,
 				tt,
+				et,
 			);
 			mainGroup = E4BF2DCA1BACE8CA00DA9D68;
 			packageReferences = (


### PR DESCRIPTION
This PR is to add the missing locales.

In theory by going to that menu, Localizations > click on '+' button and select a new locale should work.
<img width="1112" alt="Captura de Pantalla 2022-07-29 a las 10 48 55" src="https://user-images.githubusercontent.com/1897507/181721811-101522bf-84f2-427d-87d1-5c7699f55099.png">

But even though the locale is added, we would need a dialgo like this one just after selecting the new locale (screenshot from firefox):
<img width="703" alt="Captura de Pantalla 2022-07-29 a las 9 14 09" src="https://user-images.githubusercontent.com/1897507/181722032-357bb897-2638-4d86-a657-4868101fe675.png">

On focus nothing happens and the import string process ignores the new locale since the localization files have not been created.

@razvanlitianu @rilury I would need your help with this... I have tried different options but nothing works... do you have any idea where the problem could be?