### PR TITLE
 Fixes #3659 - Links should not open outside of Focus by default 

### DIFF
--- a/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/Blockzilla/Modules/WebView/WebViewController.swift
@@ -422,8 +422,11 @@ extension WebViewController: WKNavigationDelegate {
         }
 
         currentBackForwardItem = webView.backForwardList.currentItem
+        // prevent Focus from opening universal links
+        // https://stackoverflow.com/questions/38450586/prevent-universal-links-from-opening-in-wkwebview-uiwebview
+        let allowDecision = WKNavigationActionPolicy(rawValue: WKNavigationActionPolicy.allow.rawValue + 2) ?? .allow
 
-        let decision: WKNavigationActionPolicy = RequestHandler().handle(request: navigationAction.request, alertCallback: present) ? .allow : .cancel
+        let decision: WKNavigationActionPolicy = RequestHandler().handle(request: navigationAction.request, alertCallback: present) ? allowDecision : .cancel
         if navigationAction.navigationType == .linkActivated && browserView.url != navigationAction.request.url {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.websiteLink)
         }


### PR DESCRIPTION
## Commit Message

 Fixes #3659 - Links should not open outside of Focus by default