### PR TITLE
Fixes #2971 - Hold the back navigation button to see a history of the current tab since opening

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		B3CD41CC1FD1CAF000AEBD58 /* PaddedSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD41CB1FD1CAF000AEBD58 /* PaddedSwitch.swift */; };
 		B3D23BEF1FA3A9E500D9C50F /* postload.js in Resources */ = {isa = PBXBuildFile; fileRef = B3D23BEE1FA3A9E500D9C50F /* postload.js */; };
 		B3F4A3171FA136E70029A6F2 /* preload.js in Resources */ = {isa = PBXBuildFile; fileRef = B3F4A3161FA136E60029A6F2 /* preload.js */; };
+		BD2497B02951099100CE0F1C /* BrowserToolbarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2497AF2951099100CE0F1C /* BrowserToolbarDelegate.swift */; };
 		BD4B1EB629250AA500065AAD /* KeyboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B1EB529250AA500065AAD /* KeyboardType.swift */; };
 		C80F901C26C554B800F5112B /* PhotonActionSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80F901B26C554B800F5112B /* PhotonActionSheetCell.swift */; };
 		C817A35722CE73B4002529FF /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = C817A35322CE73B4002529FF /* Deferred.swift */; };
@@ -730,6 +731,7 @@
 		B3D23BEE1FA3A9E500D9C50F /* postload.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = postload.js; sourceTree = "<group>"; };
 		B3F4A3161FA136E60029A6F2 /* preload.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = preload.js; sourceTree = "<group>"; };
 		BC16C41C8D4A74C79A493D42 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		BD2497AF2951099100CE0F1C /* BrowserToolbarDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolbarDelegate.swift; sourceTree = "<group>"; };
 		BD4B1EB529250AA500065AAD /* KeyboardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardType.swift; sourceTree = "<group>"; };
 		C652A61E213D254A86DF5736 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		C80F901B26C554B800F5112B /* PhotonActionSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetCell.swift; sourceTree = "<group>"; };
@@ -1567,6 +1569,7 @@
 				D30DF93D1DC1634F0064736C /* Toast.swift */,
 				C82F45F428193DA5000D7D84 /* ShortcutView+UIContextMenuInteractionDelegate.swift */,
 				E5CB2ED8288E909800CE6428 /* UIAlertController+Rename.swift */,
+				BD2497AF2951099100CE0F1C /* BrowserToolbarDelegate.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -2604,6 +2607,7 @@
 				C8EADCD22742A00300E76AE6 /* MenuActionable.swift in Sources */,
 				1D3BEDFB20C5E76B0019B722 /* FindInPageBar.swift in Sources */,
 				E5639E5F2940997700E55B9B /* URLBarDelegate.swift in Sources */,
+				BD2497B02951099100CE0F1C /* BrowserToolbarDelegate.swift in Sources */,
 				D30DF93E1DC1634F0064736C /* Toast.swift in Sources */,
 				F861799F27961F4200CFD324 /* InternalSettings.swift in Sources */,
 				D33A1AB11BC48FAC0003D929 /* SettingsViewController.swift in Sources */,

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -204,6 +204,7 @@ class BrowserViewController: UIViewController {
         browserToolbar.isHidden = true
         browserToolbar.alpha = 0
         browserToolbar.translatesAutoresizingMaskIntoConstraints = false
+        browserToolbar.delegate = self
         mainContainerView.addSubview(browserToolbar)
 
         overlayView.isHidden = true
@@ -1428,6 +1429,18 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidLongPress(_ urlBar: URLBar) { }
+}
+
+extension BrowserViewController: BrowserToolbarDelegate {
+    func browserToolbarDidPressBack(_ browserToolbar: BrowserToolbar, button: UIButton) {
+        let actions = webViewController.generateActions(from: webViewController.backList)
+        button.menu = button.menu?.replacingChildren(actions)
+    }
+
+    func browserToolbarDidPressForward(_ browserToolbar: BrowserToolbar, button: UIButton) {
+        let actions = webViewController.generateActions(from: webViewController.forwardList)
+        button.menu = button.menu?.replacingChildren(actions)
+    }
 }
 
 extension BrowserViewController: PhotonActionSheetDelegate {

--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -328,10 +328,10 @@ class WebViewController: UIViewController, WebController {
         let list = backForwardList == backList ? backList : forwardList
         return list.map { backForwardListItem in
             let actionTitle = backForwardListItem.title != nil ?
-            backForwardListItem.title! + "\n" + backForwardListItem.initialURL.description :
-            backForwardListItem.initialURL.description
+            backForwardListItem.title! + "\n" + backForwardListItem.url.description :
+            backForwardListItem.url.description
             if #available(iOS 15.0, *) {
-                return UIAction(title: backForwardListItem.title ?? "", subtitle: backForwardListItem.initialURL.description) { _ in
+                return UIAction(title: backForwardListItem.title ?? "", subtitle: backForwardListItem.url.description) { _ in
                     self.goToBackForwardListItem(backForwardListItem)
                 }
             }

--- a/Blockzilla/UIComponents/BrowserToolbar.swift
+++ b/Blockzilla/UIComponents/BrowserToolbar.swift
@@ -11,6 +11,7 @@ public class BrowserToolbar: UIView {
     private let backgroundDark = UIView()
     private let backgroundBright = UIView()
     private let stackView = UIStackView()
+    weak var delegate: BrowserToolbarDelegate?
 
     private lazy var backButton: UIButton = {
         let backButton = UIButton()
@@ -18,6 +19,8 @@ public class BrowserToolbar: UIView {
         backButton.contentEdgeInsets = UIConstants.layout.toolbarButtonInsets
         backButton.accessibilityLabel = UIConstants.strings.browserBack
         backButton.isEnabled = false
+        backButton.menu = UIMenu(children: [])
+        backButton.addTarget(self, action: #selector(didPressBack), for: .touchDown)
         return backButton
     }()
 
@@ -27,6 +30,8 @@ public class BrowserToolbar: UIView {
         forwardButton.contentEdgeInsets = UIConstants.layout.toolbarButtonInsets
         forwardButton.accessibilityLabel = UIConstants.strings.browserForward
         forwardButton.isEnabled = false
+        forwardButton.menu = UIMenu(children: [])
+        forwardButton.addTarget(self, action: #selector(didPressForward), for: .touchDown)
         return forwardButton
     }()
 
@@ -99,6 +104,14 @@ public class BrowserToolbar: UIView {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func didPressBack(_ sender: UIButton) {
+        delegate?.browserToolbarDidPressBack(self, button: backButton)
+    }
+
+    @objc private func didPressForward(_ sender: UIButton) {
+        delegate?.browserToolbarDidPressForward(self, button: forwardButton)
     }
 
     private func bindButtonActions() {

--- a/Blockzilla/UIComponents/BrowserToolbarDelegate.swift
+++ b/Blockzilla/UIComponents/BrowserToolbarDelegate.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+protocol BrowserToolbarDelegate: AnyObject {
+    func browserToolbarDidPressBack(_ browserToolbar: BrowserToolbar, button: UIButton)
+    func browserToolbarDidPressForward(_ browserToolbar: BrowserToolbar, button: UIButton)
+}


### PR DESCRIPTION
## Commit Message

Fixes #2971 - Hold the back navigation button to see a history of the current tab since opening

### Video

https://user-images.githubusercontent.com/51127880/209118948-b608360f-602b-40c8-96a4-66f44cbf4cf7.mp4


