### PR TITLE
Bugfix 1865788 - use taskgraph's "decision" docker image instead of "…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -225,7 +225,7 @@ tasks:
                           # Note: This task is built server side without the context or tooling that
                           # exist in tree so we must hard code the hash
                           image:
-                              mozillareleases/taskgraph:decision-mobile-7e11b0cc3966ad9729e08b19551399b3343d3b385eac067b6335d4c34431a899@sha256:b309fa59efd59991ba286a326cb43b724c38e6f3872c52d0f85e96428899c2fc
+                              mozillareleases/taskgraph:decision-10068f116a3800a829ddba367136a95bef5634e06f77e051859586202c93b18a@sha256:a74ed430fd80ebb647bb4a5b019523cf5f69246ed2c2603386dbc8f7200c8140
 
                           maxRunTime: 1800
 


### PR DESCRIPTION
…decision-mobile"

The latter adds a JDK, which is not necessary here.