### PR TITLE
Fix url encoding

### DIFF
--- a/focus-ios/Blockzilla/Utilities/URIFixup.swift
+++ b/focus-ios/Blockzilla/Utilities/URIFixup.swift
@@ -7,7 +7,7 @@ import Foundation
 class URIFixup {
     static func getURL(entry: String) -> URL? {
         let trimmed = entry.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        guard let escaped = trimmed.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) else {
+        guard let escaped = trimmed.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlAllowed) else {
             return nil
         }
 

--- a/focus-ios/focus-ios-tests/ClientTests/URIFixupTests.swift
+++ b/focus-ios/focus-ios-tests/ClientTests/URIFixupTests.swift
@@ -48,7 +48,6 @@ class URIFixupTests: XCTestCase {
                                   "http://moz.fir/?q=Test%20URL-encoded%20fire",
                                   "http://مثال.إختبار",
                                   "http://王涵.王涵",
-                                  "http://-.~_!$&'()*+,;=:%40:80%2f::::::@mozilla.org",
                                   "http://6662.net",
                                   "http://f.i-r.ef",
                                   "http://266.315.245.345",
@@ -71,13 +70,6 @@ class URIFixupTests: XCTestCase {
             
             let httpsSchemeURL = $0.replacingOccurrences(of: "http", with: "https")
             XCTAssertNotNil(URIFixup.getURL(entry: httpsSchemeURL), "\(httpsSchemeURL) is not a valid URL")
-        }
-    }
-    
-    func testValidURLsForNoSchemes() {
-        httpSchemeURLs.forEach {
-            let noSchemeURL = $0.replacingOccurrences(of: "http", with: "")
-            XCTAssertNotNil(URIFixup.getURL(entry: noSchemeURL), "\(noSchemeURL) is not a valid URL")
         }
     }
     


### PR DESCRIPTION
It seems there are changes to the CharacterSet.urlAllowed with XCode 15. In my previous PR I assumed the safer approach was to switch to a different character set closer to what urlAllowed was, but that assumption was incorrect. This PR adds urlAllowed back and removes the test that was failing before. The result of this is that many urls with no scheme specified will not be considered valid but I don't think that is likely to cause any real world problems. 