### PR TITLE
Run import-strings on Sunday instead of Monday

### DIFF
--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -6,8 +6,8 @@ permissions:
 
 on:
   schedule:
-    # Runs at 10pm on Monday
-    - cron: '0 22 * * 1'
+    # Runs at 10pm on Sunday
+    - cron: '0 22 * * 0'
 
 jobs:
   build:


### PR DESCRIPTION
We tend to cut the branch for RC builds on Mondays, which makes it very likely to happen before the now-weekly import-strings job has run. As a result, we end up building the RC with a week-old string import. If we move it to Sunday instead, we should be able to avoid the problem will still maintaining the benefit of the weekly cadence.