### PR TITLE
Fixes #3553 - added search metrics to baseline ping

### DIFF
--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -55,6 +55,11 @@ browser:
       - focus-ios-data-stewards@mozilla.com
       - sarentz@mozilla.com
     expires: never
+    send_in_pings:
+      - metrics
+      - baseline
+    no_lint:
+      - BASELINE_PING
 
 mozilla_products:
   has_firefox_installed:
@@ -514,6 +519,9 @@ browser_search:
       The key format is ‘<provider-name>’.
     send_in_pings:
       - metrics
+      - baseline
+    no_lint:
+      - BASELINE_PING
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3330
     data_reviews:
@@ -528,6 +536,9 @@ browser_search:
       The key format is ‘<provider-name>’.
     send_in_pings:
       - metrics
+      - baseline
+    no_lint:
+      - BASELINE_PING
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3330
     data_reviews:
@@ -546,6 +557,9 @@ browser_search:
       `source` will be: `action`, `suggestion`.
     send_in_pings:
       - metrics
+      - baseline
+    no_lint:
+      - BASELINE_PING
     bugs:
       - https://github.com/mozilla-mobile/focus-ios/issues/3479
     data_reviews:
@@ -567,6 +581,11 @@ browser_search:
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: "2023-10-06"
+    send_in_pings:
+      - metrics
+      - baseline
+    no_lint:
+      - BASELINE_PING
 
 onboarding:
   card_view:
@@ -691,3 +710,8 @@ search:
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: "2023-09-22"
+    send_in_pings:
+      - metrics
+      - baseline
+    no_lint:
+      - BASELINE_PING


### PR DESCRIPTION
Included specifying some pings in places where it was left to default values