### PR TITLE
Bugfix FXIOS-6872 [v116] Download nimbus-fml binary from archive.mozilla.org

### DIFF
--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -165,7 +165,7 @@ if [ -n "$MOZ_APPSERVICES_LOCAL" ] ; then
     export BINARY_PATH="$HOME/.cargo/bin/cargo run --manifest-path $LOCAL_FML_DIR/Cargo.toml --"
 else
     # Otherwise, we should download a pre-built copy
-    AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/v$AS_VERSION"
+    AS_DOWNLOAD_URL="https://archive.mozilla.org/pub/app-services/releases/$AS_VERSION"
     CHECKSUM_URL="$AS_DOWNLOAD_URL/nimbus-fml.sha256"
     FML_URL="$AS_DOWNLOAD_URL/nimbus-fml.zip"
     RELEASE_STATUS_CODE=$(curl -L --write-out '%{http_code}' --silent --output /dev/null "$CHECKSUM_URL")


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15306)
[JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6872)

## :bulb: Description
Updates the `nimbus-fml` binary URL for releases to use archive.mozilla.org.  This one requires the app-services version to be 116.0 before it's testable (which I think means taking the rust-componest-swift for that release).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [x] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [x] Updated documentation / comments for complex code and public methods if needed

