### PR TITLE
Fixes  #3534 - Can't close shield menu when accessibility text is turned on

### DIFF
--- a/Blockzilla/Tracking Protection/Presentation/SheetModalViewController.swift
+++ b/Blockzilla/Tracking Protection/Presentation/SheetModalViewController.swift
@@ -59,6 +59,8 @@ class SheetModalViewController: UIViewController {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
         let height = min(container.preferredContentSize.height + metrics.closeButtonSize + metrics.closeButtonInset, metrics.maximumContainerHeight)
         animateContainerHeight(height)
+        closeButton.snp.removeConstraints()
+        setCloseButtonConstraints(isFullScreen: containerView.frame.height >= metrics.maximumContainerHeight)
     }
 
     override func viewDidLoad() {
@@ -91,8 +93,17 @@ class SheetModalViewController: UIViewController {
         }
 
         containerView.addSubview(closeButton)
+        setCloseButtonConstraints(isFullScreen: false)
+    }
+
+    private func setCloseButtonConstraints(isFullScreen: Bool) {
         closeButton.snp.makeConstraints { make in
-            make.trailing.top.equalToSuperview().inset(metrics.closeButtonInset)
+            if isFullScreen {
+                make.top.equalTo(view.safeAreaLayoutGuide)
+            } else {
+                make.top.equalToSuperview().inset(metrics.closeButtonInset)
+            }
+            make.trailing.equalToSuperview().inset(metrics.closeButtonInset)
             make.height.width.equalTo(metrics.closeButtonSize)
         }
     }

--- a/Blockzilla/Tracking Protection/Presentation/SheetModalViewController.swift
+++ b/Blockzilla/Tracking Protection/Presentation/SheetModalViewController.swift
@@ -59,8 +59,6 @@ class SheetModalViewController: UIViewController {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
         let height = min(container.preferredContentSize.height + metrics.closeButtonSize + metrics.closeButtonInset, metrics.maximumContainerHeight)
         animateContainerHeight(height)
-        closeButton.snp.removeConstraints()
-        setCloseButtonConstraints(isFullScreen: containerView.frame.height >= metrics.maximumContainerHeight)
     }
 
     override func viewDidLoad() {
@@ -93,17 +91,8 @@ class SheetModalViewController: UIViewController {
         }
 
         containerView.addSubview(closeButton)
-        setCloseButtonConstraints(isFullScreen: false)
-    }
-
-    private func setCloseButtonConstraints(isFullScreen: Bool) {
         closeButton.snp.makeConstraints { make in
-            if isFullScreen {
-                make.top.equalTo(view.safeAreaLayoutGuide)
-            } else {
-                make.top.equalToSuperview().inset(metrics.closeButtonInset)
-            }
-            make.trailing.equalToSuperview().inset(metrics.closeButtonInset)
+            make.trailing.top.equalTo(containerView.safeAreaLayoutGuide).inset(metrics.closeButtonInset)
             make.height.width.equalTo(metrics.closeButtonSize)
         }
     }

--- a/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -217,7 +217,7 @@ class TrackingProtectionViewController: UIViewController {
         if case .browsing = state { return 2 }  else { return 1 }
     }
     private var tableViewTopInset: CGFloat {
-        if case .settings = state { return 0 }  else { return 48 }
+        if case .settings = state { return 0 }  else { return 54 }
     }
     var state: TrackingProtectionState
     let favIconPublisher: AnyPublisher<URL?, Never>?
