### PR TITLE
Fix the build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ Build Instructions
 3. Pull in the project dependencies:
 
   ```shell
-  cd focus-ios
   ./checkout.sh
   ```
 
-4. Open `Blockzilla.xcodeproj` in Xcode.
+4. Open `focus-ios/Blockzilla.xcodeproj` in Xcode.
 5. Build the `Focus` scheme in Xcode.
 
 


### PR DESCRIPTION
This PR fixes the build instructions in README because `checkout.sh` has been moved.