### PR TITLE
Migrate iPad Full Functional Test Suite to MacStadium

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -637,53 +637,6 @@ workflows:
       bitrise.io:
         stack: osx-xcode-14.0.x
         machine_type_id: g2.8core
-  runFocus-iPad:
-    steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@6.2: {}
-    - cache-pull@2: {}
-    - certificate-and-profile-installer@1: {}
-    - script@1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            ./checkout.sh
-        title: ContentBlockerGen
-    - script@1:
-        title: Set Default Web Browser Entitlement
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -x
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
-    - xcode-build-for-simulator@0.12:
-        inputs:
-        - configuration: FocusDebug
-        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-        - scheme: Focus
-    - xcode-test@4.5:
-        is_always_run: true
-        inputs:
-        - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan FullFunctionalTests
-        - scheme: Focus
-        - simulator_device: iPad Pro (12.9-inch) (5th generation)
-        - simulator_os_version: '15.4'
-    - xcode-test@4.5:
-        is_always_run: true
-        inputs:
-        - xcodebuild_test_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -maximum-parallel-testing-workers 2 -testPlan SmokeTest
-        - scheme: Focus
-        - simulator_device:  iPad Pro (12.9-inch) (5th generation)
-        - simulator_os_version: '15.4'
-    - deploy-to-bitrise-io@1: {}
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.3.x
-        machine_type_id: g2.8core
   L10nScreenshotsTests:
     steps:
     - activate-ssh-key@4:


### PR DESCRIPTION
Removing Bitrise job and scheduling iPad Full Functional Suites to now run nightly on MacStadium using Jenkins