### PR TITLE
Call out that the `main` branch is tested on Xcode 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ We also tag recommended bugs for contributions with [help wanted](https://github
 Main Branch
 ----------------
 
-This branch works with Xcode 13 and supports iOS 13.0 and newer.
+This branch works with Xcode 14.3 and supports iOS 13.0 and newer.
 
 Pull requests should be submitted with `main` as the base branch.
 
 Build Instructions
 ------------------
 
-1. Install Xcode 13 [Xcode developer tools](https://developer.apple.com/xcode/downloads/) from Apple.
+1. Install Xcode 14.3 [Xcode developer tools](https://developer.apple.com/xcode/downloads/) from Apple.
 2. Clone the repository:
 
   ```shell


### PR DESCRIPTION
From https://github.com/mozilla-mobile/focus-ios/pull/3756 I get that everything is now on Xcode 14.
Is that correct?

cc @clarmso 

---

I'm asking because we plan to upgrade the Glean SDK to build on Xcode 14 and thus consumers need to be on 14 as well when they upgrade to the next version.