### PR TITLE
L10n tests a few more updates

### DIFF
--- a/ScreenshotTests/BaseTestCaseL10n.swift
+++ b/ScreenshotTests/BaseTestCaseL10n.swift
@@ -17,7 +17,7 @@ class BaseTestCaseL10n: XCTestCase {
             let key = String(parts[1])
             if testRunningFirstRun.contains(key) {
             // for the current test name, add the db fixture used
-                app.launchArguments = ["testMode"]
+            // Do nothing and Run Onboarding
             } else {
                 app.launchArguments = ["testMode", "disableFirstRunUI"]
             }

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -124,9 +124,9 @@ class SnapshotTests: BaseTestCaseL10n {
         waitForWebPageLoad()
 
         // Tap on shortcuts settings menu option
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 5)
+        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
         app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8))
+        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8), timeout: 10)
         snapshot("WebsiteBrowserMenu")
         app.collectionViews.cells.buttons.element(boundBy: 8).tap()
 

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -126,36 +126,36 @@ class SnapshotTests: BaseTestCaseL10n {
         // Tap on shortcuts settings menu option
         waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
         app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8), timeout: 10)
+        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 7), timeout: 10)
         snapshot("WebsiteBrowserMenu")
-        app.collectionViews.cells.buttons.element(boundBy: 8).tap()
+        app.collectionViews.cells.buttons.element(boundBy: 7).tap()
 
         // Tap on erase button to go to homepage and check the shortcut created
-//        waitForExistence(app.buttons["URLBar.deleteButton"])
-//        app.buttons["URLBar.deleteButton"].firstMatch.tap()
-//        // Verify the shortcut is created
-//        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
+        waitForExistence(app.buttons["URLBar.deleteButton"])
+        app.buttons["URLBar.deleteButton"].firstMatch.tap()
+        // Verify the shortcut is created
+        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Open shortcut to check the tab menu label for shortcut option
-//        app.otherElements.staticTexts["Mozilla"].tap()
-//        waitForExistence(app.buttons["HomeView.settingsButton"])
-//        app.buttons["HomeView.settingsButton"].tap()
-//        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8), timeout: 5)
-//        snapshot("1-RemoveShortcutTabMenu")
-//
-//        // Go back to homescreen
-//        app.collectionViews.cells.buttons.element(boundBy: 0).tap()
-//        waitForExistence(app.navigationBars.buttons["SettingsViewController.doneButton"])
-//        app.navigationBars.buttons["SettingsViewController.doneButton"].tap()
-//        waitForExistence(app.buttons["URLBar.deleteButton"].firstMatch)
-//        app.buttons["URLBar.deleteButton"].firstMatch.tap()
-//        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
+        app.otherElements.staticTexts["Mozilla"].tap()
+        waitForExistence(app.buttons["HomeView.settingsButton"])
+        app.buttons["HomeView.settingsButton"].tap()
+        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 7), timeout: 5)
+        snapshot("1-RemoveShortcutTabMenu")
+
+        // Go back to homescreen
+        app.collectionViews.cells.buttons.element(boundBy: 0).tap()
+        waitForExistence(app.navigationBars.buttons["SettingsViewController.doneButton"])
+        app.navigationBars.buttons["SettingsViewController.doneButton"].tap()
+        waitForExistence(app.buttons["URLBar.deleteButton"].firstMatch)
+        app.buttons["URLBar.deleteButton"].firstMatch.tap()
+        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Remove created shortcut
-//        let icon = app.otherElements.containing(.staticText, identifier: "Mozilla")
-//        icon.otherElements["outerView"].press(forDuration: 2)
-//        waitForExistence(app.collectionViews.cells.buttons.firstMatch)
-//        snapshot("2-RemoveShortcutLongPressOnIt")
+        let icon = app.otherElements.containing(.staticText, identifier: "Mozilla")
+        icon.otherElements["outerView"].press(forDuration: 2)
+        waitForExistence(app.collectionViews.cells.buttons.firstMatch)
+        snapshot("2-RemoveShortcutLongPressOnIt")
     }
 
 //    Run it only for EN locales for now

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -124,17 +124,17 @@ class SnapshotTests: BaseTestCaseL10n {
         waitForWebPageLoad()
 
         // Tap on shortcuts settings menu option
-        waitForExistence(app.buttons["HomeView.settingsButton"])
+        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 5)
         app.buttons["HomeView.settingsButton"].tap()
         waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8))
         snapshot("WebsiteBrowserMenu")
         app.collectionViews.cells.buttons.element(boundBy: 8).tap()
 
         // Tap on erase button to go to homepage and check the shortcut created
-        waitForExistence(app.buttons["URLBar.deleteButton"])
-        app.buttons["URLBar.deleteButton"].firstMatch.tap()
-        // Verify the shortcut is created
-        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
+//        waitForExistence(app.buttons["URLBar.deleteButton"])
+//        app.buttons["URLBar.deleteButton"].firstMatch.tap()
+//        // Verify the shortcut is created
+//        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Open shortcut to check the tab menu label for shortcut option
 //        app.otherElements.staticTexts["Mozilla"].tap()

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -59,23 +59,6 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("13About")
     }
 
