### PR TITLE
Refactor FXIOS [v106] Screenshot Tests

### DIFF
--- a/ScreenshotTests/BaseTestCaseL10n.swift
+++ b/ScreenshotTests/BaseTestCaseL10n.swift
@@ -150,7 +150,7 @@ class BaseTestCaseL10n: XCTestCase {
 
     func openSettings() {
         app.buttons["HomeView.settingsButton"].tap()
-        app.collectionViews.buttons.element(boundBy: 1).tap()
+        app.collectionViews.buttons.element(boundBy: 2).tap()
     }
 }
 

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -119,7 +119,7 @@ class SnapshotTests: BaseTestCaseL10n {
         dismissURLBarFocused()
         app.buttons["HomeView.settingsButton"].tap()
         snapshot("20HomeViewSettings")
-        app.collectionViews.buttons.element(boundBy: 1).tap()
+        app.collectionViews.buttons.element(boundBy: 2).tap()
         waitForExistence(app.cells["SettingsViewController.searchCell"])
         app.cells["SettingsViewController.searchCell"].tap()
         snapshot("SettingsSearchEngine")
@@ -148,28 +148,29 @@ class SnapshotTests: BaseTestCaseL10n {
 
         // Tap on shortcuts settings menu option
         app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 6))
-        app.collectionViews.cells.buttons.element(boundBy: 6).tap()
+        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8))
+        app.collectionViews.cells.buttons.element(boundBy: 8).tap()
 
         // Tap on erase button to go to homepage and check the shortcut created
         app.buttons["URLBar.deleteButton"].firstMatch.tap()
         // Verify the shortcut is created
-        waitForExistence(app.otherElements.staticTexts["M"], timeout: 5)
+        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Open shortcut to check the tab menu label for shortcut option
-        app.otherElements.staticTexts["M"].tap()
+        app.otherElements.staticTexts["Mozilla"].tap()
         app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 6), timeout: 5)
+        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8), timeout: 5)
         snapshot("1-RemoveShortcutTabMenu")
 
         // Go back to homescreen
         app.collectionViews.cells.buttons.element(boundBy: 0).tap()
         app.navigationBars.buttons["SettingsViewController.doneButton"].tap()
         app.buttons["URLBar.deleteButton"].firstMatch.tap()
-        waitForExistence(app.otherElements.staticTexts["M"], timeout: 5)
+        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Remove created shortcut
-        app.otherElements.staticTexts["M"].press(forDuration: 2)
+        let icon = app.otherElements.containing(.staticText, identifier: "Mozilla")
+        icon.otherElements["outerView"].press(forDuration: 2)
         waitForExistence(app.collectionViews.cells.buttons.firstMatch)
         snapshot("2-RemoveShortcutLongPressOnIt")
     }


### PR DESCRIPTION
The screenshot tests are updated for the following:
* "Settings" is now the 3rd (and last) item from the home screen's hamburger menu. The other items above "Settings" are "What's New" and "Help". The test failed because "Help" has been selected.
* "Add Shortcuts" and "Remove from Shortcuts" is not the 9th item from the hamburger menu in the bottom.
* To remove a shortcut, we press on the icon ("outerView") and not on the text.

Note: There's no JIRA ticket for this issue. I'll update the title once the JIRA ticket is known.