### PR TITLE
Refactor FOCUSIOS-273 [v119] Renew expired telemetry probes

### DIFF
--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -34,7 +34,7 @@ app:
       - https://github.com/mozilla-mobile/focus-ios/pull/3465
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-03-14"
+    expires: never
 
   keyboard_type:
     type: string
@@ -103,7 +103,7 @@ mozilla_products:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2022-09-01"
+    expires: never
 
 settings_screen:
   set_as_default_browser_pressed:
@@ -119,7 +119,7 @@ settings_screen:
       - focus-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2023-07-20"
+    expires: never
 
   autocomplete_domain_added:
     type: counter
@@ -364,7 +364,7 @@ browser_menu:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-02-02"
+    expires: never
     extra_keys:
       item:
         description: |
@@ -386,7 +386,7 @@ show_search_suggestions:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-02-14"
+    expires: never
   disabled_from_panel:
     type: event
     description: The "no"" option from the suggestion panel has been tapped.
@@ -398,7 +398,7 @@ show_search_suggestions:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-02-14"
+    expires: never
   changed_from_settings:
     type: event
     description: The enabled state has been changed from the settings screen.
@@ -410,7 +410,7 @@ show_search_suggestions:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-02-14"
+    expires: never
     extra_keys:
       is_enabled:
         description: The new setting value, true for ON, false for OFF
@@ -428,7 +428,7 @@ search_suggestions:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-02-14"
+    expires: never
     extra_keys:
       engine_name:
         description: The name of the engine used to perform the search.
@@ -444,7 +444,7 @@ search_suggestions:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-02-14"
+    expires: never
     extra_keys:
       engine_name:
         description: The name of the engine used to perform the search.
@@ -460,7 +460,7 @@ search_suggestions:
       - interaction
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
-    expires: "2023-02-14"
+    expires: never
 
 url_interaction:
   drag_started:

--- a/Blockzilla/metrics.yaml
+++ b/Blockzilla/metrics.yaml
@@ -32,6 +32,7 @@ app:
       - https://github.com/mozilla-mobile/focus-ios/issues/3425
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3465
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     expires: never
@@ -98,6 +99,7 @@ mozilla_products:
       - https://github.com/mozilla-mobile/focus-ios/issues/2227
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/2284
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - technical
       - interaction
@@ -115,6 +117,7 @@ settings_screen:
       - https://github.com/mozilla-mobile/focus-ios/issues/3328
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3344
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     notification_emails:
       - focus-ios-data-stewards@mozilla.com
     data_sensitivity:
@@ -360,6 +363,7 @@ browser_menu:
       - https://github.com/mozilla-mobile/focus-ios/issues/3004
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3015
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - interaction
     notification_emails:
@@ -382,6 +386,7 @@ show_search_suggestions:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3031
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - interaction
     notification_emails:
@@ -394,6 +399,7 @@ show_search_suggestions:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3031
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - interaction
     notification_emails:
@@ -406,6 +412,7 @@ show_search_suggestions:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3031
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - interaction
     notification_emails:
@@ -424,6 +431,7 @@ search_suggestions:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3031
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - interaction
     notification_emails:
@@ -440,6 +448,7 @@ search_suggestions:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3031
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - interaction
     notification_emails:
@@ -456,6 +465,7 @@ search_suggestions:
       - https://github.com/mozilla-mobile/focus-ios/issues/3003
     data_reviews:
       - https://github.com/mozilla-mobile/focus-ios/pull/3031
+      - https://github.com/mozilla-mobile/focus-ios/pull/3855
     data_sensitivity:
       - interaction
     notification_emails:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - main](https://mozilla-hub.atlassian.net/browse/FXIOS-7380)
[Jira ticket - focus](https://mozilla-hub.atlassian.net/browse/FOCUSIOS-273)
[Github issue ref1](https://github.com/mozilla-mobile/firefox-ios/issues/16358)
[Github issue ref2](https://github.com/mozilla-mobile/focus-ios/issues/3854)

# Request for Data Collection Renewal

1) Provide a link to the initial Data Collection Review Request for this collection.
app.opened_as_default_browser(expired on 2023-03-14) [Focus] [Firefox]
- https://github.com/mozilla-mobile/focus-ios/pull/3465
browser_menu.browser_menu_action(expired on 2023-02-02) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/3015
mozilla_products.has_firefox_installed(expired on 2022-09-01) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/2284
search_suggestions.autocomplete_arrow_tapped(expired on 2023-02-14) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/3031
search_suggestions.search_tapped(expired on 2023-02-14) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/3031
search_suggestions.suggestion_tapped(expired on 2023-02-14) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/3031
settings_screen.set_as_default_browser_pressed(expired on 2023-07-20) [Focus] [Firefox]
- https://github.com/mozilla-mobile/focus-ios/pull/3344
show_search_suggestions.changed_from_settings(expired on 2023-02-14) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/3031
show_search_suggestions.disabled_from_panel(expired on 2023-02-14) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/3031
show_search_suggestions.enabled_from_panel(expired on 2023-02-14) [Focus]
- https://github.com/mozilla-mobile/focus-ios/pull/3031

2) When will this collection now expire?
Never
3) Why was the initial period of collection insufficient?
We still want to monitor this data.