-    func test04ShareMenu() {
-        app.textFields["URLBar.urlText"].tap()
-        app.textFields["URLBar.urlText"].typeText("example.com\n")
-        waitForValueContains(app.textFields["URLBar.urlText"], value: "example")
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
-        app.buttons["HomeView.settingsButton"].tap()
-        snapshot("WebsiteSettingsMenu")
-        waitForExistence(app.cells.buttons.element(boundBy: 6))
-        app.cells.buttons.element(boundBy: 6).tap()
-        waitForExistence(app.buttons["HomeView.settingsButton"])
-        app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.cells.buttons.element(boundBy: 5))
-        snapshot("WebsiteSettingsMenu-RemovePin")
-        app.cells.buttons.element(boundBy: 5).tap()
-        snapshot("14ShareMenu")
-    }
-
     func test05SafariIntegration() {
         dismissURLBarFocused()
         openSettings()
@@ -147,24 +130,30 @@ class SnapshotTests: BaseTestCaseL10n {
         waitForWebPageLoad()
 
         // Tap on shortcuts settings menu option
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
         waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8))
+        snapshot("WebsiteBrowserMenu")
         app.collectionViews.cells.buttons.element(boundBy: 8).tap()
 
         // Tap on erase button to go to homepage and check the shortcut created
+        waitForExistence(app.buttons["URLBar.deleteButton"])
         app.buttons["URLBar.deleteButton"].firstMatch.tap()
         // Verify the shortcut is created
         waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Open shortcut to check the tab menu label for shortcut option
         app.otherElements.staticTexts["Mozilla"].tap()
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
         waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8), timeout: 5)
         snapshot("1-RemoveShortcutTabMenu")
 
         // Go back to homescreen
         app.collectionViews.cells.buttons.element(boundBy: 0).tap()
+        waitForExistence(app.navigationBars.buttons["SettingsViewController.doneButton"])
         app.navigationBars.buttons["SettingsViewController.doneButton"].tap()
+        waitForExistence(app.buttons["URLBar.deleteButton"].firstMatch)
         app.buttons["URLBar.deleteButton"].firstMatch.tap()
         waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -7,14 +7,8 @@ import XCTest
 class SnapshotTests: BaseTestCaseL10n {
 
     func test01FirstRunScreens() {
+        waitForExistence(app.buttons["IntroViewController.startBrowsingButton"], timeout: 10)
         snapshot("00FirstRun")
-        app.swipeLeft()
-        snapshot("01FirstRun")
-        app.swipeLeft()
-        snapshot("02FirstRun")
-        waitForExistence(app.buttons["IntroViewController.button"], timeout: 15)
-        app.buttons["IntroViewController.button"].tap()
-        snapshot("03Home")
     }
 
     func test02Settings() {
@@ -143,25 +137,25 @@ class SnapshotTests: BaseTestCaseL10n {
         waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Open shortcut to check the tab menu label for shortcut option
-        app.otherElements.staticTexts["Mozilla"].tap()
-        waitForExistence(app.buttons["HomeView.settingsButton"])
-        app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8), timeout: 5)
-        snapshot("1-RemoveShortcutTabMenu")
-
-        // Go back to homescreen
-        app.collectionViews.cells.buttons.element(boundBy: 0).tap()
-        waitForExistence(app.navigationBars.buttons["SettingsViewController.doneButton"])
-        app.navigationBars.buttons["SettingsViewController.doneButton"].tap()
-        waitForExistence(app.buttons["URLBar.deleteButton"].firstMatch)
-        app.buttons["URLBar.deleteButton"].firstMatch.tap()
-        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
+//        app.otherElements.staticTexts["Mozilla"].tap()
+//        waitForExistence(app.buttons["HomeView.settingsButton"])
+//        app.buttons["HomeView.settingsButton"].tap()
+//        waitForExistence(app.collectionViews.cells.buttons.element(boundBy: 8), timeout: 5)
+//        snapshot("1-RemoveShortcutTabMenu")
+//
+//        // Go back to homescreen
+//        app.collectionViews.cells.buttons.element(boundBy: 0).tap()
+//        waitForExistence(app.navigationBars.buttons["SettingsViewController.doneButton"])
+//        app.navigationBars.buttons["SettingsViewController.doneButton"].tap()
+//        waitForExistence(app.buttons["URLBar.deleteButton"].firstMatch)
+//        app.buttons["URLBar.deleteButton"].firstMatch.tap()
+//        waitForExistence(app.otherElements.staticTexts["Mozilla"], timeout: 5)
 
         // Remove created shortcut
-        let icon = app.otherElements.containing(.staticText, identifier: "Mozilla")
-        icon.otherElements["outerView"].press(forDuration: 2)
-        waitForExistence(app.collectionViews.cells.buttons.firstMatch)
-        snapshot("2-RemoveShortcutLongPressOnIt")
+//        let icon = app.otherElements.containing(.staticText, identifier: "Mozilla")
+//        icon.otherElements["outerView"].press(forDuration: 2)
+//        waitForExistence(app.collectionViews.cells.buttons.firstMatch)
+//        snapshot("2-RemoveShortcutLongPressOnIt")
     }
 
 //    Run it only for EN locales for now

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,7 +8,7 @@ trigger_map:
 - push_branch: main
   workflow: runParallelTests
 - pull_request_source_branch: "*"
-  workflow: runParallelTests
+  workflow: L10nBuild
 - tag: "*"
   workflow: release
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,7 +8,7 @@ trigger_map:
 - push_branch: main
   workflow: runParallelTests
 - pull_request_source_branch: "*"
-  workflow: L10nBuild
+  workflow: runParallelTests
 - tag: "*"
   workflow: release
 


### PR DESCRIPTION
Trying to fix #3281
- Show the prod onboarding not the old one
- Remove obsolote test that was not adding new/valuable screenshots
- Adding waits for element for the removeShortcuts test