### PR TITLE
Follow up PR to fix release workflow for Klar

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -415,7 +415,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            focus-ios/tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
+            focus-ios/focus-ios-tests/tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org mozilla --project klar-ios "$BITRISE_DSYM_DIR_PATH"
     meta:
       bitrise.io:


### PR DESCRIPTION
My bad, forgot to also updat the path for Klar.

The steps in the Release workflow are all passing for Focus, see buid:
https://app.bitrise.io/build/bb0c2553-4eda-4f49-989e-e66c7e41a318?tab=log

Hopefully with this change, the release workflow will be fixed