### PR TITLE
Bugfix FXIOS-2244 too eager text replace

### DIFF
--- a/Blockzilla/UIComponents/AutocompleteTextField.swift
+++ b/Blockzilla/UIComponents/AutocompleteTextField.swift
@@ -224,8 +224,13 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
         autocompleteTextLabel = createAutocompleteLabelWith(autocompleteText)
         if let l = autocompleteTextLabel {
             addSubview(l)
-            hideCursor = true
-            forceResetCursor()
+            // Only call forceResetCursor() if `hideCursor` changes.
+            // Because forceResetCursor() auto accept iOS user's text replacement
+            // (e.g. mu->μ) which makes user unable to type "mu".
+            if !hideCursor {
+                hideCursor = true
+                forceResetCursor()
+            }
         }
     }
 


### PR DESCRIPTION
Manually cherry-picked from
https://github.com/mozilla-mobile/firefox-ios/pull/10575

Reproduce by typing 'omw' in the search bar, it will immediately be replaced by "On my way!" as that's a default iOS replacement. See Settings > General > Keyboards > Text Replacement.