### PR TITLE
Fixes #3593 - Firefox Focus – welcome page instructions should be correctly written

### DIFF
--- a/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -33,8 +33,10 @@ struct DefaultBrowserOnboardingView: View {
                     .padding(.bottom, .titleBottomPadding)
                 VStack(alignment: .leading) {
                     Text(viewModel.defaultBrowserConfig.firstSubtitle)
+                        .font(.body16)
                         .padding(.bottom, .firstSubtitleBottomPadding)
                     Text(viewModel.defaultBrowserConfig.secondSubtitle)
+                        .font(.body16)
                 }
             }
             .foregroundColor(.secondOnboardingScreenText)

--- a/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -33,11 +33,10 @@ struct DefaultBrowserOnboardingView: View {
                     .padding(.bottom, .titleBottomPadding)
                 VStack(alignment: .leading) {
                     Text(viewModel.defaultBrowserConfig.firstSubtitle)
-                        .font(.body16)
                         .padding(.bottom, .firstSubtitleBottomPadding)
                     Text(viewModel.defaultBrowserConfig.secondSubtitle)
-                        .font(.body16)
                 }
+                .font(.body16)
             }
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()


### PR DESCRIPTION

![simulator_screenshot_F882D11E-F2B2-40AC-8111-E1393D52CCCE](https://user-images.githubusercontent.com/16647663/204230927-06453a6a-9692-4080-8490-8660fa5d16af.png)

## Commit Message
Fixes #3593 - Firefox Focus – welcome page instructions should be correctly written