### PR TITLE
Update Glean to v56.0.0

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -6513,7 +6513,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 55.0.0;
+				minimumVersion = 56.0.0;
 			};
 		};
 		F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mozilla/glean-swift",
         "state": {
           "branch": null,
-          "revision": "24ed58dcc11c35460edf98975b19cce55e39790a",
-          "version": "55.0.0"
+          "revision": "aa9172bfe715a9f918dd95bf49d8f1b2363500a0",
+          "version": "56.0.0"
         }
       },
       {


### PR DESCRIPTION
This is needed for yesterday's SPM bump. Changelog: https://github.com/mozilla/glean/releases/tag/v56.0.0