### PR TITLE
Update base image of screenshots Dockerfile

### DIFF
--- a/taskcluster/docker/screenshots/Dockerfile
+++ b/taskcluster/docker/screenshots/Dockerfile
@@ -2,9 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM ubuntu:18.04
-
-MAINTAINER Johan Lorenzo "jlorenzo+docker@mozilla.com"
+FROM ubuntu:22.04
 
 # Add worker user
 RUN mkdir /builds && \


### PR DESCRIPTION
We're currently using Ubuntu 18.04 as the base image, which is out of support. Let's bump to 22.04 which should be safe per @JohanLorenzo.