### PR TITLE
Fixes #2936 "Open Link" in page preview opens in external browser instead of Focus

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -1063,7 +1063,7 @@ class BrowserViewController: UIViewController {
             let actionMenu = UIMenu(options: .displayInline, children: actionItems)
             actions.append(actionMenu)
 
-            var shareItems: [UIMenuElement?] = [UIAction(copyItem)]
+            var shareItems: [UIMenuElement?] = [UIAction(copyItem(url: url))]
             shareItems.append(UIAction(sharePageItem(for: utils, sender: sender)))
             shareItems.append(openInFireFoxItem(for: url).map(UIAction.init))
             shareItems.append(openInChromeItem(for: url).map(UIAction.init))
@@ -1095,7 +1095,7 @@ class BrowserViewController: UIViewController {
                 : PhotonActionSheetItem(requestDesktopItem)
             )
 
-            var shareItems: [PhotonActionSheetItem?] = [PhotonActionSheetItem(copyItem)]
+            var shareItems: [PhotonActionSheetItem?] = [PhotonActionSheetItem(copyItem(url: url))]
             shareItems.append(PhotonActionSheetItem(sharePageItem(for: utils, sender: sender)))
             shareItems.append(openInFireFoxItem(for: url).map(PhotonActionSheetItem.init))
             shareItems.append(openInChromeItem(for: url).map(PhotonActionSheetItem.init))
@@ -1991,8 +1991,8 @@ extension BrowserViewController: MenuActionable {
         submit(url: URL(forSupportTopic: .whatsNew))
     }
 
-    func showCopy() {
-        urlBar.copyToClipboard()
+    func showCopy(url: URL) {
+        UIPasteboard.general.string = url.absoluteString
         Toast(text: UIConstants.strings.copyURLToast).show()
 
         GleanMetrics.BrowserMenu.browserMenuAction.record(GleanMetrics.BrowserMenu.BrowserMenuActionExtra(item: "copy_url"))

--- a/Blockzilla/Menu/Protocol/MenuActionable.swift
+++ b/Blockzilla/Menu/Protocol/MenuActionable.swift
@@ -4,7 +4,13 @@
 
 import UIKit
 
-protocol MenuActionable: AnyObject {
+protocol WebViewMenuActionable: AnyObject {
+    func openInDefaultBrowser(url: URL)
+    func showCopy(url: URL)
+    func showSharePage(for utils: OpenUtils, sender: UIView)
+}
+
+protocol MenuActionable: WebViewMenuActionable {
     func addToShortcuts(url: URL)
     func removeShortcut(url: URL)
 
@@ -12,11 +18,8 @@ protocol MenuActionable: AnyObject {
     func requestDesktopBrowsing()
     func requestMobileBrowsing()
 
-    func showCopy()
-    func showSharePage(for utils: OpenUtils, sender: UIView)
     func openInFirefox(url: URL)
     func openInChrome(url: URL)
-    func openInDefaultBrowser(url: URL)
     var canOpenInFirefox: Bool { get }
     var canOpenInChrome: Bool { get }
 

--- a/Blockzilla/Menu/Protocol/MenuItemProvider.swift
+++ b/Blockzilla/Menu/Protocol/MenuItemProvider.swift
@@ -5,12 +5,37 @@
 import UIKit
 import AppShortcuts
 
-protocol MenuItemProvider: AnyObject {
+protocol WebViewItemProvider: AnyObject {
+    func openInDefaultBrowserItem(for url: URL) -> MenuAction
+    func copyItem(url: URL) -> MenuAction
+    func sharePageItem(for utils: OpenUtils, sender: UIView) -> MenuAction
+}
+
+extension WebViewItemProvider where Self: WebViewMenuActionable {
+    func openInDefaultBrowserItem(for url: URL) -> MenuAction {
+        MenuAction(title: UIConstants.strings.shareOpenInDefaultBrowser, image: "icon_favicon") { [unowned self] in
+            self.openInDefaultBrowser(url: url)
+        }
+    }
+
+    func sharePageItem(for utils: OpenUtils, sender: UIView) -> MenuAction {
+        MenuAction(title: UIConstants.strings.sharePage, image: "icon_openwith_active") { [unowned self] in
+            self.showSharePage(for: utils, sender: sender)
+        }
+    }
+
+    func copyItem(url: URL) -> MenuAction {
+        MenuAction(title: UIConstants.strings.copyAddress, image: "icon_link") { [unowned self] in
+            self.showCopy(url: url)
+        }
+    }
+}
+
+protocol MenuItemProvider: WebViewItemProvider {
     var shortcutManager: ShortcutsManager { get }
 
     func openInFireFoxItem(for url: URL) -> MenuAction?
     func openInChromeItem(for url: URL) -> MenuAction?
-    func openInDefaultBrowserItem(for url: URL) -> MenuAction
 
     var findInPageItem: MenuAction { get }
     var requestDesktopItem: MenuAction { get }
@@ -18,12 +43,10 @@ protocol MenuItemProvider: AnyObject {
     var settingsItem: MenuAction { get }
     var helpItem: MenuAction { get }
     var whatsNewItem: MenuAction { get }
-    var copyItem: MenuAction { get }
 
     func getShortcutsItem(for url: URL) -> MenuAction?
     func addToShortcutsItem(for url: URL) -> MenuAction
     func removeFromShortcutsItem(for url: URL) -> MenuAction
-    func sharePageItem(for utils: OpenUtils, sender: UIView) -> MenuAction
 }
 
 extension MenuItemProvider where Self: MenuActionable {
@@ -42,12 +65,6 @@ extension MenuItemProvider where Self: MenuActionable {
             self.openInChrome(url: url)
         }
         : nil
-    }
-
-    func openInDefaultBrowserItem(for url: URL) -> MenuAction {
-        MenuAction(title: UIConstants.strings.shareOpenInDefaultBrowser, image: "icon_favicon") { [unowned self] in
-            self.openInDefaultBrowser(url: url)
-        }
     }
 
     var findInPageItem: MenuAction {
@@ -86,12 +103,6 @@ extension MenuItemProvider where Self: MenuActionable {
         }
     }
 
-    var copyItem: MenuAction {
-        MenuAction(title: UIConstants.strings.copyAddress, image: "icon_link") { [unowned self] in
-            self.showCopy()
-        }
-    }
-
     func getShortcutsItem(for url: URL) -> MenuAction? {
         if shortcutManager.isSaved(url: url) {
             return removeFromShortcutsItem(for: url)
@@ -111,12 +122,6 @@ extension MenuItemProvider where Self: MenuActionable {
     func removeFromShortcutsItem(for url: URL) -> MenuAction {
         MenuAction(title: UIConstants.strings.shareMenuRemoveFromShortcuts, image: "icon_shortcuts_remove") { [unowned self] in
             self.removeShortcut(url: url)
-        }
-    }
-
-    func sharePageItem(for utils: OpenUtils, sender: UIView) -> MenuAction {
-        MenuAction(title: UIConstants.strings.sharePage, image: "icon_openwith_active") { [unowned self] in
-            self.showSharePage(for: utils, sender: sender)
         }
     }
 }


### PR DESCRIPTION
<img height="400" alt="Screenshot 2022-10-10 at 12 23 21" src="https://user-images.githubusercontent.com/26011662/196181283-7b71e4d9-deeb-43d0-bcf7-524f3aa841a1.PNG">

## Commit message
Fixes #2936 "Open Link" in page preview opens in external browser instead of Focus