### PR TITLE
Improve IPv4/IPv6 check and add tests

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		1DE903CE20C751D7002E53ED /* FindInPageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE903CD20C751D7002E53ED /* FindInPageTest.swift */; };
 		24433101219DA46F00778D02 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24433100219DA46F00778D02 /* Debouncer.swift */; };
 		2696EB04211F540600F0C73F /* SearchHistoryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */; };
+		2981645327FBD7CA0033FA0A /* URLExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2981645227FBD7CA0033FA0A /* URLExtensionsTests.swift */; };
 		30DFF98021810BF20055707C /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30DFF97F21810BF20055707C /* SearchSuggestClient.swift */; };
 		31421EB12176492A0015F48B /* TitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */; };
 		394C36CD2906DE1500B9845E /* AppNimbus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394C36CC2906DE1500B9845E /* AppNimbus.swift */; };
@@ -372,6 +373,7 @@
 		1DE903CD20C751D7002E53ED /* FindInPageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindInPageTest.swift; sourceTree = "<group>"; };
 		24433100219DA46F00778D02 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		2696EB03211F540600F0C73F /* SearchHistoryUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryUtils.swift; sourceTree = "<group>"; };
+		2981645227FBD7CA0033FA0A /* URLExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtensionsTests.swift; sourceTree = "<group>"; };
 		29B90C056305836CB297FF79 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		30DFF97F21810BF20055707C /* SearchSuggestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		31421EB02176492A0015F48B /* TitleActivityItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProvider.swift; sourceTree = "<group>"; };
@@ -1803,6 +1805,7 @@
 				3AEC0B3D267DE30A007B7850 /* URIFixupTests.swift */,
 				F8DE0EC726CC887800A31419 /* SupportUtilsTest.swift */,
 				BDEEF248297AC0D500D43345 /* RequestHandlerTests.swift */,
+				2981645227FBD7CA0033FA0A /* URLExtensionsTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -2538,6 +2541,7 @@
 				D831FEE2205247A400EAE19A /* BrowserViewControllerTests.swift in Sources */,
 				D8E0155F1FCF409F00CA3B9F /* SearchEngineManagerTests.swift in Sources */,
 				F8DE0EC926CC88B200A31419 /* SupportUtils.swift in Sources */,
+				2981645327FBD7CA0033FA0A /* URLExtensionsTests.swift in Sources */,
 				D8E0156E1FD9E40F00CA3B9F /* DomainCompletionTests.swift in Sources */,
 				D025F225218B64D600B262D8 /* SearchEngineTests.swift in Sources */,
 				748BCE7728ACC981005BC0CF /* TrackingAdsTests.swift in Sources */,

