### PR TITLE
Fixes #3561 - 'Drag URL text' feature interferes with basic text-editing cursor

### DIFF
--- a/Blockzilla/UIComponents/URLBar.swift
+++ b/Blockzilla/UIComponents/URLBar.swift
@@ -944,24 +944,6 @@ extension URLBar: UIDragInteractionDelegate {
         GleanMetrics.UrlInteraction.dragStarted.record()
         return [dragItem]
     }
-
-    func dragInteraction(_ interaction: UIDragInteraction, previewForLifting item: UIDragItem, session: UIDragSession) -> UITargetedDragPreview? {
-        let params = UIDragPreviewParameters()
-        params.backgroundColor = UIColor.clear
-        return UITargetedDragPreview(view: draggableUrlTextView, parameters: params)
-    }
-
-    func dragInteraction(_ interaction: UIDragInteraction, sessionDidMove session: UIDragSession) {
-        for item in session.items {
-            item.previewProvider = {
-                guard let url = self.url else {
-                    return UIDragPreview(view: UIView())
-                }
-                return UIDragPreview(for: url)
-            }
-        }
-    }
-
 }
 
 private class URLTextField: AutocompleteTextField {

--- a/Blockzilla/UIComponents/URLBar.swift
+++ b/Blockzilla/UIComponents/URLBar.swift
@@ -157,7 +157,7 @@ class URLBar: UIView {
         textAndLockContainer.addGestureRecognizer(longPress)
 
         let dragInteraction = UIDragInteraction(delegate: self)
-        textAndLockContainer.addInteraction(dragInteraction)
+        urlBarBackgroundView.addInteraction(dragInteraction)
 
         addSubview(toolset.backButton)
         addSubview(toolset.forwardButton)


### PR DESCRIPTION
## Commit Message

Fixes #3561 - 'Drag URL text' feature interferes with basic text-editing cursor

### Video

https://user-images.githubusercontent.com/51127880/205321739-c69df1e3-36fa-4f68-a111-c321f3178df8.mp4



