### PR TITLE
Build MTE-267 Upgrade GitHub Action XCode and MacOS Version

### DIFF
--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-13
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.9]
-        xcode: ["13.0"]
+        xcode: ["14.3.0"]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Need to update the GitHub Action for `import-strings` to upgrade xcode from `13.4.1` to `14.3.0` and macos from `11` to `13`