### PR TITLE
Fixes #3575 - App crashes on entering misformed URL in the address bar

### DIFF
--- a/Blockzilla/Extensions/URLExtensions.swift
+++ b/Blockzilla/Extensions/URLExtensions.swift
@@ -211,6 +211,7 @@ extension URL {
      :returns: The base domain string for the given host name.
      */
     public var baseDomain: String? {
+        guard host != nil else { return absoluteDisplayString }
         guard !isIPv4 && !isIPv6, let host = host else { return host }
 
         // If this is just a hostname and not a FQDN, use the entire hostname.


### PR DESCRIPTION

### Commit message
Fixes #3575 - App crashes on entering misformed URL in the address bar