### PR TITLE
Add newer style parameters for NimbusBuilder

### DIFF
--- a/Blockzilla/Nimbus/NimbusWrapper.swift
+++ b/Blockzilla/Nimbus/NimbusWrapper.swift
@@ -34,28 +34,22 @@ class NimbusWrapper {
             fatalError("Failed to determine Nimbus database path")
         }
 
-        let builder = NimbusBuilder(dbPath: databasePath)
-
         let urlString = NimbusServerSettings.getNimbusEndpoint(useStagingServer: useStagingServer)?.absoluteString
-        builder.with(url: urlString)
 
         let bundles = [
             Bundle.main,
-            Bundle.main.fallbackTranslationBundle()
+            Bundle.main.fallbackTranslationBundle(language: "en-US")
         ].compactMap { $0 }
 
-        builder.with(bundles: bundles)
+        return NimbusBuilder(dbPath: databasePath)
+            .with(url: urlString)
+            .with(bundles: bundles)
+            .with(featureManifest: AppNimbus.shared)
+            .with(commandLineArgs: CommandLine.arguments)
             .using(previewCollection: usePreviewCollection)
             .with(initialExperiments: Bundle.main.url(forResource: "initial_experiments", withExtension: "json"))
             .isFirstRun(isFirstRun)
-            .onCreate { nimbus in
-                AppNimbus.shared.initialize { nimbus }
-            }
-            .onApply { _ in
-                AppNimbus.shared.invalidateCachedValues()
-            }
-
-        return builder.build(appInfo: nimbusAppSettings)
+            .build(appInfo: nimbusAppSettings)
     }()
 
     func initializeRustComponents() throws {


### PR DESCRIPTION
Fixes [EXP-3623](https://mozilla-hub.atlassian.net/browse/EXP-3623).

This PR adds some newer parameters to the call to the `NimbusBuilder`.

These are:
- removing explicit callbacks to initalize the Feature Manifest, and instead passes the Feature Manifest. This is to allow for more initialization to be done within the builder implementation (e.g. to support coenrolling feature ids).
- adding command line args, to make it compatible with the nimbus-cli
- fixing up a fallback translations bug