### PR TITLE
Update Sentry to 8.1.0

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -6485,7 +6485,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 7.31.3;
+				version = 8.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "c3c19e29f775ee95b77aa3168f3e2fd6c20deba6",
-          "version": "7.31.3"
+          "revision": "24fa90aa4ef8f81c65eb5803e40875f685de0dcd",
+          "version": "8.1.0"
         }
       },
       {


### PR DESCRIPTION
We should probably wait to do anything with this for Focus until after https://github.com/mozilla-mobile/firefox-ios/pull/12961 lands as there's some open questions about some of the changes shipped in the new major release. Mainly getting this submitted for now to at least look for any build bustage.