### PR TITLE
Fix overlapping button and tab view index control on onboarding screen

### DIFF
--- a/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -10,6 +10,8 @@ struct DefaultBrowserOnboardingView: View {
     init(viewModel: OnboardingViewModel) {
         self.viewModel = viewModel
     }
+    
+    let bottomSafeAreaInset = UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0
 
     var body: some View {
         VStack {
@@ -61,7 +63,7 @@ struct DefaultBrowserOnboardingView: View {
                     .background(Color.secondOnboardingScreenBottomButton)
                     .cornerRadius(.radius)
             })
-            .padding(.bottom, .skipButtonPadding)
+            .padding(.bottom, bottomSafeAreaInset > 0 ? .skipButtonPadding : .skipButtonPaddingNoSafeArea)
         }
         .padding([.leading, .trailing], .viewPadding)
         .navigationBarHidden(true)
@@ -78,6 +80,7 @@ fileprivate extension CGFloat {
     static let titleSize: CGFloat = 26
     static let titleBottomPadding: CGFloat = 12
     static let skipButtonPadding: CGFloat = 20
+    static let skipButtonPaddingNoSafeArea: CGFloat = 40
     static let firstSubtitleBottomPadding: CGFloat = 14
     static let viewPadding: CGFloat = 26
     static let radius: CGFloat = 12


### PR DESCRIPTION
Fix a small bug on the new onboarding screen where the TabView's dots are drawn on top of the Skip button. For example, on the 3rd generation iPhone SE or iPhone 8 (basically those devices where the safe area does not exist).

Before:
<img src="https://user-images.githubusercontent.com/4525736/199326841-b7244504-c74e-4db9-97e3-7b318445df01.png" width="300">

After:
<img src="https://user-images.githubusercontent.com/4525736/199326871-0de2bd16-7dc6-419a-adec-e789060bd434.png" width="300">
