### PR TITLE
Add webview fail telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ focus-ios/focus-ios-tests/tools/Localizations
 
 # Glean
 .venv/
-Blockzilla/Generated
+focus-ios/Blockzilla/Generated
 
 import-strings.log
 export-strings.log

--- a/focus-ios/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/WebViewController.swift
@@ -7,6 +7,7 @@ import WebKit
 import Telemetry
 import PassKit
 import Combine
+import Glean
 
 protocol BrowserState {
     var url: URL? { get }
@@ -390,10 +391,14 @@ extension WebViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        GleanMetrics.Webview.fail.record()
+
         delegate?.webController(self, didFailNavigationWithError: error)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        GleanMetrics.Webview.failProvisional.record()
+
         let error = error as NSError
         guard error.code != Int(CFNetworkErrors.cfurlErrorCancelled.rawValue), let errorUrl = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL else { return }
         let errorPageData = ErrorPage(error: error).data

--- a/focus-ios/Blockzilla/metrics.yaml
+++ b/focus-ios/Blockzilla/metrics.yaml
@@ -763,7 +763,7 @@ webview:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-ios/pull/TODO
+      - https://github.com/mozilla-mobile/focus-ios/pull/3968
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -774,7 +774,7 @@ webview:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-ios/pull/TODO
+      - https://github.com/mozilla-mobile/focus-ios/pull/3968
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/focus-ios/Blockzilla/metrics.yaml
+++ b/focus-ios/Blockzilla/metrics.yaml
@@ -754,3 +754,27 @@ search:
       - baseline
     no_lint:
       - BASELINE_PING
+
+webview:
+  fail_provisional:
+    type: event
+    description: |
+      Recorded when an error occurs while starting to load data for the main frame, so early navigation.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17716
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  fail:
+    type: event
+    description: |
+      Recorded when an error occurred during navigation.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17716
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never

--- a/focus-ios/Blockzilla/metrics.yaml
+++ b/focus-ios/Blockzilla/metrics.yaml
@@ -759,7 +759,7 @@ webview:
   fail_provisional:
     type: event
     description: |
-      Recorded when an error occurs while starting to load data for the main frame, so early navigation.
+      Recorded when an error occurs on early webview navigation.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:


### PR DESCRIPTION
Equivalent of https://github.com/mozilla-mobile/firefox-ios/pull/17910 on Firefox iOS. There's less places to add telemetry in the case of Focus.