### PR TITLE
Fix MTE-2022 testSearchQuery test

### DIFF
--- a/focus-ios/focus-ios-tests/XCUITest/SearchProviderTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/SearchProviderTest.swift
@@ -23,8 +23,17 @@ class SearchProviderTest: BaseTestCase {
 
     func testSearchQuery() {
         searchQuery("test", provider: "Google")
+        dismissKeyboardFocusMenuSettings()
         searchQuery("test", provider: "Amazon.com")
+        dismissKeyboardFocusMenuSettings()
         searchQuery("test", provider: "DuckDuckGo")
+    }
+
+    private func dismissKeyboardFocusMenuSettings() {
+        if !app.buttons["HomeView.settingsButton"].isHittable
+        {
+            dismissURLBarFocused()
+        }
     }
 
     func searchProviderTestHelper(provider:String) {


### PR DESCRIPTION
Fix for testSearchQuery test. A dismiss keyboard was required in order to have visibility over the settings menu button.