@@ -303,7 +303,9 @@ class TrackingProtectionViewController: UIViewController {
            let baseDomain = browsingStatus.url.baseDomain {
             view.addSubview(header)
             header.snp.makeConstraints { make in
+                self.headerHeight = make.height.equalTo(72).constraint
                 make.top.leading.trailing.equalToSuperview()
+                make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
             }
             if let publisher = favIconPublisher {
                 header.configure(domain: baseDomain, publisher: publisher)

--- a/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -217,7 +217,7 @@ class TrackingProtectionViewController: UIViewController {
         if case .browsing = state { return 2 }  else { return 1 }
     }
     private var tableViewTopInset: CGFloat {
-        if case .settings = state { return 0 }  else { return 54 }
+        if case .settings = state { return 0 }  else { return UIConstants.layout.trackingProtectionTableViewTopInset }
     }
     var state: TrackingProtectionState
     let favIconPublisher: AnyPublisher<URL?, Never>?
@@ -303,9 +303,9 @@ class TrackingProtectionViewController: UIViewController {
            let baseDomain = browsingStatus.url.baseDomain {
             view.addSubview(header)
             header.snp.makeConstraints { make in
-                self.headerHeight = make.height.equalTo(72).constraint
-                make.top.leading.trailing.equalToSuperview()
-                make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+                self.headerHeight = make.height.equalTo(UIConstants.layout.trackingProtectionHeaderHeight).constraint
+                make.leading.trailing.equalToSuperview()
+                make.top.equalTo(view.safeAreaLayoutGuide).offset(UIConstants.layout.trackingProtectionHeaderTopOffset)
             }
             if let publisher = favIconPublisher {
                 header.configure(domain: baseDomain, publisher: publisher)

--- a/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -303,7 +303,6 @@ class TrackingProtectionViewController: UIViewController {
            let baseDomain = browsingStatus.url.baseDomain {
             view.addSubview(header)
             header.snp.makeConstraints { make in
-                self.headerHeight = make.height.equalTo(72).constraint
                 make.top.leading.trailing.equalToSuperview()
             }
             if let publisher = favIconPublisher {

--- a/Blockzilla/Tracking Protection/Views/SubtitleCell.swift
+++ b/Blockzilla/Tracking Protection/Views/SubtitleCell.swift
@@ -10,11 +10,13 @@ class SubtitleCell: UITableViewCell {
         self.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
         textLabel?.text = title
         textLabel?.textColor = .primaryText.withAlphaComponent(0.6)
-        textLabel?.font = .body15
+        textLabel?.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: .body15)
+        textLabel?.adjustsFontForContentSizeCategory = true
         textLabel?.numberOfLines = 0
         detailTextLabel?.text = subtitle
         detailTextLabel?.textColor = .primaryText
-        detailTextLabel?.font = .title20
+        detailTextLabel?.font = UIFontMetrics(forTextStyle: .title1).scaledFont(for: .title20)
+        detailTextLabel?.adjustsFontForContentSizeCategory = true
         backgroundColor = .secondarySystemGroupedBackground
         selectionStyle = .none
     }

--- a/Blockzilla/UIComponents/UIConstants.swift
+++ b/Blockzilla/UIComponents/UIConstants.swift
@@ -79,6 +79,9 @@ struct UIConstants {
         static let findInPagePreviousButtonOffset: CGFloat = 16
         static let progressBarHeight: CGFloat = 1.5
         static let trackingProtectionHeight: CGFloat = 18
+        static let trackingProtectionTableViewTopInset: CGFloat = 54
+        static let trackingProtectionHeaderHeight: CGFloat = 72
+        static let trackingProtectionHeaderTopOffset: CGFloat = 18
         static let collapsedProtectionBadgeOffset: CGFloat = 10
         static let truncatedUrlTextOffset: CGFloat = 5
         static let addSearchEngineInputHeight: CGFloat = 44


### PR DESCRIPTION
### Commit message
Fixes  #3534 - Can't close shield menu when accessibility text is turned on

Smaller text size:
<img width="564" alt="Screen Shot 2022-11-02 at 12 49 16 PM" src="https://user-images.githubusercontent.com/46751540/199473710-5f5bb9cb-3a48-4ae2-9d42-8344e8e74cb0.png">

Max text size:
<img width="564" alt="Screen Shot 2022-11-02 at 12 48 48 PM" src="https://user-images.githubusercontent.com/46751540/199473694-94ab6cd2-b9f3-4437-a594-003ae17381b9.png">
