### PR TITLE
Fixes #3556 - Implement a permanent link for the "What's new target" 

### DIFF
--- a/Blockzilla/Utilities/SupportUtils.swift
+++ b/Blockzilla/Utilities/SupportUtils.swift
@@ -16,7 +16,7 @@ public enum SupportTopic: CaseIterable {
     public var slug: String {
         switch self {
         case .whatsNew:
-            return "whats-new-\(AppInfo.config.productName.lowercased())-ios-\(AppInfo.majorVersion)"
+            return "whats-new-\(AppInfo.config.productName.lowercased())-ios"
         case .searchSuggestions:
             return "search-suggestions-focus-ios"
         case .usageData:


### PR DESCRIPTION
## Commit Message

Fixes #3556 - Implement a permanent link for the "What's new target" 