### PR TITLE
Fixes #3359 - Display the second onboarding tooltip on the first occurence of a site where Focus blocks trackers

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -313,7 +313,6 @@ class BrowserViewController: UIViewController {
                     presentedController = controller
 
                 case .trash:
-                    let isTrackerBlocked = onboardingEventsHandler.shownTips.contains(.trackingProtectionShield) ? true : false
                     let sourceButton = showsToolsetInURLBar ? urlBar.deleteButton : browserToolbar.deleteButton
                     let sourceRect = showsToolsetInURLBar ? CGRect(x: sourceButton.bounds.midX, y: sourceButton.bounds.maxY - 10, width: 0, height: 0) :
                     CGRect(x: sourceButton.bounds.midX, y: sourceButton.bounds.minY + 10, width: 0, height: 0)
@@ -321,13 +320,7 @@ class BrowserViewController: UIViewController {
                         anchoredBy: sourceButton,
                         sourceRect: sourceRect,
                         body: UIConstants.strings.tooltipBodyTextForTrashIcon,
-                        dismiss: {
-                            self.dismiss(animated: true)
-                            if !isTrackerBlocked, self.getNumberOfLifetimeTrackersBlocked() > 0 {
-                                self.onboardingEventsHandler.shownTips.remove(.trackingProtectionShield)
-                                self.onboardingEventsHandler.send(.trackerBlocked)
-                            }
-                        }
+                        dismiss: { self.onboardingEventsHandler.route = nil }
                     )
                     self.present(controller, animated: true)
                     presentedController = controller

--- a/BlockzillaPackage/Package.swift
+++ b/BlockzillaPackage/Package.swift
@@ -23,6 +23,9 @@ let package = Package(
             name: "UIComponents",
             targets: ["UIComponents"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/SnapKit/SnapKit.git", from: "5.0.1")
+    ],
     targets: [
         .target(
             name: "UIComponents",
@@ -39,7 +42,8 @@ let package = Package(
         .target(
             name: "Onboarding",
             dependencies: [
-                "DesignSystem"
+                "DesignSystem",
+                .product(name: "SnapKit", package: "SnapKit")
             ]
         ),
         .target(

--- a/BlockzillaPackage/Sources/Onboarding/OnboardingEventsHandler.swift
+++ b/BlockzillaPackage/Sources/Onboarding/OnboardingEventsHandler.swift
@@ -35,7 +35,7 @@ public class OnboardingEventsHandler {
         case menu
     }
 
-    @Published public var route: ToolTipRoute?
+    @Published private var route: ToolTipRoute?
 
     private var visitedURLcounter = 0
     public var shownTips = Set<ToolTipRoute>() {

--- a/BlockzillaPackage/Sources/Onboarding/OnboardingEventsHandler.swift
+++ b/BlockzillaPackage/Sources/Onboarding/OnboardingEventsHandler.swift
@@ -35,10 +35,10 @@ public class OnboardingEventsHandler {
         case menu
     }
 
-    @Published private var route: ToolTipRoute?
+    @Published public var route: ToolTipRoute?
 
     private var visitedURLcounter = 0
-    public var shownTips = Set<ToolTipRoute>() {
+    private var shownTips = Set<ToolTipRoute>() {
         didSet {
             setShownTips(shownTips)
         }

--- a/BlockzillaPackage/Sources/Onboarding/OnboardingEventsHandler.swift
+++ b/BlockzillaPackage/Sources/Onboarding/OnboardingEventsHandler.swift
@@ -16,6 +16,7 @@ public class OnboardingEventsHandler {
         case enterHome
         case startBrowsing
         case showTrackingProtection
+        case trackerBlocked
     }
 
     public enum OnboardingType: Equatable, Hashable, Codable {
@@ -37,7 +38,7 @@ public class OnboardingEventsHandler {
     @Published public var route: ToolTipRoute?
 
     private var visitedURLcounter = 0
-    private var shownTips = Set<ToolTipRoute>() {
+    public var shownTips = Set<ToolTipRoute>() {
         didSet {
             setShownTips(shownTips)
         }
@@ -75,10 +76,6 @@ public class OnboardingEventsHandler {
             visitedURLcounter += 1
             guard shouldShowNewOnboarding() else { return }
 
-            if visitedURLcounter == 1 {
-                show(route: .trackingProtectionShield)
-            }
-
             if visitedURLcounter == 3 {
                 show(route: .trash)
             }
@@ -86,6 +83,9 @@ public class OnboardingEventsHandler {
         case .showTrackingProtection:
             guard shouldShowNewOnboarding() else { return }
             show(route: .trackingProtection)
+        case .trackerBlocked:
+            guard shouldShowNewOnboarding() else { return }
+            show(route: .trackingProtectionShield)
         }
     }
 


### PR DESCRIPTION
## Commit Message

Fixes #3359 - Display the second onboarding tooltip on the first occurence of a site where Focus blocks trackers 