--- a/focus-ios/Blockzilla/Extensions/URLExtensions.swift
+++ b/focus-ios/Blockzilla/Extensions/URLExtensions.swift
@@ -311,7 +311,6 @@ extension URL {
     }
 
     public var isIPv4: Bool {
-        print("checking \(String(describing: host))")
         guard let host else {
             return false
         }

--- a/focus-ios/Blockzilla/Extensions/URLExtensions.swift
+++ b/focus-ios/Blockzilla/Extensions/URLExtensions.swift
@@ -311,11 +311,18 @@ extension URL {
     }
 
     public var isIPv4: Bool {
-        return IPv4Address(host) != nil;
+        print("checking \(String(describing: host))")
+        guard let host else {
+            return false
+        }
+        return IPv4Address(host) != nil
     }
 
     public var isIPv6: Bool {
-        return IPv6Address(host) != nil;
+        guard let host else {
+            return false
+        }
+        return IPv6Address(host) != nil
     }
 
     /**

--- a/focus-ios/Blockzilla/Extensions/URLExtensions.swift
+++ b/focus-ios/Blockzilla/Extensions/URLExtensions.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Network
 
 private struct ETLDEntry: CustomStringConvertible {
     let entry: String
@@ -310,13 +311,11 @@ extension URL {
     }
 
     public var isIPv4: Bool {
-        let ipv4Pattern = #"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"#
-
-        return host?.range(of: ipv4Pattern, options: .regularExpression) != nil
+        return IPv4Address(host) != nil;
     }
 
     public var isIPv6: Bool {
-        return host?.contains(":") ?? false
+        return IPv6Address(host) != nil;
     }
 
     /**

--- a/focus-ios/focus-ios-tests/ClientTests/URLExtensionsTests.swift
+++ b/focus-ios/focus-ios-tests/ClientTests/URLExtensionsTests.swift
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+import Foundation
+
+class URLExtensionsTests: XCTestCase {
+    
+    // MARK: -- IPV4 Tests
+    func testIPV4_Valid_Input_ShouldReturnTrue() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertTrue(url.isIPv4(host: "64.233.177.105"), "Test should not fail here for valid ipv4 hosts")
+    }
+    
+    func testIPV4_Invalid_IP6Input_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv4(host: "2607:f8b0:4002:c02::67"), "isIPv4 should always return false for IPV6 addresses")
+    }
+    
+    func testIPV4_Invalid_EmptyInput_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv4(host: ""), "isIPv4 should always return false for empty hosts.")
+    }
+    
+    // MARK: -- IPV6 Tests
+    func testIPV6_Valid_Input_ShouldReturnTrue() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertTrue(url.isIPv6(host: "2607:f8b0:4002:c02::67"), "Test should not fail here for valid ipv6 hosts")
+    }
+    
+    func testIPV4_Invalid_IP4Input_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv6(host: "64.233.177.105"), "isIPv6 should always return false for IPV4 addresses")
+    }
+    
+    func testIPV6_Invalid_EmptyInput_ShouldReturnFalse() {
+        guard let url = URL.init(string: "www.google.com") else {
+            XCTAssert(false);
+            return;
+        }
+        XCTAssertFalse(url.isIPv6(host: ""), "isIPv6 should always return false for empty hosts.")
+    }
+    
+    
+}

--- a/focus-ios/focus-ios-tests/ClientTests/URLExtensionsTests.swift
+++ b/focus-ios/focus-ios-tests/ClientTests/URLExtensionsTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import Foundation
 
 class URLExtensionsTests: XCTestCase {
-    
+
     private let validURLwithIPv4Address = [
         "http://0.0.0.0",
         "http://255.255.255.255",
@@ -15,7 +15,7 @@ class URLExtensionsTests: XCTestCase {
         "http://user:password@127.0.0.1:80",
         "http://127.0.0.1:80/a/path",
         "http://127.0.0.1:80/a/path?q=aquery",
-        "telnet://192.0.2.16:80/",
+        "telnet://192.0.2.16:80/"
     ]
 
     private let invalidURLwithIPv4Address = [
@@ -25,7 +25,7 @@ class URLExtensionsTests: XCTestCase {
         "http://256.256.256.256", // Number too big
         "http://256.0.0.1:80", // Number too big
         "http://256.0.0.1:80/a/path", // Number too big
-        "http://256.0.0.1:80/a/path?q=aquery", // Number too big
+        "http://256.0.0.1:80/a/path?q=aquery" // Number too big
     ]
 
     private let validURLwithIPv6Address = [
@@ -47,7 +47,7 @@ class URLExtensionsTests: XCTestCase {
         "http://[64:ff9b::192.0.2.128]",
         "http://[::1]:80",
         "http://[::1]:80/a/path",
-        "ldap://[2001:db8::7]/c=GB?objectClass?one",
+        "ldap://[2001:db8::7]/c=GB?objectClass?one"
     ]
 
     private let invalidURLwithIPv6Address = [
@@ -58,7 +58,7 @@ class URLExtensionsTests: XCTestCase {
         "http://[1::3::8]", // Two '0' blocks
         "http://[1:2:3:4:5:6:7:8:9]", // Too many segments
         "http://[fe80::7:8en0]", // % missing before interface
-        "http://[2001:0db8:0000:0000::0000:ff00:0042:8329]", // :: even though all 0 written
+        "http://[2001:0db8:0000:0000::0000:ff00:0042:8329]" // :: even though all 0 written
     ]
 
     func testValidIPv4Addresses() throws {

--- a/focus-ios/focus-ios-tests/ClientTests/URLExtensionsTests.swift
+++ b/focus-ios/focus-ios-tests/ClientTests/URLExtensionsTests.swift
@@ -7,55 +7,85 @@ import Foundation
 
 class URLExtensionsTests: XCTestCase {
     
-    // MARK: -- IPV4 Tests
-    func testIPV4_Valid_Input_ShouldReturnTrue() {
-        guard let url = URL.init(string: "www.google.com") else {
-            XCTAssert(false);
-            return;
+    private let validURLwithIPv4Address = [
+        "http://0.0.0.0",
+        "http://255.255.255.255",
+        "http://127.0.0.1",
+        "http://127.0.0.1:80",
+        "http://user:password@127.0.0.1:80",
+        "http://127.0.0.1:80/a/path",
+        "http://127.0.0.1:80/a/path?q=aquery",
+        "telnet://192.0.2.16:80/",
+    ]
+
+    private let invalidURLwithIPv4Address = [
+        "127.0.0.1", // No scheme -> cannot extract host
+        "http://127.0.0.0.1", // Too many segments
+        "https://www.mozilla.com", // Does not include an address
+        "http://256.256.256.256", // Number too big
+        "http://256.0.0.1:80", // Number too big
+        "http://256.0.0.1:80/a/path", // Number too big
+        "http://256.0.0.1:80/a/path?q=aquery", // Number too big
+    ]
+
+    private let validURLwithIPv6Address = [
+        "http://[::1]",
+        "http://[1:2:3:4:5:6:7:8]",
+        "http://[1:2:3:4:5:6::8]",
+        "http://[1:2:3:4:5::8]",
+        "http://[1:2:3:4::8]",
+        "http://[1:2:3::8]",
+        "http://[1:2::8]",
+        "http://[1::8]",
+        "http://[1::]",
+        "http://[1:2:3:4:5:6:7:8%en0]",
+        "http://[fe80::7:8%1]",
+        "http://[2001:0db8:0000:0000:0000:ff00:0042:8329]",
+        "http://[2001:db8:0:0:0:ff00:42:8329]",
+        "http://[2001:db8::ff00:42:8329]",
+        "http://[fe80::1]",
+        "http://[64:ff9b::192.0.2.128]",
+        "http://[::1]:80",
+        "http://[::1]:80/a/path",
+        "ldap://[2001:db8::7]/c=GB?objectClass?one",
+    ]
+
+    private let invalidURLwithIPv6Address = [
+        "https://www.mozilla.com", // Does not include an address
+        "::1", // No scheme -> cannot extract host
+        "http://[1:]", // Too little ':'
+        "http://[1:::]", // Too many ':'
+        "http://[1::3::8]", // Two '0' blocks
+        "http://[1:2:3:4:5:6:7:8:9]", // Too many segments
+        "http://[fe80::7:8en0]", // % missing before interface
+        "http://[2001:0db8:0000:0000::0000:ff00:0042:8329]", // :: even though all 0 written
+    ]
+
+    func testValidIPv4Addresses() throws {
+        try validURLwithIPv4Address.forEach {
+            let url = try XCTUnwrap(URL(string: $0))
+            XCTAssertTrue(url.isIPv4, "No IPv4 address in URL: '\(url)'")
         }
-        XCTAssertTrue(url.isIPv4(host: "64.233.177.105"), "Test should not fail here for valid ipv4 hosts")
     }
-    
-    func testIPV4_Invalid_IP6Input_ShouldReturnFalse() {
-        guard let url = URL.init(string: "www.google.com") else {
-            XCTAssert(false);
-            return;
+
+    func testInvalidIPv4Addresses() throws {
+        try invalidURLwithIPv4Address.forEach {
+            let url = try XCTUnwrap(URL(string: $0))
+            XCTAssertFalse(url.isIPv4, "Unexpected IPv4 address in URL: '\(url)'")
         }
-        XCTAssertFalse(url.isIPv4(host: "2607:f8b0:4002:c02::67"), "isIPv4 should always return false for IPV6 addresses")
     }
-    
-    func testIPV4_Invalid_EmptyInput_ShouldReturnFalse() {
-        guard let url = URL.init(string: "www.google.com") else {
-            XCTAssert(false);
-            return;
+
+    func testValidIPv6Addresses() throws {
+        try validURLwithIPv6Address.forEach {
+            let url = try XCTUnwrap(URL(string: $0))
+            XCTAssertTrue(url.isIPv6, "No IPv& address in URL: '\(url)'")
         }
-        XCTAssertFalse(url.isIPv4(host: ""), "isIPv4 should always return false for empty hosts.")
     }
-    
-    // MARK: -- IPV6 Tests
-    func testIPV6_Valid_Input_ShouldReturnTrue() {
-        guard let url = URL.init(string: "www.google.com") else {
-            XCTAssert(false);
-            return;
+
+    func testInvalidIPv6Addresses() throws {
+        try invalidURLwithIPv6Address.forEach {
+            let url = try XCTUnwrap(URL(string: $0))
+            XCTAssertFalse(url.isIPv6, "Unexpected IPv6 address in URL: '\(url)'")
         }
-        XCTAssertTrue(url.isIPv6(host: "2607:f8b0:4002:c02::67"), "Test should not fail here for valid ipv6 hosts")
     }
-    
-    func testIPV4_Invalid_IP4Input_ShouldReturnFalse() {
-        guard let url = URL.init(string: "www.google.com") else {
-            XCTAssert(false);
-            return;
-        }
-        XCTAssertFalse(url.isIPv6(host: "64.233.177.105"), "isIPv6 should always return false for IPV4 addresses")
-    }
-    
-    func testIPV6_Invalid_EmptyInput_ShouldReturnFalse() {
-        guard let url = URL.init(string: "www.google.com") else {
-            XCTAssert(false);
-            return;
-        }
-        XCTAssertFalse(url.isIPv6(host: ""), "isIPv6 should always return false for empty hosts.")
-    }
-    
-    
 }


### PR DESCRIPTION
Fix #2949

### History
- #3503 was closed due to a missing rebase
- #3180 has been open over a year and is missing a rebase

I based my PR on #3180 because the branch was still available.


### Improvements

- Improve IPv4/IPv6 checks in the URL extension, keeping the original computed variable implementation.
- Extend and organize test cases.