### PR TITLE
Use correct apostrophe in SearchEngine.addEngineError string

### DIFF
--- a/Blockzilla/UIComponents/UIConstants.swift
+++ b/Blockzilla/UIComponents/UIConstants.swift
@@ -347,7 +347,7 @@ struct UIConstants {
         static let autocompleteAddCustomUrlWithPlus = NSLocalizedString("Autocomplete.addCustomUrlWithPlus", value: "+ Add Custom URL", comment: "Label for button to add a custom URL with the + prefix")
         static let autocompleteAddCustomUrl = NSLocalizedString("Autocomplete.addCustomUrl", value: "Add Custom URL", comment: "Label for button to add a custom URL")
         static let autocompleteAddCustomUrlError = NSLocalizedString("Autocomplete.addCustomUrlError", value: "Double-check the URL you entered.", comment: "Label for error state when entering an invalid URL")
-        static let addSearchEngineError = NSLocalizedString("SearchEngine.addEngineError", value: "That didn't work. Try replacing the search term with this: %s.", comment: "Label for error state when entering an invalid search engine URL. %s is a search term in a URL.")
+        static let addSearchEngineError = NSLocalizedString("SearchEngine.addEngineError", value: "That didn’t work. Try replacing the search term with this: %s.", comment: "Label for error state when entering an invalid search engine URL. %s is a search term in a URL.")
 
         static let autocompleteAddCustomUrlPlaceholder = NSLocalizedString("Autocomplete.addCustomUrlPlaceholder", value: "Paste or enter URL", comment: "Placeholder for the input field to add a custom URL")
         static let autocompleteAddCustomUrlLabel = NSLocalizedString("Autocomplete.addCustomUrlLabel", value: "URL to add", comment: "Label for the input to add a custom URL")

--- a/Blockzilla/en.lproj/Localizable.strings
+++ b/Blockzilla/en.lproj/Localizable.strings
@@ -284,7 +284,7 @@
 "Save" = "Save";
 
 /* Label for error state when entering an invalid search engine URL. %s is a search term in a URL. */
-"SearchEngine.addEngineError" = "That didn't work. Try replacing the search term with this: %s.";
+"SearchEngine.addEngineError" = "That didn’t work. Try replacing the search term with this: %s.";
 
 /* Label for disable option on search suggestions prompt */
 "SearchSuggestions.promptDisable" = "No";


### PR DESCRIPTION
Noticed while writing a linter for the source files in iOS projects.