### PR TITLE
MTE-355: Fix and Refactor Broken Tests

### DIFF
--- a/XCUITest/AsianLocaleTest.swift
+++ b/XCUITest/AsianLocaleTest.swift
@@ -5,35 +5,32 @@
 import XCTest
 
 class AsianLocaleTest: BaseTestCase {
-	func testSearchinLocale() {
-        dismissURLBarFocused()
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
-        // Set search engine to Google
-		app.buttons["HomeView.settingsButton"].tap()
-        let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
-        settingsButton.tap()
-        waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
-		app.tables.cells["SettingsViewController.searchCell"].tap()
-
-		app.tables.staticTexts["Google"].tap()
-        app.buttons["SettingsViewController.doneButton"].tap()
-
-		// Enter 'mozilla' on the search field
-		search(searchWord: "모질라")
-        app.buttons["URLBar.deleteButton"].tap()
+    let locales: [String: String]  = [
+        "Korean": "모질라",
+        "Japanese": "モジラ",
+        "Chinese": "因特網"
+    ]
+    
+    func searchForMozillaInLocale(localeName: String, searchText: String) {
+        let urlBarDeleteButton = app.eraseButton
+        
+        search(searchWord: searchText, waitForLoadToFinish: true)
+        mozTap(urlBarDeleteButton)
         dismissURLBarFocused()
         checkForHomeScreen()
-
-		search(searchWord: "モジラ")
-        app.buttons["URLBar.deleteButton"].tap()
+    }
+    
+	func testSearchInLocale() {
+        // Test Setup
         dismissURLBarFocused()
         checkForHomeScreen()
-
-		search(searchWord: "因特網")
-        app.buttons["URLBar.deleteButton"].tap()
-        dismissURLBarFocused()
-        checkForHomeScreen()
+        navigateToSettingSearchEngine()
+        setDefaultSearchEngine(searchEngine: "Google")
+        
+        // Test Steps
+        for (localeName, searchText) in locales {
+            searchForMozillaInLocale(localeName: localeName, searchText: searchText)
+        }
 	}
 
 }

--- a/XCUITest/BaseTestCase.swift
+++ b/XCUITest/BaseTestCase.swift
@@ -5,7 +5,6 @@
 import XCTest
 
 class BaseTestCase: XCTestCase {
-
     let app = XCUIApplication()
 
     override func setUp() {
@@ -68,7 +67,7 @@ class BaseTestCase: XCTestCase {
 
     func waitForValueContains(_ element: XCUIElement, value: String, file: String = #file, line: UInt = #line) {
             waitFor(element, with: "value CONTAINS '\(value)'", file: file, line: line)
-        }
+    }
 
     private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 5.0, file: String, line: UInt) {
             let predicate = NSPredicate(format: predicateString)
@@ -85,14 +84,11 @@ class BaseTestCase: XCTestCase {
 
     func search(searchWord: String, waitForLoadToFinish: Bool = true) {
         let searchOrEnterAddressTextField = app.textFields["Search or enter address"]
+        let keyboardGoButton = app/*@START_MENU_TOKEN@*/.buttons["Go"]/*[[".keyboards",".buttons[\"go\"]",".buttons[\"Go\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/
 
-        UIPasteboard.general.string = searchWord
-
-        // Must press this way in order to support iPhone 5s
-        searchOrEnterAddressTextField.tap()
-        searchOrEnterAddressTextField.press(forDuration: 1)
-        waitForExistence(app.menuItems["Paste & Go"])
-        app.menuItems["Paste & Go"].tap()
+        mozTap(searchOrEnterAddressTextField)
+        mozTypeText(searchOrEnterAddressTextField, text: searchWord)
+        mozTap(keyboardGoButton)
 
         if waitForLoadToFinish {
             let finishLoadingTimeout: TimeInterval = 30
@@ -141,6 +137,34 @@ class BaseTestCase: XCTestCase {
 
         expectation(for: NSPredicate(format: "exists != true"), evaluatedWith: progressIndicator, handler: nil)
         waitForExpectations(timeout: finishLoadingTimeout, handler: nil)
+    }
+    
+    func mozTap(_ element: XCUIElement, timeout: TimeInterval = 10) {
+        waitForExistence(element, timeout: timeout)
+        element.tap()
+    }
+    
+    func mozTypeText(_ element: XCUIElement, text: String, timeout: TimeInterval = 10) {
+        waitForExistence(element, timeout: timeout)
+        element.typeText(text)
+    }
+    
+    func navigateToSettingSearchEngine() {
+        let homeViewSettingsButton = app.homeViewSettingsButton
+        let settingsButton = app.settingsButton
+        let settingsViewControllerSearchCell = app.tables.cells["SettingsViewController.searchCell"]
+        
+        mozTap(homeViewSettingsButton)
+        mozTap(settingsButton)
+        mozTap(settingsViewControllerSearchCell)
+    }
+    
+    func setDefaultSearchEngine(searchEngine: String) {
+        let searchEngineSelection = app.staticTexts[searchEngine]
+        let settingsViewControllerDoneButton = app.settingsViewControllerDoneButton
+        
+        mozTap(searchEngineSelection)
+        mozTap(settingsViewControllerDoneButton)
     }
 }
                        

--- a/XCUITest/SearchSuggestionsTest.swift
+++ b/XCUITest/SearchSuggestionsTest.swift
@@ -123,9 +123,7 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         waitForExistence(app.tables.switches["BlockerToggle.enableSearchSuggestions"], timeout: 5)
 
         app.tables.cells.switches["BlockerToggle.enableSearchSuggestions"].tap()
-        if iPad() {
-            app.tables.cells.switches["BlockerToggle.enableSearchSuggestions"].tap()
-        }
+        
         // Prompt should not display
         app.buttons["SettingsViewController.doneButton"].tap()
         typeInURLBar(text: "g")
@@ -170,9 +168,6 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         settingsButton.tap()
         waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
         app.tables.switches["BlockerToggle.enableSearchSuggestions"].tap()
-        if iPad() {
-            app.tables.switches["BlockerToggle.enableSearchSuggestions"].tap()
-        }
         checkToggle(isOn: false)
 
         // Ensure only one search cell is shown

--- a/XCUITest/XCUIApplication+Buttons.swift
+++ b/XCUITest/XCUIApplication+Buttons.swift
@@ -26,6 +26,27 @@ extension XCUIApplication {
         return self.buttons["URLBar.deleteButton"]
     }
 
+    var homeViewSettingsButton: XCUIElement {
+        return self.buttons["HomeView.settingsButton"]
+    }
+    
+    var searchSuggestionsOverlay: XCUIElement {
+        return self.buttons["OverlayView.searchButton"]
+    }
+    
+    var settingsViewControllerDoneButton: XCUIElement {
+        return self.buttons["SettingsViewController.doneButton"]
+    }
+    
+    var settingsBackButton: XCUIElement {
+        return self.navigationBars.buttons["Settings"]
+    }
+    
+    var settingsDoneButton: XCUIElement {
+        return self.buttons["SettingsViewController.doneButton"]
+    }
+    
+    
     var urlTextField: XCUIElement {
         return self.textFields["URLBar.urlText"]
     }


### PR DESCRIPTION
Methodology

Added some helper methods and refactored tests to prepare for a dynamic, data-driven strategy that can become self-discoverable, lowering maintenance and allowing for large scale test automation generated via test data instead of ad-hoc custom commands.

Fixed Tests
- AsianLocaleTest: testSearchInLocale
- SearchSuggestionsPromptTest: testEnableThroughToggle
- WebsiteAccessTests: testDisableAutoComplete, testAutocompleteCustomDomain

Created New Test
- WebsiteAccessTests: testReEnableAutoComplete

The old `testDisableAutoComplete` test was nested with two tests; so, I split them out for better testing scope and tracking.

Staged Helper Methods
- AsianLocaleTest: searchForMozillaInLocale()
- BaseTestCase: navigateToSettingSearchEngine()
- BaseTestCase: setDefaultSearchEngine()
- WebsiteAccessTest: setUrlAutoCompleteTo()

I would prefer to organize these by state, component, or page, but left them in their contexts pending a decision to better organize helper methods depending on the design pattern that's chosen (or if no change is decided).

Added Base Helper Methods
- BaseTestCase: mozTap()
- BaseTestCase: mozTypeText()

Added these to remove duplication of `waitForExistence` in all tests and allow for a more standard custom handling of actions during tests, including preparing for custom logging for easier debugging.