### PR TITLE
Fixes #3703 Search telemetry should not be counting URLs

### DIFF
--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -913,6 +913,7 @@ class BrowserViewController: UIViewController {
         if url == nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            recordSearchEvent(source)
             url = searchEngineManager.activeEngine.urlForQuery(text)
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)
@@ -932,8 +933,6 @@ class BrowserViewController: UIViewController {
     func submit(url: URL, source: Source) {
         // If this is the first navigation, show the browser and the toolbar.
         guard isViewLoaded else { initialUrl = url; return }
-
-        recordSearchEvent(source)
 
         shortcutsPresenter.shortcutsState = .none
         SearchInContentTelemetry.shouldSetUrlTypeSearch = true
@@ -1351,6 +1350,7 @@ extension BrowserViewController: URLBarDelegate {
         if url == nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            recordSearchEvent(source)
             url = searchEngineManager.activeEngine.urlForQuery(text)
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)
@@ -1568,7 +1568,7 @@ extension BrowserViewController: OverlayViewDelegate {
         if searchEngineManager.activeEngine.urlForQuery(query) != nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.selectQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
-            urlBar(urlBar, didSubmitText: query, source: .topsite)
+            urlBar(urlBar, didSubmitText: query, source: .suggestion)
         }
 
         urlBar.dismiss()
@@ -1610,6 +1610,7 @@ extension BrowserViewController: OverlayViewDelegate {
         if url == nil {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeQuery, object: TelemetryEventObject.searchBar)
             Telemetry.default.recordSearch(location: .actionBar, searchEngine: searchEngineManager.activeEngine.getNameOrCustom())
+            recordSearchEvent(.suggestion)
             url = searchEngineManager.activeEngine.urlForQuery(text)
         } else {
             Telemetry.default.recordEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.typeURL, object: TelemetryEventObject.searchBar)

--- a/Blockzilla/UIComponents/URLBar/URLBar.swift
+++ b/Blockzilla/UIComponents/URLBar/URLBar.swift
@@ -1101,12 +1101,14 @@ extension URLBar: AutocompleteTextFieldDelegate {
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool {
         // If the new search string is not longer than the previous
         // we don't need to find an autocomplete suggestion.
+        var source = Source.action
         if let autocompleteText = autocompleteTextField.text, autocompleteText != userInputText {
+            source = .topsite
             Telemetry.default.recordEvent(TelemetryEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.autofill))
         }
         userInputText = nil
 
-        delegate?.urlBar(self, didSubmitText: autocompleteTextField.text ?? "", source: .action)
+        delegate?.urlBar(self, didSubmitText: autocompleteTextField.text ?? "", source: source)
 
         if Settings.getToggle(.enableSearchSuggestions) {
             Telemetry.default.recordEvent(TelemetryEvent(category: TelemetryEventCategory.action, method: TelemetryEventMethod.click, object: TelemetryEventObject.searchSuggestionNotSelected))


### PR DESCRIPTION
Change to record Glean event only on query search. Also fixed search source to be `.topSites` for autocomplete and `.suggestion` for overlay suggestions.