### PR TITLE
Fixes #3475 Default search engine telemetry addition

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -361,6 +361,8 @@ extension AppDelegate {
         let defaultSearchEngineProvider = activeSearchEngine.isCustom ? "custom" : activeSearchEngine.name
         telemetryConfig.defaultSearchEngineProvider = defaultSearchEngineProvider
 
+        GleanMetrics.Search.defaultEngine.set(defaultSearchEngineProvider)
+
         telemetryConfig.measureUserDefaultsSetting(forKey: SearchEngineManager.prefKeyEngine, withDefaultValue: defaultSearchEngineProvider)
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockAds, withDefaultValue: Settings.getToggle(.blockAds))
         telemetryConfig.measureUserDefaultsSetting(forKey: SettingsToggle.blockAnalytics, withDefaultValue: Settings.getToggle(.blockAnalytics))

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -556,3 +556,20 @@ browser_search:
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: "2023-09-22"
+
+search:
+  default_engine:
+    type: string
+    lifetime: application
+    description: |
+      The default search engine identifier if the search engine is
+      pre-loaded with Focus.  If it's a custom search engine,
+      then the value will be 'custom'.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-ios/issues/3439
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
+    notification_emails:
+      - focus-ios-data-stewards@mozilla.com
+    expires: "2023-09-22"


### PR DESCRIPTION
This PR will add .
# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_

- What percentage of users use what kind of search engine?

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_

As we get to know number of users and what search engine they use it will help us in understanding better user retention and Focus usage.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_

No alternative method to get this data.

_4) Can current instrumentation answer these questions?_

No. 

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Track user's default search engine</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-ios/issues/3475</td>
  </tr>
</table>

_6) How long will this data be collected?  Choose one of the following:_

Until 2023-09-22.

_7) What populations will you measure?_

All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_

Users can opt of of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._

Using Glean, by monitoring the count of how often users are performing these actions.

_10) Where do you intend to share the results of your analysis?_

Only on Glean, mobile teams and BD have internal access.

_11) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_

No.

## Commit Message
Fixes #3475 Default search engine telemetry addition