### PR TITLE
Fixes #3479 Browser search count telemetry addition

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -851,6 +851,7 @@ class BrowserViewController: UIViewController {
     func submit(url: URL) {
         // If this is the first navigation, show the browser and the toolbar.
         guard isViewLoaded else { initialUrl = url; return }
+        GleanMetrics.BrowserSearch.searchCount["action"].add()
         shortcutsPresenter.shortcutsState = .none
 
         if isIPadRegularDimensions {

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -535,3 +535,24 @@ browser_search:
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: "2023-08-20"
+  search_count:
+    type: labeled_counter
+    description: |
+      The labels for this counter are `<search-engine-name>.<source>`.
+      If the search engine is bundled with Focus `search-engine-name` will be
+      the name of the search engine. If it's a custom search engine (defined:
+      https://github.com/mozilla-mobile/fenix/issues/1607) the value will be
+      `custom`.
+      `source` will be: `action`, `suggestion`
+    send_in_pings:
+        - metrics
+    bugs:
+        https://github.com/mozilla-mobile/focus-ios/issues/3479
+    data_reviews:
+        - https://github.com/mozilla-mobile/focus-ios/pull/3483
+    data_sensitivity:
+        - technical
+        - interaction
+    notification_emails:
+        - android-probes@mozilla.com
+    expires: "2023-09-22"

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -543,16 +543,16 @@ browser_search:
       the name of the search engine. If it's a custom search engine (defined:
       https://github.com/mozilla-mobile/fenix/issues/1607) the value will be
       `custom`.
-      `source` will be: `action`, `suggestion`
+      `source` will be: `action`, `suggestion`.
     send_in_pings:
-        - metrics
+      - metrics
     bugs:
-        https://github.com/mozilla-mobile/focus-ios/issues/3479
+      - https://github.com/mozilla-mobile/focus-ios/issues/3479
     data_reviews:
-        - https://github.com/mozilla-mobile/focus-ios/pull/3483
+      - https://github.com/mozilla-mobile/focus-ios/pull/3483
     data_sensitivity:
-        - technical
-        - interaction
+      - technical
+      - interaction
     notification_emails:
-        - android-probes@mozilla.com
+      - focus-ios-data-stewards@mozilla.com
     expires: "2023-09-22"


### PR DESCRIPTION
# Request for data collection review form

All questions are mandatory. You must receive a review from a data steward peer on your responses to these questions before shipping new data collection.

1) What questions will you answer with this data?
How many times the user searched informations using Focus and what's the source of search(action, suggestion)?

2) Why does Mozilla need to answer these questions? Are there benefits for users? Do we need this information to address product or business requirements?
This is needed to analyze feature usage and possible feature improvements.

3) What alternative methods did you consider to answer these questions? Why were they not sufficient?
This is the only way.

4) Can current instrumentation answer these questions?
No. We need a new specific event for a specific app feature.

5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki.

Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.

<!DOCTYPE html>

Measurement Description | Data Collection Category | Tracking Bug #
-- | -- | --
Searching counter | Category 2 | https://github.com/mozilla-mobile/focus-ios/issues/3479

6) How long will this data be collected? Choose one of the following:
Expiry for capturing data is set to "2023-09-22"

7) What populations will you measure?
All release channels and locales.

8) If this data collection is default on, what is the opt-out mechanism for users?
Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

9) Please provide a general description of how you will analyze this data.
Glean

10) Where do you intend to share the results of your analysis?
Only on Glean, mobile teams, and BD have internal access.

12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?
No.

## Commit message
Fixes #3479 Browser search count telemetry addition