### PR TITLE
Fixes #3469 - The "Get Started" button is not fully displayed in landscape mode 

### DIFF
--- a/Blockzilla/Onboarding/OnboardingFactory.swift
+++ b/Blockzilla/Onboarding/OnboardingFactory.swift
@@ -44,7 +44,7 @@ class OnboardingFactory {
     static func make(onboardingType: OnboardingVersion, dismissAction: @escaping () -> Void) -> UIViewController {
         switch onboardingType {
         case .v2:
-            let controller = UIHostingController(rootView: GetStartedOnboardingView(
+            let controller = OnboardingHostingControllerV2(rootView: GetStartedOnboardingView(
                 config: .init(title: .onboardingTitle, subtitle: .onboardingSubtitleV2, buttonTitle: .onboardingButtonTitleV2),
                 defaultBrowserConfig: .init(
                     title: .defaultBrowserOnboardingViewTitleV2,
@@ -54,8 +54,7 @@ class OnboardingFactory {
                     bottomButtonTitle: .defaultBrowserOnboardingViewBottomButtonTitleV2),
                 dismissAction: dismissAction))
 
-            controller.modalPresentationStyle = .formSheet
-            controller.isModalInPresentation = true
+            controller.modalPresentationStyle = .fullScreen
             return controller
 
         case .v1:

--- a/BlockzillaPackage/Sources/Onboarding/OnboardingHostingControllerV2.swift
+++ b/BlockzillaPackage/Sources/Onboarding/OnboardingHostingControllerV2.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+
+public class OnboardingHostingControllerV2<Content>: UIHostingController<Content> where Content : View {
+
+    public override var shouldAutorotate: Bool { return false }
+
+    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask { return .portrait }
+}

--- a/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -68,7 +68,7 @@ struct DefaultBrowserOnboardingView: View {
         .padding([.top, .leading, .trailing], .viewPadding)
         .navigationBarHidden(true)
         .background(Color.secondOnboardingScreenBackground
-            .edgesIgnoringSafeArea(.bottom))
+            .edgesIgnoringSafeArea([.top, .bottom]))
     }
 }
 


### PR DESCRIPTION
## Commit Message

To resolve this issue we made the screen available only in portrait mode.

Fixes #3469 - The "Get Started" button is not fully displayed in landscape mode