### PR TITLE
Bugfix MTE-249 Fix SnapshotTests

### DIFF
--- a/ScreenshotTests/BaseTestCaseL10n.swift
+++ b/ScreenshotTests/BaseTestCaseL10n.swift
@@ -18,7 +18,6 @@ class BaseTestCaseL10n: XCTestCase {
             if testRunningFirstRun.contains(key) {
             // for the current test name, add the db fixture used
             // Do nothing and Run Onboarding
-                app.launchArguments = ["testMode"]
             } else {
                 app.launchArguments = ["testMode", "disableFirstRunUI"]
             }

--- a/ScreenshotTests/BaseTestCaseL10n.swift
+++ b/ScreenshotTests/BaseTestCaseL10n.swift
@@ -18,6 +18,7 @@ class BaseTestCaseL10n: XCTestCase {
             if testRunningFirstRun.contains(key) {
             // for the current test name, add the db fixture used
             // Do nothing and Run Onboarding
+                app.launchArguments = ["testMode"]
             } else {
                 app.launchArguments = ["testMode", "disableFirstRunUI"]
             }

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class SnapshotTests: BaseTestCaseL10n {
 
     func test01FirstRunScreens() {
-        waitForExistence(app.buttons["IntroViewController.startBrowsingButton"], timeout: 10)
+        waitForExistence(app.buttons["Get Started"], timeout: 10)
         snapshot("00FirstRun")
     }
 


### PR DESCRIPTION
Currently, `test01FirstRunScreens()` from `SnapshotTests` is failing. To fix this test, I updated the label on the "Get Started" button.

Note that `test01FirstRunScreens()` can't be run repeatedly because it depends on the fact that Focus is launched for the very first time after installation. The welcome screen is shown only on the first time.

Resolves https://github.com/mozilla-mobile/focus-ios/issues/3555