### PR TITLE
Fixes #3570 - The old onboarding and tooltips are displayed on latest 9000 (15537) version (main)

### DIFF
--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -54,12 +54,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private lazy var onboardingEventsHandler: OnboardingEventsHandling = {
         var shouldShowNewOnboarding: () -> Bool = { [unowned self] in
-            if UserDefaults.standard.bool(forKey: OnboardingConstants.ignoreOnboardingExperiment) {
-                return !UserDefaults.standard.bool(forKey: OnboardingConstants.showOldOnboarding)
-            } else {
-                let config = AppNimbus.shared.features.onboardingVariables.value()
-                return config.showNewOnboarding
-            }
+            !UserDefaults.standard.bool(forKey: OnboardingConstants.showOldOnboarding)
         }
         guard !AppInfo.isTesting() else { return TestOnboarding() }
         return OnboardingFactory.makeOnboardingEventsHandler(shouldShowNewOnboarding)

--- a/Blockzilla/InternalSettings/InternalOnboardingSettingsView.swift
+++ b/Blockzilla/InternalSettings/InternalOnboardingSettingsView.swift
@@ -11,7 +11,7 @@ struct InternalOnboardingSettingsView {
 extension InternalOnboardingSettingsView: View {
     var body: some View {
         Form {
-            Section{
+            Section {
                 Toggle(isOn: $internalSettings.showOldOnboarding) {
                     Text(verbatim: "Show Old Onboarding")
                 }

--- a/Blockzilla/InternalSettings/InternalOnboardingSettingsView.swift
+++ b/Blockzilla/InternalSettings/InternalOnboardingSettingsView.swift
@@ -11,10 +11,7 @@ struct InternalOnboardingSettingsView {
 extension InternalOnboardingSettingsView: View {
     var body: some View {
         Form {
-            Section(footer: Text(verbatim: "To show the old version of onboarding disable first the Nimbus experiment, then turn on the option.")) {
-                Toggle(isOn: $internalSettings.ignoreOnboardingExperiment) {
-                    Text(verbatim: "Ignore Onboarding Experiment")
-                }
+            Section{
                 Toggle(isOn: $internalSettings.showOldOnboarding) {
                     Text(verbatim: "Show Old Onboarding")
                 }


### PR DESCRIPTION
### Commit message
Fixes #3570 - The old onboarding and tooltips are displayed on latest 9000 (15537) version (main)