### PR TITLE
Refactor follow up on focus-ios changes and fix github action

### DIFF
--- a/.github/workflows/focus-ios-check-rust-component-dependency.yml
+++ b/.github/workflows/focus-ios-check-rust-component-dependency.yml
@@ -49,7 +49,7 @@ jobs:
       if: env.BRANCH_CREATED == 'false'
       run: |-
         git diff
-        git diff --quiet || (git add Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved Blockzilla.xcodeproj/project.pbxproj)
+        git diff --quiet || (git add focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved focus-ios/Blockzilla.xcodeproj/project.pbxproj)
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       if: env.BRANCH_CREATED == 'false'

--- a/focus-ios/focus-ios-tests/github-actions-scripts/update-rust-component-version.py
+++ b/focus-ios/focus-ios-tests/github-actions-scripts/update-rust-component-version.py
@@ -33,8 +33,6 @@ def read_rust_components_tag_version():
     f.close()
 
     # Return the current version and commit
-    print(json_new_version["version"])
-    print(json_new_version["revision"])
     return json_new_version["version"], json_new_version["revision"]
 
 def read_project_min_version():

--- a/focus-ios/focus-ios-tests/github-actions-scripts/update-rust-component-version.py
+++ b/focus-ios/focus-ios-tests/github-actions-scripts/update-rust-component-version.py
@@ -6,8 +6,8 @@ from github import Github
 
 
 GITHUB_REPO = "mozilla/rust-components-swift"
-SPM_PACKAGE = "Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
-BLOCKZILLA_PROJECT = "Blockzilla.xcodeproj/project.pbxproj"
+SPM_PACKAGE = "focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+BLOCKZILLA_PROJECT = "focus-ios/Blockzilla.xcodeproj/project.pbxproj"
 github_access_token = os.getenv("GITHUB_TOKEN")
 
 def get_latest_rust_components_version():
@@ -33,6 +33,8 @@ def read_rust_components_tag_version():
     f.close()
 
     # Return the current version and commit
+    print(json_new_version["version"])
+    print(json_new_version["revision"])
     return json_new_version["version"], json_new_version["revision"]
 
 def read_project_min_version():
@@ -113,7 +115,7 @@ def main():
         update_proj_file(current_min_version, rust_component_repo_tag, BLOCKZILLA_PROJECT)
 
         # Save the newer version to be used in the PR info
-        f= open("focus-ios/github-actions-scripts/newest_tag.txt","w+")
+        f= open("focus-ios/focus-ios-tests/github-actions-scripts/newest_tag.txt","w+")
         f.write(rust_component_repo_tag+"\n")
 
 if __name__ == '__main__':


### PR DESCRIPTION
The  Create a PR to build the app using newest rust-component version available github action is failing because the path was not modified with the very latest changes. 
This PR will fix that